### PR TITLE
Changes for GlassImagePy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "GlassImage"]
 	path = GlassImage
-	url = git@github.com:Glass-Imaging/GlassImage.git
+	url = https://github.com/Glass-Imaging/GlassImage.git

--- a/ImagingPipeline/imagingPipeline.hpp
+++ b/ImagingPipeline/imagingPipeline.hpp
@@ -30,16 +30,19 @@
 
 #include "CameraCalibration.hpp"
 
-static const char* TAG = "RawPipeline Test";
+static const char *TAG = "RawPipeline Test";
 
-void copyMetadata(const gls::tiff_metadata& source, gls::tiff_metadata* destination, ttag_t tag) {
+void copyMetadata(const gls::tiff_metadata &source, gls::tiff_metadata *destination, ttag_t tag)
+{
     const auto entry = source.find(tag);
-    if (entry != source.end()) {
-        destination->insert({ tag, entry->second });
+    if (entry != source.end())
+    {
+        destination->insert({tag, entry->second});
     }
 }
 
-void saveStrippedDNG(const std::string& file_name, const gls::image<gls::luma_pixel_16>& inputImage, const gls::tiff_metadata& dng_metadata, const gls::tiff_metadata& exif_metadata) {
+void saveStrippedDNG(const std::string &file_name, const gls::image<gls::luma_pixel_16> &inputImage, const gls::tiff_metadata &dng_metadata, const gls::tiff_metadata &exif_metadata)
+{
     gls::tiff_metadata my_exif_metadata;
     copyMetadata(exif_metadata, &my_exif_metadata, EXIFTAG_FNUMBER);
     copyMetadata(exif_metadata, &my_exif_metadata, EXIFTAG_EXPOSUREPROGRAM);
@@ -69,39 +72,39 @@ void saveStrippedDNG(const std::string& file_name, const gls::image<gls::luma_pi
     copyMetadata(exif_metadata, &my_exif_metadata, EXIFTAG_LENSSERIALNUMBER);
 
     // Write out a stripped DNG files with minimal metadata
-    inputImage.write_dng_file(file_name, /*compression=*/ gls::JPEG, &dng_metadata, &my_exif_metadata);
+    inputImage.write_dng_file(file_name, /*compression=*/gls::JPEG, &dng_metadata, &my_exif_metadata);
 }
 
-void transcodeAdobeDNG(const std::filesystem::path& input_path) {
+void transcodeAdobeDNG(const std::filesystem::path &input_path)
+{
     gls::tiff_metadata dng_metadata, exif_metadata;
-    dng_metadata.insert({ TIFFTAG_COLORMATRIX1, std::vector<float>{ 1.4955, -0.6760, -0.1453, -0.1341, 1.0072, 0.1269, -0.0647, 0.1987, 0.4304 } });
-    dng_metadata.insert({ TIFFTAG_ASSHOTNEUTRAL, std::vector<float>{ 1 / 1.73344, 1, 1 / 1.68018 } });
-//    dng_metadata.insert({ TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{ 2, 2 } });
-//    dng_metadata.insert({ TIFFTAG_CFAPATTERN, std::vector<uint8_t>{ 2, 1, 1, 0 } });
-//    dng_metadata.insert({ TIFFTAG_BLACKLEVEL, std::vector<float>{ 0 } });
-//    // dng_metadata.insert({ TIFFTAG_WHITELEVEL, std::vector<uint32_t>{ 0x3fff } });
+    dng_metadata.insert({TIFFTAG_COLORMATRIX1, std::vector<float>{1.4955, -0.6760, -0.1453, -0.1341, 1.0072, 0.1269, -0.0647, 0.1987, 0.4304}});
+    dng_metadata.insert({TIFFTAG_ASSHOTNEUTRAL, std::vector<float>{1 / 1.73344, 1, 1 / 1.68018}});
+    //    dng_metadata.insert({ TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{ 2, 2 } });
+    //    dng_metadata.insert({ TIFFTAG_CFAPATTERN, std::vector<uint8_t>{ 2, 1, 1, 0 } });
+    //    dng_metadata.insert({ TIFFTAG_BLACKLEVEL, std::vector<float>{ 0 } });
+    //    // dng_metadata.insert({ TIFFTAG_WHITELEVEL, std::vector<uint32_t>{ 0x3fff } });
     const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
 
     auto output_file = (input_path.parent_path() / input_path.stem()).string() + "_fixed.dng";
     saveStrippedDNG(output_file, *inputImage, dng_metadata, exif_metadata);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter *rawConverter, const std::filesystem::path &input_path)
+{
     DemosaicParameters demosaicParameters = {
         .rgbConversionParameters = {
-            .localToneMapping = false
-        },
+            .localToneMapping = false},
     };
 
     gls::tiff_metadata dng_metadata, exif_metadata;
     const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
 
-    unpackDNGMetadata(*inputImage, &dng_metadata, &demosaicParameters, /*auto_white_balance=*/ false, nullptr /* &gmb_position */, /*rotate_180=*/ false);
+    unpackDNGMetadata(*inputImage, &dng_metadata, &demosaicParameters, /*auto_white_balance=*/false, nullptr /* &gmb_position */, /*rotate_180=*/false);
 
     // Minimal noise model
     demosaicParameters.noiseModel.rawNlf = {
-        {0, 0, 0, 0}, {2.8482e-04, 3.6848e-04, 3.3079e-04, 3.2821e-04}
-    };
+        {0, 0, 0, 0}, {2.8482e-04, 3.6848e-04, 3.3079e-04, 3.2821e-04}};
     demosaicParameters.noiseModel.pyramidNlf = {{
         {{2.1e-04, 1.0e-08, 8.2e-06}, {2.6e-04, 3.9e-05, 9.0e-06}},
         {{1.6e-04, 1.0e-08, 1.6e-06}, {6.1e-04, 1.8e-04, 6.1e-05}},
@@ -111,52 +114,43 @@ gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter* rawConver
     }};
 
     // Minimal noise model
-    float lmult[5] = { 0.125, 0.125, 0.125, 0.125, 0.125 };
-    float cmult[5] = { 0.125, 0.125, 0.125, 0.125, 0.125 };
+    float lmult[5] = {0.125, 0.125, 0.125, 0.125, 0.125};
+    float cmult[5] = {0.125, 0.125, 0.125, 0.125, 0.125};
 
-    demosaicParameters.denoiseParameters = std::array<DenoiseParameters, 5> {{
-        {
-            .luma = lmult[0],
-            .chroma = cmult[0],
-            .sharpening = 1
-        },
-        {
-            .luma = lmult[1],
-            .chroma = cmult[1],
-            .sharpening = 1
-        },
-        {
-            .luma = lmult[2],
-            .chroma = cmult[2],
-            .sharpening = 1
-        },
-        {
-            .luma = lmult[3],
-            .chroma = cmult[3],
-            .sharpening = 1
-        },
-        {
-            .luma = lmult[4],
-            .chroma = cmult[4],
-            .sharpening = 1
-        }
-    }};
+    demosaicParameters.denoiseParameters = std::array<DenoiseParameters, 5>{{{.luma = lmult[0],
+                                                                              .chroma = cmult[0],
+                                                                              .sharpening = 1},
+                                                                             {.luma = lmult[1],
+                                                                              .chroma = cmult[1],
+                                                                              .sharpening = 1},
+                                                                             {.luma = lmult[2],
+                                                                              .chroma = cmult[2],
+                                                                              .sharpening = 1},
+                                                                             {.luma = lmult[3],
+                                                                              .chroma = cmult[3],
+                                                                              .sharpening = 1},
+                                                                             {.luma = lmult[4],
+                                                                              .chroma = cmult[4],
+                                                                              .sharpening = 1}}};
 
-    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, &demosaicParameters, /*calibrateFromImage=*/ true));
+    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, &demosaicParameters, /*calibrateFromImage=*/true));
 }
 
-void processKodakSet(gls::OpenCLContext* glsContext, const std::filesystem::path& input_path) {
+void processKodakSet(gls::OpenCLContext *glsContext, const std::filesystem::path &input_path)
+{
     auto input_dir = std::filesystem::path(input_path.parent_path());
     std::vector<std::filesystem::path> directory_listing;
     std::copy(std::filesystem::directory_iterator(input_dir), std::filesystem::directory_iterator(),
               std::back_inserter(directory_listing));
     std::sort(directory_listing.begin(), directory_listing.end());
 
-    for (const auto& input_path : directory_listing) {
+    for (const auto &input_path : directory_listing)
+    {
         RawConverter rawConverter(glsContext);
 
         const auto extension = input_path.extension();
-        if ((extension != ".png") || input_path.filename().string().starts_with(".")) {
+        if ((extension != ".png") || input_path.filename().string().starts_with("."))
+        {
             continue;
         }
 
@@ -168,9 +162,16 @@ void processKodakSet(gls::OpenCLContext* glsContext, const std::filesystem::path
 
         auto offsets = bayerOffsets[grbg];
 
-        enum { red = 0, green = 1, blue = 2, green2 = 3 };
+        enum
+        {
+            red = 0,
+            green = 1,
+            blue = 2,
+            green2 = 3
+        };
 
-        bayer.apply([&offsets, &rgb](gls::luma_pixel_16* p, int x, int y) {
+        bayer.apply([&offsets, &rgb](gls::luma_pixel_16 *p, int x, int y)
+                    {
             for (int c : { red, green, blue, green2 }) {
                 if ((x & 1) == (offsets[c].x & 1) && (y & 1) == (offsets[c].y & 1)) {
                     switch (c) {
@@ -187,24 +188,22 @@ void processKodakSet(gls::OpenCLContext* glsContext, const std::filesystem::path
                     }
                     break;
                 }
-            }
-        });
+            } });
 
         gls::tiff_metadata dng_metadata;
-        dng_metadata.insert({ TIFFTAG_COLORMATRIX1, std::vector<float>{
-             3.2404542, -1.5371385, -0.4985314,
-            -0.9692660,  1.8760108,  0.04160,
-             0.0556434, -0.2040259,  1.05752
-        }});
-        dng_metadata.insert({ TIFFTAG_ASSHOTNEUTRAL, std::vector<float>{ 1, 1, 1 } });
-        dng_metadata.insert({ TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{ 2, 2 } });
-        dng_metadata.insert({ TIFFTAG_CFAPATTERN, std::vector<uint8_t>{ 1, 0, 2, 1 } });
-        dng_metadata.insert({ TIFFTAG_BLACKLEVEL, std::vector<float>{ 0 } });
-        dng_metadata.insert({ TIFFTAG_WHITELEVEL, std::vector<uint32_t>{ 0xffff } });
-        dng_metadata.insert({ TIFFTAG_PROFILETONECURVE, std::vector<float>{ 0, 0, 1, 1 } });
+        dng_metadata.insert({TIFFTAG_COLORMATRIX1, std::vector<float>{
+                                                       3.2404542, -1.5371385, -0.4985314,
+                                                       -0.9692660, 1.8760108, 0.04160,
+                                                       0.0556434, -0.2040259, 1.05752}});
+        dng_metadata.insert({TIFFTAG_ASSHOTNEUTRAL, std::vector<float>{1, 1, 1}});
+        dng_metadata.insert({TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{2, 2}});
+        dng_metadata.insert({TIFFTAG_CFAPATTERN, std::vector<uint8_t>{1, 0, 2, 1}});
+        dng_metadata.insert({TIFFTAG_BLACKLEVEL, std::vector<float>{0}});
+        dng_metadata.insert({TIFFTAG_WHITELEVEL, std::vector<uint32_t>{0xffff}});
+        dng_metadata.insert({TIFFTAG_PROFILETONECURVE, std::vector<float>{0, 0, 1, 1}});
 
         auto dng_file = (input_path.parent_path() / input_path.stem()).string() + ".dng";
-        bayer.write_dng_file(dng_file, /*compression=*/ gls::NONE, &dng_metadata);
+        bayer.write_dng_file(dng_file, /*compression=*/gls::NONE, &dng_metadata);
 
         const auto demosaiced = demosaicPlainFile(&rawConverter, dng_file);
 
@@ -213,7 +212,8 @@ void processKodakSet(gls::OpenCLContext* glsContext, const std::filesystem::path
     }
 }
 
-void demosaicFile(RawConverter* rawConverter, std::filesystem::path input_path) {
+void demosaicFile(RawConverter *rawConverter, std::filesystem::path input_path)
+{
     LOG_INFO(TAG) << "Processing File: " << input_path.filename() << std::endl;
 
     // transcodeAdobeDNG(input_path);
@@ -224,10 +224,35 @@ void demosaicFile(RawConverter* rawConverter, std::filesystem::path input_path) 
     // const auto rgb_image = demosaicRicohGRIII2DNG(rawConverter, input_path);
     // const auto rgb_image = demosaicLeicaQ2DNG(rawConverter, input_path);
     // rgb_image->write_jpeg_file((input_path.parent_path() /*/ "Processed" */ / input_path.stem()).string() + "_new_sharp_white.jpg", 100);
-    rgb_image->write_png_file((input_path.parent_path() /* / "Processed" */ / input_path.stem()).string() + "_rgb_c_ln_raw_denoise_k.png", /*skip_alpha=*/ true);
+    rgb_image->write_png_file((input_path.parent_path() /* / "Processed" */ / input_path.stem()).string() + "_rgb_c_ln_raw_denoise_k.png", /*skip_alpha=*/true);
 }
 
-void demosaicDirectory(RawConverter* rawConverter, std::filesystem::path input_path) {
+gls::image<gls::rgb_pixel_16>::unique_ptr demosaic_raw_data(RawConverter *rawConverter, const gls::image<gls::luma_pixel_16> &raw_data, int ISO, std::vector<float> color_matrix, std::vector<float> as_shot_neutral, std::vector<uint8_t> cfapattern, int blacklevel, int whitelevel)
+{
+    // std::vector<float> color_matrix = {1.2594, -0.5333, -0.1138, -0.1404, 0.9717, 0.1688, 0.0342, 0.0969, 0.4330};
+    // std::vector<float> as_shot_neutral = {1 / 1.8930, 1.0000, 1 / 1.7007};
+
+    gls::tiff_metadata dng_metadata, exif_metadata;
+
+    // Basic DNG image interpretation metadata
+    dng_metadata.insert({TIFFTAG_COLORMATRIX1, color_matrix});
+    dng_metadata.insert({TIFFTAG_ASSHOTNEUTRAL, as_shot_neutral});
+
+    dng_metadata.insert({TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{2, 2}});
+    dng_metadata.insert({TIFFTAG_CFAPATTERN, cfapattern});
+    // TODO: Is this right how the black and white level are cast?
+    dng_metadata.insert({TIFFTAG_BLACKLEVEL, std::vector<float>{(float)blacklevel}});
+    dng_metadata.insert({TIFFTAG_WHITELEVEL, std::vector<uint32_t>{(uint32_t)whitelevel}});
+
+    // Basic EXIF metadata
+    // const auto ISO = 100; // Provide the actual ISO informations
+    exif_metadata.insert({EXIFTAG_ISOSPEEDRATINGS, std::vector<uint16_t>{(uint16_t)ISO}});
+
+    return demosaicSonya6400RawImage<gls::rgb_pixel_16>(rawConverter, &dng_metadata, &exif_metadata, raw_data);
+}
+
+void demosaicDirectory(RawConverter *rawConverter, std::filesystem::path input_path)
+{
     LOG_INFO(TAG) << "Processing Directory: " << input_path.filename() << std::endl;
 
     auto input_dir = std::filesystem::directory_entry(input_path).is_directory() ? input_path : input_path.parent_path();
@@ -236,27 +261,35 @@ void demosaicDirectory(RawConverter* rawConverter, std::filesystem::path input_p
               std::back_inserter(directory_listing));
     std::sort(directory_listing.begin(), directory_listing.end());
 
-    for (const auto& input_path : directory_listing) {
-        if (input_path.filename().string().starts_with(".")) {
+    for (const auto &input_path : directory_listing)
+    {
+        if (input_path.filename().string().starts_with("."))
+        {
             continue;
         }
 
-        if (std::filesystem::directory_entry(input_path).is_regular_file()) {
+        if (std::filesystem::directory_entry(input_path).is_regular_file())
+        {
             const auto extension = input_path.extension();
-            if ((extension != ".dng" && extension != ".DNG")) {
+            if ((extension != ".dng" && extension != ".DNG"))
+            {
                 continue;
             }
             demosaicFile(rawConverter, input_path);
-        } else if (std::filesystem::directory_entry(input_path).is_directory()) {
+        }
+        else if (std::filesystem::directory_entry(input_path).is_directory())
+        {
             demosaicDirectory(rawConverter, input_path);
         }
     }
 }
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[])
+{
     printf("RawPipeline Test!\n");
 
-    if (argc > 1) {
+    if (argc > 1)
+    {
         gls::OpenCLContext glsContext("");
         RawConverter rawConverter(&glsContext);
 
@@ -275,18 +308,18 @@ int main(int argc, const char* argv[]) {
 
         demosaicFile(&rawConverter, input_path);
 
-//        {
-//            gls::tiff_metadata dng_metadata, exif_metadata;
-//            const auto rawImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
-//            auto cpu_image = demosaicImageCPU(*rawImage, &dng_metadata, false);
-//            cpu_image->apply([](gls::rgb_pixel_16* p, int x, int y) {
-//                *p = {
-//                    (uint16_t) (0xffff * sqrt((*p)[0] / (float) 0xffff)),
-//                    (uint16_t) (0xffff * sqrt((*p)[1] / (float) 0xffff)),
-//                    (uint16_t) (0xffff * sqrt((*p)[2] / (float) 0xffff))
-//                };
-//            });
-//            cpu_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cpu_rgb.png", /*skip_alpha=*/ true);
-//        }
+        //        {
+        //            gls::tiff_metadata dng_metadata, exif_metadata;
+        //            const auto rawImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+        //            auto cpu_image = demosaicImageCPU(*rawImage, &dng_metadata, false);
+        //            cpu_image->apply([](gls::rgb_pixel_16* p, int x, int y) {
+        //                *p = {
+        //                    (uint16_t) (0xffff * sqrt((*p)[0] / (float) 0xffff)),
+        //                    (uint16_t) (0xffff * sqrt((*p)[1] / (float) 0xffff)),
+        //                    (uint16_t) (0xffff * sqrt((*p)[2] / (float) 0xffff))
+        //                };
+        //            });
+        //            cpu_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cpu_rgb.png", /*skip_alpha=*/ true);
+        //        }
     }
 }

--- a/ImagingPipeline/imagingPipeline.hpp
+++ b/ImagingPipeline/imagingPipeline.hpp
@@ -13,36 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <string>
-#include <cmath>
-#include <chrono>
-
-#include "gls_logging.h"
-#include "gls_image.hpp"
-
-#include "raw_converter.hpp"
-
-#include "demosaic.hpp"
-#include "gls_tiff_metadata.hpp"
-
-#include "gls_linalg.hpp"
 
 #include "CameraCalibration.hpp"
+#include "demosaic.hpp"
+#include "gls_image.hpp"
+#include "gls_linalg.hpp"
+#include "gls_logging.h"
+#include "gls_tiff_metadata.hpp"
+#include "raw_converter.hpp"
 
-static const char *TAG = "RawPipeline Test";
-
-void copyMetadata(const gls::tiff_metadata &source, gls::tiff_metadata *destination, ttag_t tag)
-{
+static const char* TAG = "RawPipeline Test";
+void copyMetadata(const gls::tiff_metadata& source, gls::tiff_metadata* destination, ttag_t tag) {
     const auto entry = source.find(tag);
-    if (entry != source.end())
-    {
+    if (entry != source.end()) {
         destination->insert({tag, entry->second});
     }
 }
-
-void saveStrippedDNG(const std::string &file_name, const gls::image<gls::luma_pixel_16> &inputImage, const gls::tiff_metadata &dng_metadata, const gls::tiff_metadata &exif_metadata)
-{
+void saveStrippedDNG(const std::string& file_name, const gls::image<gls::luma_pixel_16>& inputImage,
+                     const gls::tiff_metadata& dng_metadata,
+                     const gls::tiff_metadata& exif_metadata) {
     gls::tiff_metadata my_exif_metadata;
     copyMetadata(exif_metadata, &my_exif_metadata, EXIFTAG_FNUMBER);
     copyMetadata(exif_metadata, &my_exif_metadata, EXIFTAG_EXPOSUREPROGRAM);
@@ -72,39 +65,43 @@ void saveStrippedDNG(const std::string &file_name, const gls::image<gls::luma_pi
     copyMetadata(exif_metadata, &my_exif_metadata, EXIFTAG_LENSSERIALNUMBER);
 
     // Write out a stripped DNG files with minimal metadata
-    inputImage.write_dng_file(file_name, /*compression=*/gls::JPEG, &dng_metadata, &my_exif_metadata);
+    inputImage.write_dng_file(file_name, /*compression=*/gls::JPEG, &dng_metadata,
+                              &my_exif_metadata);
 }
 
-void transcodeAdobeDNG(const std::filesystem::path &input_path)
-{
+void transcodeAdobeDNG(const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    dng_metadata.insert({TIFFTAG_COLORMATRIX1, std::vector<float>{1.4955, -0.6760, -0.1453, -0.1341, 1.0072, 0.1269, -0.0647, 0.1987, 0.4304}});
+    dng_metadata.insert(
+        {TIFFTAG_COLORMATRIX1, std::vector<float>{1.4955, -0.6760, -0.1453, -0.1341, 1.0072, 0.1269,
+                                                  -0.0647, 0.1987, 0.4304}});
     dng_metadata.insert({TIFFTAG_ASSHOTNEUTRAL, std::vector<float>{1 / 1.73344, 1, 1 / 1.68018}});
     //    dng_metadata.insert({ TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{ 2, 2 } });
     //    dng_metadata.insert({ TIFFTAG_CFAPATTERN, std::vector<uint8_t>{ 2, 1, 1, 0 } });
     //    dng_metadata.insert({ TIFFTAG_BLACKLEVEL, std::vector<float>{ 0 } });
     //    // dng_metadata.insert({ TIFFTAG_WHITELEVEL, std::vector<uint32_t>{ 0x3fff } });
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
     auto output_file = (input_path.parent_path() / input_path.stem()).string() + "_fixed.dng";
     saveStrippedDNG(output_file, *inputImage, dng_metadata, exif_metadata);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter *rawConverter, const std::filesystem::path &input_path)
-{
+gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter* rawConverter,
+                                                         const std::filesystem::path& input_path) {
     DemosaicParameters demosaicParameters = {
-        .rgbConversionParameters = {
-            .localToneMapping = false},
+        .rgbConversionParameters = {.localToneMapping = false},
     };
 
     gls::tiff_metadata dng_metadata, exif_metadata;
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
-    unpackDNGMetadata(*inputImage, &dng_metadata, &demosaicParameters, /*auto_white_balance=*/false, nullptr /* &gmb_position */, /*rotate_180=*/false);
+    unpackDNGMetadata(*inputImage, &dng_metadata, &demosaicParameters, /*auto_white_balance=*/false,
+                      nullptr /* &gmb_position */, /*rotate_180=*/false);
 
     // Minimal noise model
-    demosaicParameters.noiseModel.rawNlf = {
-        {0, 0, 0, 0}, {2.8482e-04, 3.6848e-04, 3.3079e-04, 3.2821e-04}};
+    demosaicParameters.noiseModel.rawNlf = {{0, 0, 0, 0},
+                                            {2.8482e-04, 3.6848e-04, 3.3079e-04, 3.2821e-04}};
     demosaicParameters.noiseModel.pyramidNlf = {{
         {{2.1e-04, 1.0e-08, 8.2e-06}, {2.6e-04, 3.9e-05, 9.0e-06}},
         {{1.6e-04, 1.0e-08, 1.6e-06}, {6.1e-04, 1.8e-04, 6.1e-05}},
@@ -117,40 +114,29 @@ gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter *rawConver
     float lmult[5] = {0.125, 0.125, 0.125, 0.125, 0.125};
     float cmult[5] = {0.125, 0.125, 0.125, 0.125, 0.125};
 
-    demosaicParameters.denoiseParameters = std::array<DenoiseParameters, 5>{{{.luma = lmult[0],
-                                                                              .chroma = cmult[0],
-                                                                              .sharpening = 1},
-                                                                             {.luma = lmult[1],
-                                                                              .chroma = cmult[1],
-                                                                              .sharpening = 1},
-                                                                             {.luma = lmult[2],
-                                                                              .chroma = cmult[2],
-                                                                              .sharpening = 1},
-                                                                             {.luma = lmult[3],
-                                                                              .chroma = cmult[3],
-                                                                              .sharpening = 1},
-                                                                             {.luma = lmult[4],
-                                                                              .chroma = cmult[4],
-                                                                              .sharpening = 1}}};
+    demosaicParameters.denoiseParameters =
+        std::array<DenoiseParameters, 5>{{{.luma = lmult[0], .chroma = cmult[0], .sharpening = 1},
+                                          {.luma = lmult[1], .chroma = cmult[1], .sharpening = 1},
+                                          {.luma = lmult[2], .chroma = cmult[2], .sharpening = 1},
+                                          {.luma = lmult[3], .chroma = cmult[3], .sharpening = 1},
+                                          {.luma = lmult[4], .chroma = cmult[4], .sharpening = 1}}};
 
-    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, &demosaicParameters, /*calibrateFromImage=*/true));
+    return RawConverter::convertToRGBImage(
+        *rawConverter->runPipeline(*inputImage, &demosaicParameters, /*calibrateFromImage=*/true));
 }
 
-void processKodakSet(gls::OpenCLContext *glsContext, const std::filesystem::path &input_path)
-{
+void processKodakSet(gls::OpenCLContext* glsContext, const std::filesystem::path& input_path) {
     auto input_dir = std::filesystem::path(input_path.parent_path());
     std::vector<std::filesystem::path> directory_listing;
     std::copy(std::filesystem::directory_iterator(input_dir), std::filesystem::directory_iterator(),
               std::back_inserter(directory_listing));
     std::sort(directory_listing.begin(), directory_listing.end());
 
-    for (const auto &input_path : directory_listing)
-    {
+    for (const auto& input_path : directory_listing) {
         RawConverter rawConverter(glsContext);
 
         const auto extension = input_path.extension();
-        if ((extension != ".png") || input_path.filename().string().starts_with("."))
-        {
+        if ((extension != ".png") || input_path.filename().string().starts_with(".")) {
             continue;
         }
 
@@ -162,17 +148,10 @@ void processKodakSet(gls::OpenCLContext *glsContext, const std::filesystem::path
 
         auto offsets = bayerOffsets[grbg];
 
-        enum
-        {
-            red = 0,
-            green = 1,
-            blue = 2,
-            green2 = 3
-        };
+        enum { red = 0, green = 1, blue = 2, green2 = 3 };
 
-        bayer.apply([&offsets, &rgb](gls::luma_pixel_16 *p, int x, int y)
-                    {
-            for (int c : { red, green, blue, green2 }) {
+        bayer.apply([&offsets, &rgb](gls::luma_pixel_16* p, int x, int y) {
+            for (int c : {red, green, blue, green2}) {
                 if ((x & 1) == (offsets[c].x & 1) && (y & 1) == (offsets[c].y & 1)) {
                     switch (c) {
                         case red:
@@ -188,13 +167,14 @@ void processKodakSet(gls::OpenCLContext *glsContext, const std::filesystem::path
                     }
                     break;
                 }
-            } });
+            }
+        });
 
         gls::tiff_metadata dng_metadata;
-        dng_metadata.insert({TIFFTAG_COLORMATRIX1, std::vector<float>{
-                                                       3.2404542, -1.5371385, -0.4985314,
-                                                       -0.9692660, 1.8760108, 0.04160,
-                                                       0.0556434, -0.2040259, 1.05752}});
+        dng_metadata.insert(
+            {TIFFTAG_COLORMATRIX1,
+             std::vector<float>{3.2404542, -1.5371385, -0.4985314, -0.9692660, 1.8760108, 0.04160,
+                                0.0556434, -0.2040259, 1.05752}});
         dng_metadata.insert({TIFFTAG_ASSHOTNEUTRAL, std::vector<float>{1, 1, 1}});
         dng_metadata.insert({TIFFTAG_CFAREPEATPATTERNDIM, std::vector<uint16_t>{2, 2}});
         dng_metadata.insert({TIFFTAG_CFAPATTERN, std::vector<uint8_t>{1, 0, 2, 1}});
@@ -207,13 +187,13 @@ void processKodakSet(gls::OpenCLContext *glsContext, const std::filesystem::path
 
         const auto demosaiced = demosaicPlainFile(&rawConverter, dng_file);
 
-        auto demosaiced_png_file = (input_path.parent_path() / input_path.stem()).string() + "_demosaiced_6_corr.PNG";
+        auto demosaiced_png_file =
+            (input_path.parent_path() / input_path.stem()).string() + "_demosaiced_6_corr.PNG";
         demosaiced->write_png_file(demosaiced_png_file);
     }
 }
 
-void demosaicFile(RawConverter *rawConverter, std::filesystem::path input_path)
-{
+void demosaicFile(RawConverter* rawConverter, std::filesystem::path input_path) {
     LOG_INFO(TAG) << "Processing File: " << input_path.filename() << std::endl;
 
     // transcodeAdobeDNG(input_path);
@@ -223,14 +203,20 @@ void demosaicFile(RawConverter *rawConverter, std::filesystem::path input_path)
     // const auto rgb_image = demosaiciPhone11(rawConverter, input_path);
     // const auto rgb_image = demosaicRicohGRIII2DNG(rawConverter, input_path);
     // const auto rgb_image = demosaicLeicaQ2DNG(rawConverter, input_path);
-    // rgb_image->write_jpeg_file((input_path.parent_path() /*/ "Processed" */ / input_path.stem()).string() + "_new_sharp_white.jpg", 100);
-    rgb_image->write_png_file((input_path.parent_path() /* / "Processed" */ / input_path.stem()).string() + "_rgb_c_ln_raw_denoise_k.png", /*skip_alpha=*/true);
+    // rgb_image->write_jpeg_file((input_path.parent_path() /*/ "Processed" */ /
+    // input_path.stem()).string() + "_new_sharp_white.jpg", 100);
+    rgb_image->write_png_file(
+        (input_path.parent_path() /* / "Processed" */ / input_path.stem()).string() +
+            "_rgb_c_ln_raw_denoise_k.png",
+        /*skip_alpha=*/true);
 }
 
-gls::image<gls::rgb_pixel_16>::unique_ptr demosaic_raw_data(RawConverter *rawConverter, const gls::image<gls::luma_pixel_16> &raw_data, int ISO, std::vector<float> color_matrix, std::vector<float> as_shot_neutral, std::vector<uint8_t> cfapattern, int blacklevel, int whitelevel)
-{
-    // std::vector<float> color_matrix = {1.2594, -0.5333, -0.1138, -0.1404, 0.9717, 0.1688, 0.0342, 0.0969, 0.4330};
-    // std::vector<float> as_shot_neutral = {1 / 1.8930, 1.0000, 1 / 1.7007};
+gls::image<gls::rgb_pixel_16>::unique_ptr demosaic_raw_data(
+    RawConverter* rawConverter, const gls::image<gls::luma_pixel_16>& raw_data, int ISO,
+    std::vector<float> color_matrix, std::vector<float> as_shot_neutral,
+    std::vector<uint8_t> cfapattern, int blacklevel, int whitelevel) {
+    // std::vector<float> color_matrix = {1.2594, -0.5333, -0.1138, -0.1404, 0.9717, 0.1688, 0.0342,
+    // 0.0969, 0.4330}; std::vector<float> as_shot_neutral = {1 / 1.8930, 1.0000, 1 / 1.7007};
 
     gls::tiff_metadata dng_metadata, exif_metadata;
 
@@ -248,48 +234,42 @@ gls::image<gls::rgb_pixel_16>::unique_ptr demosaic_raw_data(RawConverter *rawCon
     // const auto ISO = 100; // Provide the actual ISO informations
     exif_metadata.insert({EXIFTAG_ISOSPEEDRATINGS, std::vector<uint16_t>{(uint16_t)ISO}});
 
-    return demosaicSonya6400RawImage<gls::rgb_pixel_16>(rawConverter, &dng_metadata, &exif_metadata, raw_data);
+    return demosaicSonya6400RawImage<gls::rgb_pixel_16>(rawConverter, &dng_metadata, &exif_metadata,
+                                                        raw_data);
 }
 
-void demosaicDirectory(RawConverter *rawConverter, std::filesystem::path input_path)
-{
+void demosaicDirectory(RawConverter* rawConverter, std::filesystem::path input_path) {
     LOG_INFO(TAG) << "Processing Directory: " << input_path.filename() << std::endl;
 
-    auto input_dir = std::filesystem::directory_entry(input_path).is_directory() ? input_path : input_path.parent_path();
+    auto input_dir = std::filesystem::directory_entry(input_path).is_directory()
+                         ? input_path
+                         : input_path.parent_path();
     std::vector<std::filesystem::path> directory_listing;
     std::copy(std::filesystem::directory_iterator(input_dir), std::filesystem::directory_iterator(),
               std::back_inserter(directory_listing));
     std::sort(directory_listing.begin(), directory_listing.end());
 
-    for (const auto &input_path : directory_listing)
-    {
-        if (input_path.filename().string().starts_with("."))
-        {
+    for (const auto& input_path : directory_listing) {
+        if (input_path.filename().string().starts_with(".")) {
             continue;
         }
 
-        if (std::filesystem::directory_entry(input_path).is_regular_file())
-        {
+        if (std::filesystem::directory_entry(input_path).is_regular_file()) {
             const auto extension = input_path.extension();
-            if ((extension != ".dng" && extension != ".DNG"))
-            {
+            if ((extension != ".dng" && extension != ".DNG")) {
                 continue;
             }
             demosaicFile(rawConverter, input_path);
-        }
-        else if (std::filesystem::directory_entry(input_path).is_directory())
-        {
+        } else if (std::filesystem::directory_entry(input_path).is_directory()) {
             demosaicDirectory(rawConverter, input_path);
         }
     }
 }
 
-int main(int argc, const char *argv[])
-{
+int main(int argc, const char* argv[]) {
     printf("RawPipeline Test!\n");
 
-    if (argc > 1)
-    {
+    if (argc > 1) {
         gls::OpenCLContext glsContext("");
         RawConverter rawConverter(&glsContext);
 
@@ -310,16 +290,19 @@ int main(int argc, const char *argv[])
 
         //        {
         //            gls::tiff_metadata dng_metadata, exif_metadata;
-        //            const auto rawImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
-        //            auto cpu_image = demosaicImageCPU(*rawImage, &dng_metadata, false);
-        //            cpu_image->apply([](gls::rgb_pixel_16* p, int x, int y) {
+        //            const auto rawImage =
+        //            gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(),
+        //            &dng_metadata, &exif_metadata); auto cpu_image = demosaicImageCPU(*rawImage,
+        //            &dng_metadata, false); cpu_image->apply([](gls::rgb_pixel_16* p, int x, int y)
+        //            {
         //                *p = {
         //                    (uint16_t) (0xffff * sqrt((*p)[0] / (float) 0xffff)),
         //                    (uint16_t) (0xffff * sqrt((*p)[1] / (float) 0xffff)),
         //                    (uint16_t) (0xffff * sqrt((*p)[2] / (float) 0xffff))
         //                };
         //            });
-        //            cpu_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cpu_rgb.png", /*skip_alpha=*/ true);
+        //            cpu_image->write_png_file((input_path.parent_path() /
+        //            input_path.stem()).string() + "_cpu_rgb.png", /*skip_alpha=*/ true);
         //        }
     }
 }

--- a/include/CameraCalibration.hpp
+++ b/include/CameraCalibration.hpp
@@ -22,7 +22,8 @@
 #include "raw_converter.hpp"
 
 template <size_t levels = 5>
-class CameraCalibration {
+class CameraCalibration
+{
 public:
     virtual ~CameraCalibration() {}
 
@@ -30,23 +31,27 @@ public:
 
     virtual std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const = 0;
 
-    virtual void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const = 0;
+    virtual void calibrate(RawConverter *rawConverter, const std::filesystem::path &input_dir) const = 0;
 
     virtual DemosaicParameters buildDemosaicParameters() const = 0;
 
-    gls::image<gls::rgb_pixel>::unique_ptr calibrate(RawConverter* rawConverter,
-                                                     const std::filesystem::path& input_path,
-                                                     DemosaicParameters* demosaicParameters,
-                                                     int iso, const gls::rectangle& gmb_position) const {
+    gls::image<gls::rgb_pixel>::unique_ptr calibrate(RawConverter *rawConverter,
+                                                     const std::filesystem::path &input_path,
+                                                     DemosaicParameters *demosaicParameters,
+                                                     int iso, const gls::rectangle &gmb_position) const
+    {
         gls::tiff_metadata dng_metadata, exif_metadata;
         const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
 
-        unpackDNGMetadata(*inputImage, &dng_metadata, demosaicParameters, /*auto_white_balance=*/ false, /* &gmb_position */ nullptr, /*rotate_180=*/ false);
+        unpackDNGMetadata(*inputImage, &dng_metadata, demosaicParameters, /*auto_white_balance=*/false, /* &gmb_position */ nullptr, /*rotate_180=*/false);
 
         // See if the ISO value is present and override
-        if (getValue(exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, (uint32_t*) &iso)) {
-            iso = iso;
-        } else {
+        if (getValue(exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, (uint32_t *)&iso))
+        {
+            // iso = iso;
+        }
+        else
+        {
             iso = getVector<uint16_t>(exif_metadata, EXIFTAG_ISOSPEEDRATINGS)[0];
         }
 
@@ -54,29 +59,35 @@ public:
         demosaicParameters->noiseLevel = denoiseParameters.first;
         demosaicParameters->denoiseParameters = denoiseParameters.second;
 
-        return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters, /*calibrateFromImage=*/ true));
+        return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters, /*calibrateFromImage=*/true));
     }
 
-    std::unique_ptr<DemosaicParameters> getDemosaicParameters(const gls::image<gls::luma_pixel_16>& inputImage,
-                                                              gls::tiff_metadata* dng_metadata,
-                                                              gls::tiff_metadata* exif_metadata) const {
+    std::unique_ptr<DemosaicParameters> getDemosaicParameters(const gls::image<gls::luma_pixel_16> &inputImage,
+                                                              gls::tiff_metadata *dng_metadata,
+                                                              gls::tiff_metadata *exif_metadata) const
+    {
         auto demosaicParameters = std::make_unique<DemosaicParameters>();
 
         *demosaicParameters = buildDemosaicParameters();
 
-        unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/ false, /* &gmb_position */ nullptr, /*rotate_180=*/ false);
+        unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/false, /* &gmb_position */ nullptr, /*rotate_180=*/false);
 
         uint32_t iso = 0;
         std::vector<uint16_t> iso_16;
-        if (!(iso_16 = getVector<uint16_t>(*dng_metadata, TIFFTAG_ISO)).empty()) {
+        if (!(iso_16 = getVector<uint16_t>(*dng_metadata, TIFFTAG_ISO)).empty())
+        {
             iso = iso_16[0];
-        } else if (!(iso_16 = getVector<uint16_t>(*exif_metadata, EXIFTAG_ISOSPEEDRATINGS)).empty()) {
+        }
+        else if (!(iso_16 = getVector<uint16_t>(*exif_metadata, EXIFTAG_ISOSPEEDRATINGS)).empty())
+        {
             iso = iso_16[0];
-        } else if (getValue(*exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, &iso)) {
-            iso = iso;
+        }
+        else if (getValue(*exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, &iso))
+        {
+            // iso = iso;
         }
 
-        std::cout << "EXIF ISO: " << iso << std::endl;
+        // std::cout << "EXIF ISO: " << iso << std::endl;
 
         const auto nlfParams = nlfFromIso(iso);
         const auto denoiseParameters = getDenoiseParameters(iso);
@@ -92,28 +103,28 @@ std::unique_ptr<CameraCalibration<5>> getIPhone11Calibration();
 
 std::unique_ptr<CameraCalibration<5>> getLeicaQ2Calibration();
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter* rawConverter, const std::filesystem::path& input_path);
-void calibrateIMX571(RawConverter* rawConverter, const std::filesystem::path& input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
+void calibrateIMX571(RawConverter *rawConverter, const std::filesystem::path &input_dir);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicLeicaQ2DNG(RawConverter* rawConverter, const std::filesystem::path& input_path);
-void calibrateLeicaQ2(RawConverter* rawConverter, const std::filesystem::path& input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicLeicaQ2DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
+void calibrateLeicaQ2(RawConverter *rawConverter, const std::filesystem::path &input_dir);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicCanonEOSRPDNG(RawConverter* rawConverter, const std::filesystem::path& input_path);
-void calibrateCanonEOSRP(RawConverter* rawConverter, const std::filesystem::path& input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicCanonEOSRPDNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
+void calibrateCanonEOSRP(RawConverter *rawConverter, const std::filesystem::path &input_dir);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter* rawConverter, const std::filesystem::path& input_path);
-void calibrateSonya6400(RawConverter* rawConverter, const std::filesystem::path& input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
+void calibrateSonya6400(RawConverter *rawConverter, const std::filesystem::path &input_dir);
 
 template <typename T = gls::rgb_pixel>
-typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(RawConverter* rawConverter,
-                                                             gls::tiff_metadata* dng_metadata,
-                                                             gls::tiff_metadata* exif_metadata,
-                                                             const gls::image<gls::luma_pixel_16>& inputImage);
+typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(RawConverter *rawConverter,
+                                                             gls::tiff_metadata *dng_metadata,
+                                                             gls::tiff_metadata *exif_metadata,
+                                                             const gls::image<gls::luma_pixel_16> &inputImage);
 
-void calibrateRicohGRIII(RawConverter* rawConverter, const std::filesystem::path& input_dir);
-gls::image<gls::rgb_pixel>::unique_ptr demosaicRicohGRIII2DNG(RawConverter* rawConverter, const std::filesystem::path& input_path);
+void calibrateRicohGRIII(RawConverter *rawConverter, const std::filesystem::path &input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicRicohGRIII2DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
 
-void calibrateiPhone11(RawConverter* rawConverter, const std::filesystem::path& input_dir);
-gls::image<gls::rgb_pixel>::unique_ptr demosaiciPhone11(RawConverter* rawConverter, const std::filesystem::path& input_path);
+void calibrateiPhone11(RawConverter *rawConverter, const std::filesystem::path &input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaiciPhone11(RawConverter *rawConverter, const std::filesystem::path &input_path);
 
 #endif /* CameraCalibration_hpp */

--- a/include/CameraCalibration.hpp
+++ b/include/CameraCalibration.hpp
@@ -22,36 +22,37 @@
 #include "raw_converter.hpp"
 
 template <size_t levels = 5>
-class CameraCalibration
-{
-public:
+class CameraCalibration {
+   public:
     virtual ~CameraCalibration() {}
 
     virtual NoiseModel<levels> nlfFromIso(int iso) const = 0;
 
-    virtual std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const = 0;
+    virtual std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const = 0;
 
-    virtual void calibrate(RawConverter *rawConverter, const std::filesystem::path &input_dir) const = 0;
+    virtual void calibrate(RawConverter* rawConverter,
+                           const std::filesystem::path& input_dir) const = 0;
 
     virtual DemosaicParameters buildDemosaicParameters() const = 0;
 
-    gls::image<gls::rgb_pixel>::unique_ptr calibrate(RawConverter *rawConverter,
-                                                     const std::filesystem::path &input_path,
-                                                     DemosaicParameters *demosaicParameters,
-                                                     int iso, const gls::rectangle &gmb_position) const
-    {
+    gls::image<gls::rgb_pixel>::unique_ptr calibrate(RawConverter* rawConverter,
+                                                     const std::filesystem::path& input_path,
+                                                     DemosaicParameters* demosaicParameters,
+                                                     int iso,
+                                                     const gls::rectangle& gmb_position) const {
         gls::tiff_metadata dng_metadata, exif_metadata;
-        const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+        const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+            input_path.string(), &dng_metadata, &exif_metadata);
 
-        unpackDNGMetadata(*inputImage, &dng_metadata, demosaicParameters, /*auto_white_balance=*/false, /* &gmb_position */ nullptr, /*rotate_180=*/false);
+        unpackDNGMetadata(*inputImage, &dng_metadata, demosaicParameters,
+                          /*auto_white_balance=*/false, /* &gmb_position */ nullptr,
+                          /*rotate_180=*/false);
 
         // See if the ISO value is present and override
-        if (getValue(exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, (uint32_t *)&iso))
-        {
+        if (getValue(exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, (uint32_t*)&iso)) {
             // iso = iso;
-        }
-        else
-        {
+        } else {
             iso = getVector<uint16_t>(exif_metadata, EXIFTAG_ISOSPEEDRATINGS)[0];
         }
 
@@ -59,31 +60,29 @@ public:
         demosaicParameters->noiseLevel = denoiseParameters.first;
         demosaicParameters->denoiseParameters = denoiseParameters.second;
 
-        return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters, /*calibrateFromImage=*/true));
+        return RawConverter::convertToRGBImage(*rawConverter->runPipeline(
+            *inputImage, demosaicParameters, /*calibrateFromImage=*/true));
     }
 
-    std::unique_ptr<DemosaicParameters> getDemosaicParameters(const gls::image<gls::luma_pixel_16> &inputImage,
-                                                              gls::tiff_metadata *dng_metadata,
-                                                              gls::tiff_metadata *exif_metadata) const
-    {
+    std::unique_ptr<DemosaicParameters> getDemosaicParameters(
+        const gls::image<gls::luma_pixel_16>& inputImage, gls::tiff_metadata* dng_metadata,
+        gls::tiff_metadata* exif_metadata) const {
         auto demosaicParameters = std::make_unique<DemosaicParameters>();
 
         *demosaicParameters = buildDemosaicParameters();
 
-        unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/false, /* &gmb_position */ nullptr, /*rotate_180=*/false);
+        unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(),
+                          /*auto_white_balance=*/false, /* &gmb_position */ nullptr,
+                          /*rotate_180=*/false);
 
         uint32_t iso = 0;
         std::vector<uint16_t> iso_16;
-        if (!(iso_16 = getVector<uint16_t>(*dng_metadata, TIFFTAG_ISO)).empty())
-        {
+        if (!(iso_16 = getVector<uint16_t>(*dng_metadata, TIFFTAG_ISO)).empty()) {
             iso = iso_16[0];
-        }
-        else if (!(iso_16 = getVector<uint16_t>(*exif_metadata, EXIFTAG_ISOSPEEDRATINGS)).empty())
-        {
+        } else if (!(iso_16 = getVector<uint16_t>(*exif_metadata, EXIFTAG_ISOSPEEDRATINGS))
+                        .empty()) {
             iso = iso_16[0];
-        }
-        else if (getValue(*exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, &iso))
-        {
+        } else if (getValue(*exif_metadata, EXIFTAG_RECOMMENDEDEXPOSUREINDEX, &iso)) {
             // iso = iso;
         }
 
@@ -103,28 +102,33 @@ std::unique_ptr<CameraCalibration<5>> getIPhone11Calibration();
 
 std::unique_ptr<CameraCalibration<5>> getLeicaQ2Calibration();
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
-void calibrateIMX571(RawConverter *rawConverter, const std::filesystem::path &input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter* rawConverter,
+                                                         const std::filesystem::path& input_path);
+void calibrateIMX571(RawConverter* rawConverter, const std::filesystem::path& input_dir);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicLeicaQ2DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
-void calibrateLeicaQ2(RawConverter *rawConverter, const std::filesystem::path &input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicLeicaQ2DNG(RawConverter* rawConverter,
+                                                          const std::filesystem::path& input_path);
+void calibrateLeicaQ2(RawConverter* rawConverter, const std::filesystem::path& input_dir);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicCanonEOSRPDNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
-void calibrateCanonEOSRP(RawConverter *rawConverter, const std::filesystem::path &input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicCanonEOSRPDNG(
+    RawConverter* rawConverter, const std::filesystem::path& input_path);
+void calibrateCanonEOSRP(RawConverter* rawConverter, const std::filesystem::path& input_dir);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
-void calibrateSonya6400(RawConverter *rawConverter, const std::filesystem::path &input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(
+    RawConverter* rawConverter, const std::filesystem::path& input_path);
+void calibrateSonya6400(RawConverter* rawConverter, const std::filesystem::path& input_dir);
 
 template <typename T = gls::rgb_pixel>
-typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(RawConverter *rawConverter,
-                                                             gls::tiff_metadata *dng_metadata,
-                                                             gls::tiff_metadata *exif_metadata,
-                                                             const gls::image<gls::luma_pixel_16> &inputImage);
+typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(
+    RawConverter* rawConverter, gls::tiff_metadata* dng_metadata, gls::tiff_metadata* exif_metadata,
+    const gls::image<gls::luma_pixel_16>& inputImage);
 
-void calibrateRicohGRIII(RawConverter *rawConverter, const std::filesystem::path &input_dir);
-gls::image<gls::rgb_pixel>::unique_ptr demosaicRicohGRIII2DNG(RawConverter *rawConverter, const std::filesystem::path &input_path);
+void calibrateRicohGRIII(RawConverter* rawConverter, const std::filesystem::path& input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaicRicohGRIII2DNG(
+    RawConverter* rawConverter, const std::filesystem::path& input_path);
 
-void calibrateiPhone11(RawConverter *rawConverter, const std::filesystem::path &input_dir);
-gls::image<gls::rgb_pixel>::unique_ptr demosaiciPhone11(RawConverter *rawConverter, const std::filesystem::path &input_path);
+void calibrateiPhone11(RawConverter* rawConverter, const std::filesystem::path& input_dir);
+gls::image<gls::rgb_pixel>::unique_ptr demosaiciPhone11(RawConverter* rawConverter,
+                                                        const std::filesystem::path& input_path);
 
 #endif /* CameraCalibration_hpp */

--- a/include/RANSAC.hpp
+++ b/include/RANSAC.hpp
@@ -23,8 +23,10 @@
 
 namespace gls {
 
-gls::Matrix<3, 3> RANSAC(const std::vector<std::pair<Point2f, Point2f>> matchpoints, float threshold, int max_iterations, std::vector<int>* inlier_indices = nullptr);
+gls::Matrix<3, 3> RANSAC(const std::vector<std::pair<Point2f, Point2f>> matchpoints,
+                         float threshold, int max_iterations,
+                         std::vector<int>* inlier_indices = nullptr);
 
-} // namespace gls
+}  // namespace gls
 
 #endif /* RANSAC_hpp */

--- a/include/SURF.hpp
+++ b/include/SURF.hpp
@@ -18,10 +18,9 @@
 
 #include <float.h>
 
+#include "feature2d.hpp"
 #include "gls_cl_image.hpp"
 #include "gls_linalg.hpp"
-
-#include "feature2d.hpp"
 
 namespace gls {
 
@@ -39,26 +38,32 @@ class DMatch {
     float distance;
 
     // less is better
-    bool operator < (const DMatch& m) const { return distance < m.distance; }
+    bool operator<(const DMatch& m) const { return distance < m.distance; }
 };
 
 class SURF {
-public:
+   public:
     static std::unique_ptr<SURF> makeInstance(gls::OpenCLContext* glsContext, int width, int height,
                                               int max_features = -1, int nOctaves = 4,
                                               int nOctaveLayers = 2, float hessianThreshold = 0.02);
 
     virtual ~SURF() {}
 
-    virtual void integral(const gls::image<float>& img, const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum) = 0;
+    virtual void integral(const gls::image<float>& img,
+                          const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum) = 0;
 
-    virtual void detect(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& integralSum, std::vector<KeyPoint>* keypoints) = 0;
+    virtual void detect(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& integralSum,
+                        std::vector<KeyPoint>* keypoints) = 0;
 
-    virtual void detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints, gls::image<float>::unique_ptr* _descriptors) = 0;
+    virtual void detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints,
+                                  gls::image<float>::unique_ptr* _descriptors) = 0;
 
-    virtual std::vector<DMatch> matchKeyPoints(const gls::image<float>& descriptor1, const gls::image<float>& descriptor2) = 0;
+    virtual std::vector<DMatch> matchKeyPoints(const gls::image<float>& descriptor1,
+                                               const gls::image<float>& descriptor2) = 0;
 
-    static std::vector<std::pair<Point2f, Point2f>> detection(gls::OpenCLContext* cLContext, const gls::image<float>& image1, const gls::image<float>& image2);
+    static std::vector<std::pair<Point2f, Point2f>> detection(gls::OpenCLContext* cLContext,
+                                                              const gls::image<float>& image1,
+                                                              const gls::image<float>& image2);
 };
 
 void clRegisterAndFuse(gls::OpenCLContext* cLContext,
@@ -68,11 +73,9 @@ void clRegisterAndFuse(gls::OpenCLContext* cLContext,
                        const gls::Matrix<3, 3>& homography);
 
 template <typename T>
-void clRegisterImage(gls::OpenCLContext* cLContext,
-                     const gls::cl_image_2d<T>& inputImage,
-                     gls::cl_image_2d<T>* outputImage,
-                     const gls::Matrix<3, 3>& homography);
+void clRegisterImage(gls::OpenCLContext* cLContext, const gls::cl_image_2d<T>& inputImage,
+                     gls::cl_image_2d<T>* outputImage, const gls::Matrix<3, 3>& homography);
 
-} // namespace surf
+}  // namespace gls
 
 #endif /* SURF_hpp */

--- a/include/SVD.hpp
+++ b/include/SVD.hpp
@@ -31,7 +31,7 @@ void GivensL(gls::Matrix<N, M, T>& S_, size_t m, T a, T b) {
     T c = a / r;
     T s = -b / r;
 
-// #pragma omp parallel for
+    // #pragma omp parallel for
     for (size_t i = 0; i < M; i++) {
         T S0 = S_[m + 0][i];
         T S1 = S_[m + 1][i];
@@ -49,7 +49,7 @@ void GivensR(gls::Matrix<N, M, T>& S_, size_t m, T a, T b) {
     T c = a / r;
     T s = -b / r;
 
-// #pragma omp parallel for
+    // #pragma omp parallel for
     for (size_t i = 0; i < N; i++) {
         T S0 = S_[i][m + 0];
         T S1 = S_[i][m + 1];
@@ -92,7 +92,7 @@ void SVD(gls::Matrix<N, N, T>& U_, gls::Matrix<N, M, T>& S_, gls::Matrix<M, M, T
                         house_vec[j] = -house_vec[j];
                     }
             }
-// #pragma omp parallel for
+            // #pragma omp parallel for
             for (size_t k = i; k < M; k++) {
                 T dot_prod = 0;
                 for (size_t j = i; j < N; j++) {
@@ -102,7 +102,7 @@ void SVD(gls::Matrix<N, N, T>& U_, gls::Matrix<N, M, T>& S_, gls::Matrix<M, M, T
                     S_[j][k] -= dot_prod * house_vec[j];
                 }
             }
-// #pragma omp parallel for
+            // #pragma omp parallel for
             for (size_t k = 0; k < N; k++) {
                 T dot_prod = 0;
                 for (size_t j = i; j < N; j++) {
@@ -137,7 +137,7 @@ void SVD(gls::Matrix<N, N, T>& U_, gls::Matrix<N, M, T>& S_, gls::Matrix<M, M, T
                         house_vec[j] = -house_vec[j];
                     }
             }
-// #pragma omp parallel for
+            // #pragma omp parallel for
             for (size_t k = i; k < N; k++) {
                 T dot_prod = 0;
                 for (size_t j = i + 1; j < M; j++) {
@@ -147,7 +147,7 @@ void SVD(gls::Matrix<N, N, T>& U_, gls::Matrix<N, M, T>& S_, gls::Matrix<M, M, T
                     S_[k][j] -= dot_prod * house_vec[j];
                 }
             }
-// #pragma omp parallel for
+            // #pragma omp parallel for
             for (size_t k = 0; k < M; k++) {
                 T dot_prod = 0;
                 for (size_t j = i + 1; j < M; j++) {
@@ -244,7 +244,8 @@ void SVD(gls::Matrix<N, N, T>& U_, gls::Matrix<N, M, T>& S_, gls::Matrix<M, M, T
 }
 
 template <size_t N, size_t M, size_t DMIN = std::min(M, N), class T>
-inline void svd(const gls::Matrix<N, M, T>& A, gls::Vector<DMIN, T>& S, gls::Matrix<DMIN, M, T>& U, gls::Matrix<N, DMIN, T>& VT) {
+inline void svd(const gls::Matrix<N, M, T>& A, gls::Vector<DMIN, T>& S, gls::Matrix<DMIN, M, T>& U,
+                gls::Matrix<N, DMIN, T>& VT) {
     const constexpr size_t DMAX = std::max(M, N);
 
     auto U_ = gls::Matrix<DMAX, DMAX, T>::zeros();

--- a/include/demosaic_cl.hpp
+++ b/include/demosaic_cl.hpp
@@ -17,13 +17,11 @@
 #define demosaic_cl_hpp
 
 #include "demosaic.hpp"
-
 #include "gls_cl_image.hpp"
 
 template <typename T1, typename T2>
 void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
-                 const gls::cl_image_2d<T1>& inputImage,
-                 gls::cl_image_2d<T2>* outputImage);
+                 const gls::cl_image_2d<T1>& inputImage, gls::cl_image_2d<T2>* outputImage);
 
 void scaleRawData(gls::OpenCLContext* glsContext,
                   const gls::cl_image_2d<gls::luma_pixel_16>& rawImage,
@@ -49,25 +47,24 @@ void interpolateRedBlue(gls::OpenCLContext* glsContext,
                         const gls::cl_image_2d<gls::luma_pixel_float>& greenImage,
                         const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
                         gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-                        BayerPattern bayerPattern, gls::Vector<2> redVariance, gls::Vector<2> blueVariance);
+                        BayerPattern bayerPattern, gls::Vector<2> redVariance,
+                        gls::Vector<2> blueVariance);
 
 void interpolateRedBlueAtGreen(gls::OpenCLContext* glsContext,
                                const gls::cl_image_2d<gls::rgba_pixel_float>& rgbImageIn,
                                const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
                                gls::cl_image_2d<gls::rgba_pixel_float>* rgbImageOut,
-                               BayerPattern bayerPattern, gls::Vector<2> redVariance, gls::Vector<2> blueVariance);
+                               BayerPattern bayerPattern, gls::Vector<2> redVariance,
+                               gls::Vector<2> blueVariance);
 
-void malvar(gls::OpenCLContext* glsContext,
-            const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
+void malvar(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
             const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-            gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-            BayerPattern bayerPattern, gls::Vector<2> redVariance,
-            gls::Vector<2> greenVariance, gls::Vector<2> blueVariance);
+            gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage, BayerPattern bayerPattern,
+            gls::Vector<2> redVariance, gls::Vector<2> greenVariance, gls::Vector<2> blueVariance);
 
 void fasteDebayer(gls::OpenCLContext* glsContext,
                   const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                  gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-                  BayerPattern bayerPattern);
+                  gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage, BayerPattern bayerPattern);
 
 template <typename T>
 void resampleImage(gls::OpenCLContext* glsContext, const std::string& kernelName,
@@ -79,7 +76,8 @@ void subtractNoiseImage(gls::OpenCLContext* glsContext,
                         const gls::cl_image_2d<T>& inputImage1,
                         const gls::cl_image_2d<T>& inputImageDenoised1,
                         const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                        float luma_weight, float sharpening, const gls::Vector<2>& nlf, gls::cl_image_2d<T>* outputImage);
+                        float luma_weight, float sharpening, const gls::Vector<2>& nlf,
+                        gls::cl_image_2d<T>* outputImage);
 
 template <typename T>
 void subtractNoiseFusedImage(gls::OpenCLContext* glsContext,
@@ -113,9 +111,8 @@ void denoiseImage(gls::OpenCLContext* glsContext,
                   const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
                   const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
                   const gls::Vector<3>& var_a, const gls::Vector<3>& var_b,
-                  const gls::Vector<3> thresholdMultipliers,
-                  float chromaBoost, float gradientBoost, float gradientThreshold,
-                  gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+                  const gls::Vector<3> thresholdMultipliers, float chromaBoost, float gradientBoost,
+                  float gradientThreshold, gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
 
 void denoiseImageGuided(gls::OpenCLContext* glsContext,
                         const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
@@ -123,15 +120,13 @@ void denoiseImageGuided(gls::OpenCLContext* glsContext,
                         gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
 
 // Arrays order is LF, MF, HF
-void localToneMappingMask(gls::OpenCLContext* glsContext,
-                          const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                          const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage,
-                          const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abImage,
-                          const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abMeanImage,
-                          const LTMParameters& ltmParameters,
-                          const gls::Matrix<3, 3>& ycbcr_srgb,
-                          const gls::Vector<2>& nlf,
-                          gls::cl_image_2d<gls::luma_pixel_float>* outputImage);
+void localToneMappingMask(
+    gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+    const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage,
+    const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abImage,
+    const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abMeanImage,
+    const LTMParameters& ltmParameters, const gls::Matrix<3, 3>& ycbcr_srgb,
+    const gls::Vector<2>& nlf, gls::cl_image_2d<gls::luma_pixel_float>* outputImage);
 
 void denoiseLumaImage(gls::OpenCLContext* glsContext,
                       const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
@@ -140,13 +135,11 @@ void denoiseLumaImage(gls::OpenCLContext* glsContext,
 
 void bayerToRawRGBA(gls::OpenCLContext* glsContext,
                     const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                    gls::cl_image_2d<gls::rgba_pixel_float>* rgbaImage,
-                    BayerPattern bayerPattern);
+                    gls::cl_image_2d<gls::rgba_pixel_float>* rgbaImage, BayerPattern bayerPattern);
 
 void rawRGBAToBayer(gls::OpenCLContext* glsContext,
                     const gls::cl_image_2d<gls::rgba_pixel_float>& rgbaImage,
-                    gls::cl_image_2d<gls::luma_pixel_float>* rawImage,
-                    BayerPattern bayerPattern);
+                    gls::cl_image_2d<gls::luma_pixel_float>* rawImage, BayerPattern bayerPattern);
 
 void denoiseRawRGBAImage(gls::OpenCLContext* glsContext,
                          const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
@@ -175,11 +168,12 @@ void blueNoiseImage(gls::OpenCLContext* glsContext,
                     gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
 
 void blendHighlightsImage(gls::OpenCLContext* glsContext,
-                          const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                          float clip,
+                          const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage, float clip,
                           gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
 
-YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls::rgba_pixel_float>& image, float exposure_multiplier);
+YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext,
+                         const gls::cl_image_2d<gls::rgba_pixel_float>& image,
+                         float exposure_multiplier);
 
 RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext,
                      const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
@@ -191,13 +185,12 @@ void clFuseFrames(gls::OpenCLContext* glsContext,
                   const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
                   const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
                   const gls::cl_image_2d<gls::rgba_pixel_float>& previousFusedImage,
-                  const gls::Matrix<3, 3>& homography,
-                  const gls::Vector<3>& var_a, const gls::Vector<3>& var_b, int fusedFrames,
+                  const gls::Matrix<3, 3>& homography, const gls::Vector<3>& var_a,
+                  const gls::Vector<3>& var_b, int fusedFrames,
                   gls::cl_image_2d<gls::rgba_pixel_float>* newFusedImage);
 
 template <typename T>
-void clRescaleImage(gls::OpenCLContext* cLContext,
-                    const gls::cl_image_2d<T>& inputImage,
+void clRescaleImage(gls::OpenCLContext* cLContext, const gls::cl_image_2d<T>& inputImage,
                     gls::cl_image_2d<T>* outputImage);
 
 #endif /* demosaic_cl_hpp */

--- a/include/feature2d.hpp
+++ b/include/feature2d.hpp
@@ -30,24 +30,31 @@ struct KeyPoint {
     int octave;
     int class_id;
 
-    KeyPoint()
-        : pt(0,0), size(0), angle(-1), response(0), octave(0), class_id(-1) {}
+    KeyPoint() : pt(0, 0), size(0), angle(-1), response(0), octave(0), class_id(-1) {}
 
     KeyPoint(Point2f _pt, float _size, float _angle, float _response, int _octave, int _class_id)
-        : pt(_pt), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id) {}
+        : pt(_pt),
+          size(_size),
+          angle(_angle),
+          response(_response),
+          octave(_octave),
+          class_id(_class_id) {}
 
-    KeyPoint(float x, float y, float _size, float _angle=-1, float _response=0, int _octave=0, int _class_id=-1)
-        : pt(x, y), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id) {}
+    KeyPoint(float x, float y, float _size, float _angle = -1, float _response = 0, int _octave = 0,
+             int _class_id = -1)
+        : pt(x, y),
+          size(_size),
+          angle(_angle),
+          response(_response),
+          octave(_octave),
+          class_id(_class_id) {}
 
-    bool operator == (const KeyPoint& other) const {
-        return pt == other.pt && size == other.size &&
-               angle == other.angle && response == other.response &&
-               octave == other.octave && class_id == other.class_id;
+    bool operator==(const KeyPoint& other) const {
+        return pt == other.pt && size == other.size && angle == other.angle &&
+               response == other.response && octave == other.octave && class_id == other.class_id;
     }
 };
 
-inline int cvRound(float x) {
-    return (int) lrintf(x);
-}
+inline int cvRound(float x) { return (int)lrintf(x); }
 
 #endif /* feature2d_hpp */

--- a/include/homography.hpp
+++ b/include/homography.hpp
@@ -18,14 +18,16 @@
 
 #include <vector>
 
-#include "gls_linalg.hpp"
 #include "feature2d.hpp"
+#include "gls_linalg.hpp"
 
 namespace gls {
 
-Matrix<3, 3> findHomography(const std::vector<Point2f>& points1, const std::vector<Point2f>& points2);
+Matrix<3, 3> findHomography(const std::vector<Point2f>& points1,
+                            const std::vector<Point2f>& points2);
 
-gls::Matrix<3, 3> getPerspectiveTransformLSM2(const std::vector<Point2f>& src, const std::vector<Point2f>& dst);
+gls::Matrix<3, 3> getPerspectiveTransformLSM2(const std::vector<Point2f>& src,
+                                              const std::vector<Point2f>& dst);
 
 }  // namespace gls
 

--- a/include/pyramid_processor.hpp
+++ b/include/pyramid_processor.hpp
@@ -25,30 +25,33 @@ struct PyramidProcessor {
     int fusedFrames;
 
     typedef gls::cl_image_2d<gls::rgba_pixel_float> imageType;
-    std::array<imageType::unique_ptr, levels-1> imagePyramid;
-    std::array<gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr, levels-1> gradientPyramid;
+    std::array<imageType::unique_ptr, levels - 1> imagePyramid;
+    std::array<gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr, levels - 1>
+        gradientPyramid;
     std::array<imageType::unique_ptr, levels> subtractedImagePyramid;
     std::array<imageType::unique_ptr, levels> denoisedImagePyramid;
     std::array<imageType::unique_ptr, levels> fusionImagePyramidA;
     std::array<imageType::unique_ptr, levels> fusionImagePyramidB;
     std::array<imageType::unique_ptr, levels> fusionReferenceImagePyramid;
-    std::array<gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr, levels> fusionReferenceGradientPyramid;
+    std::array<gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr, levels>
+        fusionReferenceGradientPyramid;
     std::array<imageType::unique_ptr, levels>* fusionBuffer[2];
 
     PyramidProcessor(gls::OpenCLContext* glsContext, int width, int height);
 
-    imageType* denoise(gls::OpenCLContext* glsContext, std::array<DenoiseParameters, levels>* denoiseParameters,
+    imageType* denoise(gls::OpenCLContext* glsContext,
+                       std::array<DenoiseParameters, levels>* denoiseParameters,
                        const imageType& image,
                        const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                       std::array<YCbCrNLF, levels>* nlfParameters,
-                       float exposure_multiplier, bool calibrateFromImage = false);
+                       std::array<YCbCrNLF, levels>* nlfParameters, float exposure_multiplier,
+                       bool calibrateFromImage = false);
 
-    void fuseFrame(gls::OpenCLContext* glsContext, std::array<DenoiseParameters, levels>* denoiseParameters,
-                   const imageType& image,
+    void fuseFrame(gls::OpenCLContext* glsContext,
+                   std::array<DenoiseParameters, levels>* denoiseParameters, const imageType& image,
                    const gls::Matrix<3, 3>& homography,
                    const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                   std::array<YCbCrNLF, levels>* nlfParameters,
-                   float exposure_multiplier, bool calibrateFromImage = false);
+                   std::array<YCbCrNLF, levels>* nlfParameters, float exposure_multiplier,
+                   bool calibrateFromImage = false);
 
     imageType* getFusedImage(gls::OpenCLContext* glsContext);
 };

--- a/include/raw_converter.hpp
+++ b/include/raw_converter.hpp
@@ -16,10 +16,13 @@
 #ifndef raw_converter_hpp
 #define raw_converter_hpp
 
+#include <filesystem>
+
 #include "gls_cl_image.hpp"
 #include "pyramid_processor.hpp"
 
-class LocalToneMapping {
+class LocalToneMapping
+{
     gls::cl_image_2d<gls::luma_pixel_float>::unique_ptr ltmMaskImage;
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr lfAbGfImage;
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr lfAbGfMeanImage;
@@ -29,50 +32,54 @@ class LocalToneMapping {
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr hfAbGfMeanImage;
 
 public:
-    LocalToneMapping(gls::OpenCLContext* glsContext) {
+    LocalToneMapping(gls::OpenCLContext *glsContext)
+    {
         auto clContext = glsContext->clContext();
 
         // Placeholder, only allocated if LTM is used
         ltmMaskImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, 1, 1);
     }
 
-    void allocateTextures(gls::OpenCLContext* glsContext, int width, int height) {
+    void allocateTextures(gls::OpenCLContext *glsContext, int width, int height)
+    {
         auto clContext = glsContext->clContext();
 
-        if (ltmMaskImage->width != width || ltmMaskImage->height != height) {
-            ltmMaskImage    = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
-            lfAbGfImage     = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width/16, height/16);
-            lfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width/16, height/16);
-            mfAbGfImage     = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width/4, height/4);
-            mfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width/4, height/4);
-            hfAbGfImage     = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width, height);
+        if (ltmMaskImage->width != width || ltmMaskImage->height != height)
+        {
+            ltmMaskImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
+            lfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 16, height / 16);
+            lfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 16, height / 16);
+            mfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 4, height / 4);
+            mfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 4, height / 4);
+            hfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width, height);
             hfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width, height);
         }
     }
 
-    void createMask(gls::OpenCLContext* glsContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float>& image,
-                    const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage,
-                    const NoiseModel<5>& noiseModel,
-                    const DemosaicParameters& demosaicParameters) {
-        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abImage = {
-            lfAbGfImage.get(), mfAbGfImage.get(), hfAbGfImage.get()
-        };
-        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abMeanImage = {
-            lfAbGfMeanImage.get(), mfAbGfMeanImage.get(), hfAbGfMeanImage.get()
-        };
+    void createMask(gls::OpenCLContext *glsContext,
+                    const gls::cl_image_2d<gls::rgba_pixel_float> &image,
+                    const std::array<const gls::cl_image_2d<gls::rgba_pixel_float> *, 3> &guideImage,
+                    const NoiseModel<5> &noiseModel,
+                    const DemosaicParameters &demosaicParameters)
+    {
+        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float> *, 3> &abImage = {
+            lfAbGfImage.get(), mfAbGfImage.get(), hfAbGfImage.get()};
+        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float> *, 3> &abMeanImage = {
+            lfAbGfMeanImage.get(), mfAbGfMeanImage.get(), hfAbGfMeanImage.get()};
 
-        gls::Vector<2> nlf = { noiseModel.pyramidNlf[0].first[0], noiseModel.pyramidNlf[0].second[0] };
+        gls::Vector<2> nlf = {noiseModel.pyramidNlf[0].first[0], noiseModel.pyramidNlf[0].second[0]};
         localToneMappingMask(glsContext, image, guideImage, abImage, abMeanImage, demosaicParameters.ltmParameters, ycbcr_srgb, nlf, ltmMaskImage.get());
     }
 
-    const gls::cl_image_2d<gls::luma_pixel_float>& getMask() {
+    const gls::cl_image_2d<gls::luma_pixel_float> &getMask()
+    {
         return *ltmMaskImage;
     }
 };
 
-class RawConverter {
-    gls::OpenCLContext* _glsContext;
+class RawConverter
+{
+    gls::OpenCLContext *_glsContext;
 
     // TODO: this should probably be camera specific
     static const constexpr float kHighNoiseVariance = 2.5e-04;
@@ -100,41 +107,45 @@ class RawConverter {
     gls::cl_image_2d<gls::rgba_pixel_float>::unique_ptr clFastLinearRGBImage;
     gls::cl_image_2d<gls::rgba_pixel_float>::unique_ptr clsFastRGBImage;
 
-    void allocateTextures(gls::OpenCLContext* glsContext, int width, int height);
-    void allocateHighNoiseTextures(gls::OpenCLContext* glsContext, int width, int height);
-    void allocateFastDemosaicTextures(gls::OpenCLContext* glsContext, int width, int height);
+    void allocateTextures(gls::OpenCLContext *glsContext, int width, int height);
+    void allocateHighNoiseTextures(gls::OpenCLContext *glsContext, int width, int height);
+    void allocateFastDemosaicTextures(gls::OpenCLContext *glsContext, int width, int height);
+
+    const std::filesystem::path _assets_root;
 
 public:
-    RawConverter(gls::OpenCLContext* glsContext) : _glsContext(glsContext) {
+    RawConverter(gls::OpenCLContext *glsContext, const std::filesystem::path &assets_root = "Assets/") : _glsContext(glsContext), _assets_root(assets_root)
+    {
         localToneMapping = std::make_unique<LocalToneMapping>(_glsContext);
     }
 
-    gls::OpenCLContext* getContext() const {
+    gls::OpenCLContext *getContext() const
+    {
         return _glsContext;
     }
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* runPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                         DemosaicParameters* demosaicParameters, bool calibrateFromImage = false);
+    gls::cl_image_2d<gls::rgba_pixel_float> *runPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                         DemosaicParameters *demosaicParameters, bool calibrateFromImage = false);
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* demosaic(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                      DemosaicParameters* demosaicParameters, bool calibrateFromImage);
+    gls::cl_image_2d<gls::rgba_pixel_float> *demosaic(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                      DemosaicParameters *demosaicParameters, bool calibrateFromImage);
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* denoise(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                                                     DemosaicParameters* demosaicParameters, bool calibrateFromImage);
+    gls::cl_image_2d<gls::rgba_pixel_float> *denoise(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                                     DemosaicParameters *demosaicParameters, bool calibrateFromImage);
 
-    void fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage, const gls::Matrix<3, 3>& homography,
-                   DemosaicParameters* demosaicParameters, bool calibrateFromImage);
+    void fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage, const gls::Matrix<3, 3> &homography,
+                   DemosaicParameters *demosaicParameters, bool calibrateFromImage);
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* getFusedImage();
+    gls::cl_image_2d<gls::rgba_pixel_float> *getFusedImage();
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* postProcess(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                                                         const DemosaicParameters& demosaicParameters);
+    gls::cl_image_2d<gls::rgba_pixel_float> *postProcess(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                                         const DemosaicParameters &demosaicParameters);
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* runFastPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                             const DemosaicParameters& demosaicParameters);
+    gls::cl_image_2d<gls::rgba_pixel_float> *runFastPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                             const DemosaicParameters &demosaicParameters);
 
     template <typename T = gls::rgb_pixel>
-    static typename gls::image<T>::unique_ptr convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage);
+    static typename gls::image<T>::unique_ptr convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage);
 };
 
 #endif /* raw_converter_hpp */

--- a/include/raw_converter.hpp
+++ b/include/raw_converter.hpp
@@ -21,8 +21,7 @@
 #include "gls_cl_image.hpp"
 #include "pyramid_processor.hpp"
 
-class LocalToneMapping
-{
+class LocalToneMapping {
     gls::cl_image_2d<gls::luma_pixel_float>::unique_ptr ltmMaskImage;
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr lfAbGfImage;
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr lfAbGfMeanImage;
@@ -31,55 +30,55 @@ class LocalToneMapping
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr hfAbGfImage;
     gls::cl_image_2d<gls::luma_alpha_pixel_float>::unique_ptr hfAbGfMeanImage;
 
-public:
-    LocalToneMapping(gls::OpenCLContext *glsContext)
-    {
+   public:
+    LocalToneMapping(gls::OpenCLContext* glsContext) {
         auto clContext = glsContext->clContext();
 
         // Placeholder, only allocated if LTM is used
         ltmMaskImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, 1, 1);
     }
 
-    void allocateTextures(gls::OpenCLContext *glsContext, int width, int height)
-    {
+    void allocateTextures(gls::OpenCLContext* glsContext, int width, int height) {
         auto clContext = glsContext->clContext();
 
-        if (ltmMaskImage->width != width || ltmMaskImage->height != height)
-        {
-            ltmMaskImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
-            lfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 16, height / 16);
-            lfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 16, height / 16);
-            mfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 4, height / 4);
-            mfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width / 4, height / 4);
-            hfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width, height);
-            hfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width, height);
+        if (ltmMaskImage->width != width || ltmMaskImage->height != height) {
+            ltmMaskImage =
+                std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
+            lfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                clContext, width / 16, height / 16);
+            lfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                clContext, width / 16, height / 16);
+            mfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                clContext, width / 4, height / 4);
+            mfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                clContext, width / 4, height / 4);
+            hfAbGfImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                clContext, width, height);
+            hfAbGfMeanImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                clContext, width, height);
         }
     }
 
-    void createMask(gls::OpenCLContext *glsContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float> &image,
-                    const std::array<const gls::cl_image_2d<gls::rgba_pixel_float> *, 3> &guideImage,
-                    const NoiseModel<5> &noiseModel,
-                    const DemosaicParameters &demosaicParameters)
-    {
-        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float> *, 3> &abImage = {
+    void createMask(gls::OpenCLContext* glsContext,
+                    const gls::cl_image_2d<gls::rgba_pixel_float>& image,
+                    const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage,
+                    const NoiseModel<5>& noiseModel, const DemosaicParameters& demosaicParameters) {
+        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abImage = {
             lfAbGfImage.get(), mfAbGfImage.get(), hfAbGfImage.get()};
-        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float> *, 3> &abMeanImage = {
+        const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abMeanImage = {
             lfAbGfMeanImage.get(), mfAbGfMeanImage.get(), hfAbGfMeanImage.get()};
 
-        gls::Vector<2> nlf = {noiseModel.pyramidNlf[0].first[0], noiseModel.pyramidNlf[0].second[0]};
-        localToneMappingMask(glsContext, image, guideImage, abImage, abMeanImage, demosaicParameters.ltmParameters, ycbcr_srgb, nlf, ltmMaskImage.get());
+        gls::Vector<2> nlf = {noiseModel.pyramidNlf[0].first[0],
+                              noiseModel.pyramidNlf[0].second[0]};
+        localToneMappingMask(glsContext, image, guideImage, abImage, abMeanImage,
+                             demosaicParameters.ltmParameters, ycbcr_srgb, nlf, ltmMaskImage.get());
     }
 
-    const gls::cl_image_2d<gls::luma_pixel_float> &getMask()
-    {
-        return *ltmMaskImage;
-    }
+    const gls::cl_image_2d<gls::luma_pixel_float>& getMask() { return *ltmMaskImage; }
 };
 
-class RawConverter
-{
-    gls::OpenCLContext *_glsContext;
+class RawConverter {
+    gls::OpenCLContext* _glsContext;
 
     // TODO: this should probably be camera specific
     static const constexpr float kHighNoiseVariance = 2.5e-04;
@@ -107,45 +106,50 @@ class RawConverter
     gls::cl_image_2d<gls::rgba_pixel_float>::unique_ptr clFastLinearRGBImage;
     gls::cl_image_2d<gls::rgba_pixel_float>::unique_ptr clsFastRGBImage;
 
-    void allocateTextures(gls::OpenCLContext *glsContext, int width, int height);
-    void allocateHighNoiseTextures(gls::OpenCLContext *glsContext, int width, int height);
-    void allocateFastDemosaicTextures(gls::OpenCLContext *glsContext, int width, int height);
+    void allocateTextures(gls::OpenCLContext* glsContext, int width, int height);
+    void allocateHighNoiseTextures(gls::OpenCLContext* glsContext, int width, int height);
+    void allocateFastDemosaicTextures(gls::OpenCLContext* glsContext, int width, int height);
 
     const std::filesystem::path _assets_root;
 
-public:
-    RawConverter(gls::OpenCLContext *glsContext, const std::filesystem::path &assets_root = "Assets/") : _glsContext(glsContext), _assets_root(assets_root)
-    {
+   public:
+    RawConverter(gls::OpenCLContext* glsContext,
+                 const std::filesystem::path& assets_root = "Assets/")
+        : _glsContext(glsContext), _assets_root(assets_root) {
         localToneMapping = std::make_unique<LocalToneMapping>(_glsContext);
     }
 
-    gls::OpenCLContext *getContext() const
-    {
-        return _glsContext;
-    }
+    gls::OpenCLContext* getContext() const { return _glsContext; }
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *runPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                         DemosaicParameters *demosaicParameters, bool calibrateFromImage = false);
+    gls::cl_image_2d<gls::rgba_pixel_float>* runPipeline(
+        const gls::image<gls::luma_pixel_16>& rawImage, DemosaicParameters* demosaicParameters,
+        bool calibrateFromImage = false);
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *demosaic(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                      DemosaicParameters *demosaicParameters, bool calibrateFromImage);
+    gls::cl_image_2d<gls::rgba_pixel_float>* demosaic(
+        const gls::image<gls::luma_pixel_16>& rawImage, DemosaicParameters* demosaicParameters,
+        bool calibrateFromImage);
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *denoise(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
-                                                     DemosaicParameters *demosaicParameters, bool calibrateFromImage);
+    gls::cl_image_2d<gls::rgba_pixel_float>* denoise(
+        const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+        DemosaicParameters* demosaicParameters, bool calibrateFromImage);
 
-    void fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage, const gls::Matrix<3, 3> &homography,
-                   DemosaicParameters *demosaicParameters, bool calibrateFromImage);
+    void fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+                   const gls::Matrix<3, 3>& homography, DemosaicParameters* demosaicParameters,
+                   bool calibrateFromImage);
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *getFusedImage();
+    gls::cl_image_2d<gls::rgba_pixel_float>* getFusedImage();
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *postProcess(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
-                                                         const DemosaicParameters &demosaicParameters);
+    gls::cl_image_2d<gls::rgba_pixel_float>* postProcess(
+        const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+        const DemosaicParameters& demosaicParameters);
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *runFastPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                             const DemosaicParameters &demosaicParameters);
+    gls::cl_image_2d<gls::rgba_pixel_float>* runFastPipeline(
+        const gls::image<gls::luma_pixel_16>& rawImage,
+        const DemosaicParameters& demosaicParameters);
 
     template <typename T = gls::rgb_pixel>
-    static typename gls::image<T>::unique_ptr convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage);
+    static typename gls::image<T>::unique_ptr convertToRGBImage(
+        const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage);
 };
 
 #endif /* raw_converter_hpp */

--- a/src/CanonEOSRPCalibration.cpp
+++ b/src/CanonEOSRPCalibration.cpp
@@ -13,17 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CameraCalibration.hpp"
-
 #include <array>
 #include <cmath>
 #include <filesystem>
+
+#include "CameraCalibration.hpp"
 
 template <size_t levels = 5>
 class CanonEOSRPCalibration : public CameraCalibration<levels> {
     static const std::array<NoiseModel<levels>, 10> NLFData;
 
-public:
+   public:
     NoiseModel<levels> nlfFromIso(int iso) const override {
         iso = std::clamp(iso, 100, 50000);
         if (iso >= 100 && iso < 200) {
@@ -56,92 +56,79 @@ public:
         }
     }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override {
-        const float nlf_alpha = std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const override {
+        const float nlf_alpha =
+            std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
 
-        std::cout << "CanonEOSRP DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        std::cout << "CanonEOSRP DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+                  << std::endl;
 
         float lerp = std::lerp(0.125f, 1.2f, nlf_alpha);
         float lerp_c = std::lerp(0.5f, 1.2f, nlf_alpha);
 
         // Default Good
-        float lmult[5] = { 0.125f, 1.0f, 0.5f, 0.25f, 0.125f };
-        float cmult[5] = { 1, 1, 1, 1, 1 };
+        float lmult[5] = {0.125f, 1.0f, 0.5f, 0.25f, 0.125f};
+        float cmult[5] = {1, 1, 1, 1, 1};
 
         float chromaBoost = std::lerp(4.0f, 8.0f, nlf_alpha);
 
         float gradientBoost = 1 + 2 * smoothstep(0.3, 0.6, nlf_alpha);
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{
-            {
-                .luma = lmult[0] * lerp,
-                .chroma = cmult[0] * lerp_c,
-                .chromaBoost = 2 * chromaBoost,
-                .gradientBoost = 8,
-                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)
-            },
-            {
-                .luma = lmult[1] * lerp,
-                .chroma = cmult[1] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1.2
-            },
-            {
-                .luma = lmult[2] * lerp,
-                .chroma = cmult[2] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[3] * lerp,
-                .chroma = cmult[3] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[4] * lerp,
-                .chroma = cmult[4] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            }
-        }};
+        std::array<DenoiseParameters, 5> denoiseParameters = {
+            {{.luma = lmult[0] * lerp,
+              .chroma = cmult[0] * lerp_c,
+              .chromaBoost = 2 * chromaBoost,
+              .gradientBoost = 8,
+              .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)},
+             {.luma = lmult[1] * lerp,
+              .chroma = cmult[1] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1.2},
+             {.luma = lmult[2] * lerp,
+              .chroma = cmult[2] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[3] * lerp,
+              .chroma = cmult[3] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[4] * lerp,
+              .chroma = cmult[4] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1}}};
 
-        return { nlf_alpha, denoiseParameters };
+        return {nlf_alpha, denoiseParameters};
     }
 
     DemosaicParameters buildDemosaicParameters() const override {
-        return {
-            .rgbConversionParameters = {
-                .contrast = 1.05,
-                .saturation = 1.0,
-                .toneCurveSlope = 3.5,
-                .localToneMapping = false
-            },
-            .ltmParameters = {
-                .eps = 0.01,
-                .shadows = 1, // 0.5,
-                .highlights = 1, // 1.5,
-                .detail = { 1, 1.1, 1.3 }
-            }
-        };
+        return {.rgbConversionParameters = {.contrast = 1.05,
+                                            .saturation = 1.0,
+                                            .toneCurveSlope = 3.5,
+                                            .localToneMapping = false},
+                .ltmParameters = {.eps = 0.01,
+                                  .shadows = 1,     // 0.5,
+                                  .highlights = 1,  // 1.5,
+                                  .detail = {1, 1.1, 1.3}}};
     }
 
-    void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const override {
+    void calibrate(RawConverter* rawConverter,
+                   const std::filesystem::path& input_dir) const override {
         std::array<CalibrationEntry, 10> calibration_files = {{
-            { 100,   "IMG_1104_ISO_100.dng",   { 2541, 534, 1163, 758 }, false },
-            { 200,   "IMG_1107_ISO_200.dng",   { 2541, 534, 1163, 758 }, false },
-            { 400,   "IMG_1110_ISO_400.dng",   { 2541, 534, 1163, 758 }, false },
-            { 800,   "IMG_1113_ISO_800.dng",   { 2541, 534, 1163, 758 }, false },
-            { 1600,  "IMG_1116_ISO_1600.dng",  { 2541, 534, 1163, 758 }, false },
-            { 3200,  "IMG_1119_ISO_3200.dng",  { 2541, 534, 1163, 758 }, false },
-            { 6400,  "IMG_1122_ISO_6400.dng",  { 2541, 534, 1163, 758 }, false },
-            { 12800, "IMG_1125_ISO_12800.dng", { 2541, 534, 1163, 758 }, false },
-            { 25600, "IMG_1128_ISO_25600.dng", { 2541, 534, 1163, 758 }, false },
-            { 40000, "IMG_1131_ISO_40000.dng", { 2541, 534, 1163, 758 }, false },
+            {100, "IMG_1104_ISO_100.dng", {2541, 534, 1163, 758}, false},
+            {200, "IMG_1107_ISO_200.dng", {2541, 534, 1163, 758}, false},
+            {400, "IMG_1110_ISO_400.dng", {2541, 534, 1163, 758}, false},
+            {800, "IMG_1113_ISO_800.dng", {2541, 534, 1163, 758}, false},
+            {1600, "IMG_1116_ISO_1600.dng", {2541, 534, 1163, 758}, false},
+            {3200, "IMG_1119_ISO_3200.dng", {2541, 534, 1163, 758}, false},
+            {6400, "IMG_1122_ISO_6400.dng", {2541, 534, 1163, 758}, false},
+            {12800, "IMG_1125_ISO_12800.dng", {2541, 534, 1163, 758}, false},
+            {25600, "IMG_1128_ISO_25600.dng", {2541, 534, 1163, 758}, false},
+            {40000, "IMG_1131_ISO_40000.dng", {2541, 534, 1163, 758}, false},
         }};
 
         std::array<NoiseModel<5>, 10> noiseModel;
@@ -151,13 +138,13 @@ public:
             const auto input_path = input_dir / entry.fileName;
 
             DemosaicParameters demosaicParameters = {
-                .rgbConversionParameters = {
-                    .localToneMapping = false
-                }
-            };
+                .rgbConversionParameters = {.localToneMapping = false}};
 
-            const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/ true);
+            const auto rgb_image = CameraCalibration<5>::calibrate(
+                rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
+            rgb_image->write_png_file(
+                (input_path.parent_path() / input_path.stem()).string() + "_cal.png",
+                /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -172,128 +159,112 @@ void calibrateCanonEOSRP(RawConverter* rawConverter, const std::filesystem::path
     calibration.calibrate(rawConverter, input_dir);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicCanonEOSRPDNG(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaicCanonEOSRPDNG(
+    RawConverter* rawConverter, const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
     CanonEOSRPCalibration calibration;
-    auto demosaicParameters = calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
+    auto demosaicParameters =
+        calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
 
-    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters.get(), /*calibrateFromImage=*/ true));
+    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(
+        *inputImage, demosaicParameters.get(), /*calibrateFromImage=*/true));
 }
 
 // --- NLFData ---
 
-template<>
+template <>
 const std::array<NoiseModel<5>, 10> CanonEOSRPCalibration<5>::NLFData = {{
     // ISO 100
-    {
-        {{3.283e-06, 2.362e-06, 1.682e-06, 2.393e-06}, {1.801e-04, 1.322e-04, 1.387e-04, 1.320e-04}},
-        {{
-            {{2.797e-06, 8.173e-08, 1.421e-07}, {1.181e-04, 3.569e-06, 4.932e-06}},
-            {{1.157e-06, 1.034e-07, 1.215e-07}, {1.907e-04, 3.476e-06, 4.630e-06}},
-            {{1.000e-08, 1.873e-07, 1.606e-07}, {3.599e-04, 2.678e-06, 3.155e-06}},
-            {{1.000e-08, 3.464e-07, 3.457e-07}, {5.476e-04, 1.548e-06, 1.536e-06}},
-            {{8.617e-06, 7.370e-07, 6.917e-07}, {1.045e-03, 2.143e-06, 1.893e-06}},
-        }}
-    },
+    {{{3.283e-06, 2.362e-06, 1.682e-06, 2.393e-06}, {1.801e-04, 1.322e-04, 1.387e-04, 1.320e-04}},
+     {{
+         {{2.797e-06, 8.173e-08, 1.421e-07}, {1.181e-04, 3.569e-06, 4.932e-06}},
+         {{1.157e-06, 1.034e-07, 1.215e-07}, {1.907e-04, 3.476e-06, 4.630e-06}},
+         {{1.000e-08, 1.873e-07, 1.606e-07}, {3.599e-04, 2.678e-06, 3.155e-06}},
+         {{1.000e-08, 3.464e-07, 3.457e-07}, {5.476e-04, 1.548e-06, 1.536e-06}},
+         {{8.617e-06, 7.370e-07, 6.917e-07}, {1.045e-03, 2.143e-06, 1.893e-06}},
+     }}},
     // ISO 200
-    {
-        {{3.408e-06, 2.233e-06, 1.704e-06, 2.264e-06}, {2.221e-04, 1.514e-04, 1.639e-04, 1.515e-04}},
-        {{
-            {{2.614e-06, 8.666e-08, 1.578e-07}, {1.339e-04, 4.790e-06, 6.940e-06}},
-            {{9.126e-07, 1.081e-07, 1.281e-07}, {1.980e-04, 4.165e-06, 5.933e-06}},
-            {{1.000e-08, 1.836e-07, 1.611e-07}, {3.648e-04, 2.921e-06, 3.573e-06}},
-            {{1.000e-08, 3.435e-07, 3.404e-07}, {5.495e-04, 1.690e-06, 1.700e-06}},
-            {{9.005e-06, 7.405e-07, 6.990e-07}, {1.037e-03, 2.136e-06, 1.811e-06}},
-        }}
-    },
+    {{{3.408e-06, 2.233e-06, 1.704e-06, 2.264e-06}, {2.221e-04, 1.514e-04, 1.639e-04, 1.515e-04}},
+     {{
+         {{2.614e-06, 8.666e-08, 1.578e-07}, {1.339e-04, 4.790e-06, 6.940e-06}},
+         {{9.126e-07, 1.081e-07, 1.281e-07}, {1.980e-04, 4.165e-06, 5.933e-06}},
+         {{1.000e-08, 1.836e-07, 1.611e-07}, {3.648e-04, 2.921e-06, 3.573e-06}},
+         {{1.000e-08, 3.435e-07, 3.404e-07}, {5.495e-04, 1.690e-06, 1.700e-06}},
+         {{9.005e-06, 7.405e-07, 6.990e-07}, {1.037e-03, 2.136e-06, 1.811e-06}},
+     }}},
     // ISO 400
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.549e-04, 3.330e-04, 3.213e-04, 3.352e-04}},
-        {{
-            {{1.000e-08, 4.149e-08, 1.216e-07}, {3.622e-04, 9.477e-06, 1.389e-05}},
-            {{1.000e-08, 1.866e-08, 5.607e-08}, {4.826e-04, 8.705e-06, 1.160e-05}},
-            {{1.000e-08, 9.914e-08, 9.166e-08}, {7.298e-04, 6.135e-06, 7.029e-06}},
-            {{1.000e-08, 2.868e-07, 2.795e-07}, {9.604e-04, 4.103e-06, 4.177e-06}},
-            {{1.000e-08, 7.009e-07, 6.993e-07}, {1.379e-03, 5.942e-06, 4.644e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.549e-04, 3.330e-04, 3.213e-04, 3.352e-04}},
+     {{
+         {{1.000e-08, 4.149e-08, 1.216e-07}, {3.622e-04, 9.477e-06, 1.389e-05}},
+         {{1.000e-08, 1.866e-08, 5.607e-08}, {4.826e-04, 8.705e-06, 1.160e-05}},
+         {{1.000e-08, 9.914e-08, 9.166e-08}, {7.298e-04, 6.135e-06, 7.029e-06}},
+         {{1.000e-08, 2.868e-07, 2.795e-07}, {9.604e-04, 4.103e-06, 4.177e-06}},
+         {{1.000e-08, 7.009e-07, 6.993e-07}, {1.379e-03, 5.942e-06, 4.644e-06}},
+     }}},
     // ISO 800
-    {
-        {{7.480e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.153e-04, 3.901e-04, 4.159e-04, 3.915e-04}},
-        {{
-            {{1.000e-08, 8.893e-08, 1.971e-07}, {3.998e-04, 1.385e-05, 2.167e-05}},
-            {{1.000e-08, 4.207e-08, 8.742e-08}, {4.867e-04, 1.141e-05, 1.667e-05}},
-            {{1.000e-08, 1.064e-07, 1.041e-07}, {7.281e-04, 7.139e-06, 8.782e-06}},
-            {{1.000e-08, 2.803e-07, 2.783e-07}, {9.659e-04, 4.423e-06, 4.676e-06}},
-            {{1.000e-08, 7.179e-07, 7.086e-07}, {1.368e-03, 5.582e-06, 4.605e-06}},
-        }}
-    },
+    {{{7.480e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.153e-04, 3.901e-04, 4.159e-04, 3.915e-04}},
+     {{
+         {{1.000e-08, 8.893e-08, 1.971e-07}, {3.998e-04, 1.385e-05, 2.167e-05}},
+         {{1.000e-08, 4.207e-08, 8.742e-08}, {4.867e-04, 1.141e-05, 1.667e-05}},
+         {{1.000e-08, 1.064e-07, 1.041e-07}, {7.281e-04, 7.139e-06, 8.782e-06}},
+         {{1.000e-08, 2.803e-07, 2.783e-07}, {9.659e-04, 4.423e-06, 4.676e-06}},
+         {{1.000e-08, 7.179e-07, 7.086e-07}, {1.368e-03, 5.582e-06, 4.605e-06}},
+     }}},
     // ISO 1600
-    {
-        {{3.133e-06, 1.000e-08, 2.072e-07, 1.000e-08}, {9.422e-04, 5.147e-04, 6.210e-04, 5.156e-04}},
-        {{
-            {{1.000e-08, 2.104e-07, 4.288e-07}, {4.759e-04, 2.232e-05, 3.622e-05}},
-            {{1.000e-08, 1.039e-07, 1.911e-07}, {5.004e-04, 1.676e-05, 2.671e-05}},
-            {{1.000e-08, 1.277e-07, 1.326e-07}, {7.314e-04, 9.046e-06, 1.255e-05}},
-            {{1.000e-08, 2.745e-07, 2.882e-07}, {9.690e-04, 5.119e-06, 5.683e-06}},
-            {{1.000e-08, 7.131e-07, 7.046e-07}, {1.377e-03, 5.757e-06, 4.886e-06}},
-        }}
-    },
+    {{{3.133e-06, 1.000e-08, 2.072e-07, 1.000e-08}, {9.422e-04, 5.147e-04, 6.210e-04, 5.156e-04}},
+     {{
+         {{1.000e-08, 2.104e-07, 4.288e-07}, {4.759e-04, 2.232e-05, 3.622e-05}},
+         {{1.000e-08, 1.039e-07, 1.911e-07}, {5.004e-04, 1.676e-05, 2.671e-05}},
+         {{1.000e-08, 1.277e-07, 1.326e-07}, {7.314e-04, 9.046e-06, 1.255e-05}},
+         {{1.000e-08, 2.745e-07, 2.882e-07}, {9.690e-04, 5.119e-06, 5.683e-06}},
+         {{1.000e-08, 7.131e-07, 7.046e-07}, {1.377e-03, 5.757e-06, 4.886e-06}},
+     }}},
     // ISO 3200
-    {
-        {{1.209e-05, 3.372e-07, 3.669e-06, 1.815e-07}, {1.565e-03, 7.549e-04, 1.024e-03, 7.612e-04}},
-        {{
-            {{1.000e-08, 4.739e-07, 8.660e-07}, {6.341e-04, 3.939e-05, 6.706e-05}},
-            {{1.000e-08, 2.668e-07, 4.759e-07}, {5.198e-04, 2.718e-05, 4.591e-05}},
-            {{1.000e-08, 1.683e-07, 2.208e-07}, {7.371e-04, 1.319e-05, 1.959e-05}},
-            {{1.000e-08, 2.868e-07, 3.072e-07}, {9.702e-04, 6.231e-06, 7.865e-06}},
-            {{1.000e-08, 7.077e-07, 6.985e-07}, {1.387e-03, 6.145e-06, 5.754e-06}},
-        }}
-    },
+    {{{1.209e-05, 3.372e-07, 3.669e-06, 1.815e-07}, {1.565e-03, 7.549e-04, 1.024e-03, 7.612e-04}},
+     {{
+         {{1.000e-08, 4.739e-07, 8.660e-07}, {6.341e-04, 3.939e-05, 6.706e-05}},
+         {{1.000e-08, 2.668e-07, 4.759e-07}, {5.198e-04, 2.718e-05, 4.591e-05}},
+         {{1.000e-08, 1.683e-07, 2.208e-07}, {7.371e-04, 1.319e-05, 1.959e-05}},
+         {{1.000e-08, 2.868e-07, 3.072e-07}, {9.702e-04, 6.231e-06, 7.865e-06}},
+         {{1.000e-08, 7.077e-07, 6.985e-07}, {1.387e-03, 6.145e-06, 5.754e-06}},
+     }}},
     // ISO 6400
-    {
-        {{5.152e-05, 8.319e-06, 2.006e-05, 8.037e-06}, {2.196e-03, 1.078e-03, 1.533e-03, 1.086e-03}},
-        {{
-            {{4.366e-06, 8.977e-07, 1.839e-06}, {5.676e-04, 5.114e-05, 9.078e-05}},
-            {{2.133e-06, 6.415e-07, 1.318e-06}, {2.602e-04, 3.794e-05, 6.629e-05}},
-            {{1.000e-08, 3.474e-07, 5.311e-07}, {3.740e-04, 1.807e-05, 3.008e-05}},
-            {{1.000e-08, 3.609e-07, 4.407e-07}, {5.571e-04, 6.630e-06, 9.487e-06}},
-            {{8.765e-06, 7.391e-07, 7.180e-07}, {1.056e-03, 3.471e-06, 4.043e-06}},
-        }}
-    },
+    {{{5.152e-05, 8.319e-06, 2.006e-05, 8.037e-06}, {2.196e-03, 1.078e-03, 1.533e-03, 1.086e-03}},
+     {{
+         {{4.366e-06, 8.977e-07, 1.839e-06}, {5.676e-04, 5.114e-05, 9.078e-05}},
+         {{2.133e-06, 6.415e-07, 1.318e-06}, {2.602e-04, 3.794e-05, 6.629e-05}},
+         {{1.000e-08, 3.474e-07, 5.311e-07}, {3.740e-04, 1.807e-05, 3.008e-05}},
+         {{1.000e-08, 3.609e-07, 4.407e-07}, {5.571e-04, 6.630e-06, 9.487e-06}},
+         {{8.765e-06, 7.391e-07, 7.180e-07}, {1.056e-03, 3.471e-06, 4.043e-06}},
+     }}},
     // ISO 12800
-    {
-        {{1.106e-04, 1.855e-05, 4.755e-05, 1.766e-05}, {4.417e-03, 2.119e-03, 3.084e-03, 2.144e-03}},
-        {{
-            {{1.267e-05, 2.398e-06, 4.421e-06}, {9.705e-04, 9.682e-05, 1.814e-04}},
-            {{2.871e-06, 1.555e-06, 2.965e-06}, {3.677e-04, 7.571e-05, 1.375e-04}},
-            {{1.000e-08, 6.957e-07, 1.214e-06}, {3.980e-04, 3.438e-05, 5.864e-05}},
-            {{1.000e-08, 4.379e-07, 6.060e-07}, {5.616e-04, 1.239e-05, 1.873e-05}},
-            {{9.579e-06, 7.653e-07, 7.667e-07}, {1.051e-03, 4.840e-06, 6.471e-06}},
-        }}
-    },
+    {{{1.106e-04, 1.855e-05, 4.755e-05, 1.766e-05}, {4.417e-03, 2.119e-03, 3.084e-03, 2.144e-03}},
+     {{
+         {{1.267e-05, 2.398e-06, 4.421e-06}, {9.705e-04, 9.682e-05, 1.814e-04}},
+         {{2.871e-06, 1.555e-06, 2.965e-06}, {3.677e-04, 7.571e-05, 1.375e-04}},
+         {{1.000e-08, 6.957e-07, 1.214e-06}, {3.980e-04, 3.438e-05, 5.864e-05}},
+         {{1.000e-08, 4.379e-07, 6.060e-07}, {5.616e-04, 1.239e-05, 1.873e-05}},
+         {{9.579e-06, 7.653e-07, 7.667e-07}, {1.051e-03, 4.840e-06, 6.471e-06}},
+     }}},
     // ISO 25600
-    {
-        {{2.155e-04, 5.368e-05, 1.108e-04, 5.176e-05}, {9.895e-03, 4.630e-03, 6.654e-03, 4.675e-03}},
-        {{
-            {{4.887e-05, 7.306e-06, 1.215e-05}, {1.586e-03, 1.779e-04, 3.727e-04}},
-            {{7.466e-06, 4.920e-06, 8.293e-06}, {5.855e-04, 1.533e-04, 2.964e-04}},
-            {{9.727e-07, 1.985e-06, 3.239e-06}, {4.523e-04, 7.176e-05, 1.293e-04}},
-            {{1.000e-08, 8.197e-07, 1.179e-06}, {5.850e-04, 2.396e-05, 4.089e-05}},
-            {{9.214e-06, 8.467e-07, 9.109e-07}, {1.050e-03, 8.134e-06, 1.333e-05}},
-        }}
-    },
+    {{{2.155e-04, 5.368e-05, 1.108e-04, 5.176e-05}, {9.895e-03, 4.630e-03, 6.654e-03, 4.675e-03}},
+     {{
+         {{4.887e-05, 7.306e-06, 1.215e-05}, {1.586e-03, 1.779e-04, 3.727e-04}},
+         {{7.466e-06, 4.920e-06, 8.293e-06}, {5.855e-04, 1.533e-04, 2.964e-04}},
+         {{9.727e-07, 1.985e-06, 3.239e-06}, {4.523e-04, 7.176e-05, 1.293e-04}},
+         {{1.000e-08, 8.197e-07, 1.179e-06}, {5.850e-04, 2.396e-05, 4.089e-05}},
+         {{9.214e-06, 8.467e-07, 9.109e-07}, {1.050e-03, 8.134e-06, 1.333e-05}},
+     }}},
     // ISO 40000
-    {
-        {{2.173e-04, 4.227e-05, 8.064e-05, 4.117e-05}, {1.715e-02, 9.502e-03, 1.386e-02, 9.458e-03}},
-        {{
-            {{1.121e-04, 1.376e-05, 2.255e-05}, {1.934e-03, 2.518e-04, 5.797e-04}},
-            {{1.580e-05, 9.002e-06, 1.615e-05}, {8.018e-04, 2.455e-04, 4.796e-04}},
-            {{4.098e-06, 3.609e-06, 6.212e-06}, {4.919e-04, 1.206e-04, 2.247e-04}},
-            {{8.729e-07, 1.275e-06, 2.197e-06}, {5.740e-04, 4.054e-05, 6.821e-05}},
-            {{8.896e-06, 9.605e-07, 1.126e-06}, {1.084e-03, 1.283e-05, 2.189e-05}},
-        }}
-    },
+    {{{2.173e-04, 4.227e-05, 8.064e-05, 4.117e-05}, {1.715e-02, 9.502e-03, 1.386e-02, 9.458e-03}},
+     {{
+         {{1.121e-04, 1.376e-05, 2.255e-05}, {1.934e-03, 2.518e-04, 5.797e-04}},
+         {{1.580e-05, 9.002e-06, 1.615e-05}, {8.018e-04, 2.455e-04, 4.796e-04}},
+         {{4.098e-06, 3.609e-06, 6.212e-06}, {4.919e-04, 1.206e-04, 2.247e-04}},
+         {{8.729e-07, 1.275e-06, 2.197e-06}, {5.740e-04, 4.054e-05, 6.821e-05}},
+         {{8.896e-06, 9.605e-07, 1.126e-06}, {1.084e-03, 1.283e-05, 2.189e-05}},
+     }}},
 }};

--- a/src/IMX571Calibration.cpp
+++ b/src/IMX571Calibration.cpp
@@ -13,19 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CameraCalibration.hpp"
-
 #include <array>
 #include <cmath>
 #include <filesystem>
 
+#include "CameraCalibration.hpp"
 #include "demosaic.hpp"
 
 template <size_t levels = 5>
 class IMX571Calibration : public CameraCalibration<levels> {
     static const std::array<NoiseModel<levels>, 11> NLFData;
 
-public:
+   public:
     NoiseModel<levels> nlfFromIso(int iso) const override {
         iso = std::clamp(iso, 100, 102400);
         if (iso >= 100 && iso < 200) {
@@ -61,95 +60,80 @@ public:
         }
     }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override {
-        const float nlf_alpha = std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const override {
+        const float nlf_alpha =
+            std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
 
-        std::cout << "IMX571 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        std::cout << "IMX571 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+                  << std::endl;
 
         float lerp = std::lerp(0.125f, 2.0f, nlf_alpha);
         float lerp_c = std::lerp(0.5f, 2.0f, nlf_alpha);
 
         // Default Good
-        float lmult[5] = { 0.125f, 1.0f, 0.5f, 0.25f, 0.125f };
-        float cmult[5] = { 1, 1, 1, 1, 1 };
+        float lmult[5] = {0.125f, 1.0f, 0.5f, 0.25f, 0.125f};
+        float cmult[5] = {1, 1, 1, 1, 1};
 
         float chromaBoost = std::lerp(4.0f, 8.0f, nlf_alpha);
 
         float gradientBoost = 1 + 3 * smoothstep(0.3, 0.8, nlf_alpha);
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{
-            {
-                .luma = lmult[0] * lerp,
-                .chroma = cmult[0] * lerp_c,
-                .chromaBoost = 2 * chromaBoost,
-                .gradientBoost = 8 * gradientBoost,
-                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)
-            },
-            {
-                .luma = lmult[1] * lerp,
-                .chroma = cmult[1] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1.2
-            },
-            {
-                .luma = lmult[2] * lerp,
-                .chroma = cmult[2] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = 0, // gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[3] * lerp,
-                .chroma = cmult[3] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = 0, // gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[4] * lerp,
-                .chroma = cmult[4] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = 0, // gradientBoost,
-                .sharpening = 1
-            }
-        }};
+        std::array<DenoiseParameters, 5> denoiseParameters = {
+            {{.luma = lmult[0] * lerp,
+              .chroma = cmult[0] * lerp_c,
+              .chromaBoost = 2 * chromaBoost,
+              .gradientBoost = 8 * gradientBoost,
+              .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)},
+             {.luma = lmult[1] * lerp,
+              .chroma = cmult[1] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1.2},
+             {.luma = lmult[2] * lerp,
+              .chroma = cmult[2] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = 0,  // gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[3] * lerp,
+              .chroma = cmult[3] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = 0,  // gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[4] * lerp,
+              .chroma = cmult[4] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = 0,  // gradientBoost,
+              .sharpening = 1}}};
 
-        return { nlf_alpha, denoiseParameters };
+        return {nlf_alpha, denoiseParameters};
     }
 
     DemosaicParameters buildDemosaicParameters() const override {
-        return {
-            .rgbConversionParameters = {
-                .exposureBias = -1.0,
-                // .blacks = 0.1,
-                .contrast = 1.05,
-                .saturation = 1.0,
-                .toneCurveSlope = 3.5,
-                .localToneMapping = true
-            },
-            .ltmParameters = {
-                .eps = 0.01,
-                .shadows = 1.0,
-                .highlights = 1.5,
-                .detail = { 1, 2.0, 2.5 }
-            }
-        };
+        return {.rgbConversionParameters = {.exposureBias = -1.0,
+                                            // .blacks = 0.1,
+                                            .contrast = 1.05,
+                                            .saturation = 1.0,
+                                            .toneCurveSlope = 3.5,
+                                            .localToneMapping = true},
+                .ltmParameters = {
+                    .eps = 0.01, .shadows = 1.0, .highlights = 1.5, .detail = {1, 2.0, 2.5}}};
     }
 
-    void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const override {
+    void calibrate(RawConverter* rawConverter,
+                   const std::filesystem::path& input_dir) const override {
         std::array<CalibrationEntry, 11> calibration_files = {{
-            { 100,    "DSC00185_ISO_100.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 200,    "DSC00188_ISO_200.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 400,    "DSC00192_ISO_400.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 800,    "DSC00195_ISO_800.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 1600,   "DSC00198_ISO_1600.DNG",   { 2435, 521, 1109, 732 }, false },
-            { 3200,   "DSC00201_ISO_3200.DNG",   { 2435, 521, 1109, 732 }, false },
-            { 6400,   "DSC00204_ISO_6400.DNG",   { 2435, 521, 1109, 732 }, false },
-            { 12800,  "DSC00207_ISO_12800.DNG",  { 2435, 521, 1109, 732 }, false },
-            { 25600,  "DSC00210_ISO_25600.DNG",  { 2435, 521, 1109, 732 }, false },
-            { 51200,  "DSC00227_ISO_51200.DNG",  { 2435, 521, 1109, 732 }, false },
-            { 102400, "DSC00230_ISO_102400.DNG", { 2435, 521, 1109, 732 }, false },
+            {100, "DSC00185_ISO_100.DNG", {2435, 521, 1109, 732}, false},
+            {200, "DSC00188_ISO_200.DNG", {2435, 521, 1109, 732}, false},
+            {400, "DSC00192_ISO_400.DNG", {2435, 521, 1109, 732}, false},
+            {800, "DSC00195_ISO_800.DNG", {2435, 521, 1109, 732}, false},
+            {1600, "DSC00198_ISO_1600.DNG", {2435, 521, 1109, 732}, false},
+            {3200, "DSC00201_ISO_3200.DNG", {2435, 521, 1109, 732}, false},
+            {6400, "DSC00204_ISO_6400.DNG", {2435, 521, 1109, 732}, false},
+            {12800, "DSC00207_ISO_12800.DNG", {2435, 521, 1109, 732}, false},
+            {25600, "DSC00210_ISO_25600.DNG", {2435, 521, 1109, 732}, false},
+            {51200, "DSC00227_ISO_51200.DNG", {2435, 521, 1109, 732}, false},
+            {102400, "DSC00230_ISO_102400.DNG", {2435, 521, 1109, 732}, false},
         }};
 
         std::array<NoiseModel<5>, 11> noiseModel;
@@ -159,13 +143,13 @@ public:
             const auto input_path = input_dir / entry.fileName;
 
             DemosaicParameters demosaicParameters = {
-                .rgbConversionParameters = {
-                    .localToneMapping = false
-                }
-            };
+                .rgbConversionParameters = {.localToneMapping = false}};
 
-            const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/ true);
+            const auto rgb_image = CameraCalibration<5>::calibrate(
+                rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
+            rgb_image->write_png_file(
+                (input_path.parent_path() / input_path.stem()).string() + "_cal.png",
+                /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -180,24 +164,35 @@ void calibrateIMX571(RawConverter* rawConverter, const std::filesystem::path& in
     calibration.calibrate(rawConverter, input_dir);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter* rawConverter,
+                                                         const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    // const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    // const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(),
+    // &dng_metadata, &exif_metadata);
 
-    auto fullInputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
-    // A crop size with dimensions multiples of 128 and ratio of exactly 3:2, for a total resolution of 16MP
-    const gls::size imageSize = { 4992, 3328 };
-    const gls::rectangle crop({(fullInputImage->width - imageSize.width) / 2, (fullInputImage->height - imageSize.height) / 2 + 1}, imageSize);
+    auto fullInputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
+    // A crop size with dimensions multiples of 128 and ratio of exactly 3:2, for a total resolution
+    // of 16MP
+    const gls::size imageSize = {4992, 3328};
+    const gls::rectangle crop({(fullInputImage->width - imageSize.width) / 2,
+                               (fullInputImage->height - imageSize.height) / 2 + 1},
+                              imageSize);
     auto inputImage = std::make_unique<gls::image<gls::luma_pixel_16>>(*fullInputImage, crop);
 
     IMX571Calibration calibration;
-    auto demosaicParameters = calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
+    auto demosaicParameters =
+        calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
 
-    unpackDNGMetadata(*inputImage, &dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/ true, nullptr, false);
+    unpackDNGMetadata(*inputImage, &dng_metadata, demosaicParameters.get(),
+                      /*auto_white_balance=*/true, nullptr, false);
 
-    const auto demosaicedImage = rawConverter->runPipeline(*inputImage, demosaicParameters.get(), /*calibrateFromImage=*/ false);
+    const auto demosaicedImage = rawConverter->runPipeline(*inputImage, demosaicParameters.get(),
+                                                           /*calibrateFromImage=*/false);
 
-    gls::cl_image_2d<gls::rgba_pixel_float> unsquishedImage(rawConverter->getContext()->clContext(), demosaicedImage->width, demosaicedImage->height * 1.2);
+    gls::cl_image_2d<gls::rgba_pixel_float> unsquishedImage(rawConverter->getContext()->clContext(),
+                                                            demosaicedImage->width,
+                                                            demosaicedImage->height * 1.2);
     clRescaleImage(rawConverter->getContext(), *demosaicedImage, &unsquishedImage);
 
     return RawConverter::convertToRGBImage(unsquishedImage);
@@ -205,127 +200,105 @@ gls::image<gls::rgb_pixel>::unique_ptr demosaicIMX571DNG(RawConverter* rawConver
 
 // --- NLFData ---
 
-template<>
+template <>
 const std::array<NoiseModel<5>, 11> IMX571Calibration<5>::NLFData = {{
     // ISO 100
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {3.681e-04, 3.448e-04, 2.846e-04, 3.447e-04}},
-        {{
-            {{1.000e-08, 1.000e-08, 1.026e-08}, {3.686e-04, 7.427e-06, 8.743e-06}},
-            {{1.000e-08, 1.000e-08, 1.000e-08}, {5.010e-04, 8.027e-06, 7.757e-06}},
-            {{1.000e-08, 7.791e-08, 6.431e-08}, {7.489e-04, 6.842e-06, 6.428e-06}},
-            {{1.000e-08, 2.936e-07, 3.165e-07}, {9.712e-04, 4.746e-06, 3.824e-06}},
-            {{1.000e-08, 7.608e-07, 7.625e-07}, {1.510e-03, 7.559e-06, 5.740e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {3.681e-04, 3.448e-04, 2.846e-04, 3.447e-04}},
+     {{
+         {{1.000e-08, 1.000e-08, 1.026e-08}, {3.686e-04, 7.427e-06, 8.743e-06}},
+         {{1.000e-08, 1.000e-08, 1.000e-08}, {5.010e-04, 8.027e-06, 7.757e-06}},
+         {{1.000e-08, 7.791e-08, 6.431e-08}, {7.489e-04, 6.842e-06, 6.428e-06}},
+         {{1.000e-08, 2.936e-07, 3.165e-07}, {9.712e-04, 4.746e-06, 3.824e-06}},
+         {{1.000e-08, 7.608e-07, 7.625e-07}, {1.510e-03, 7.559e-06, 5.740e-06}},
+     }}},
     // ISO 200
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.499e-04, 3.647e-04, 3.140e-04, 3.643e-04}},
-        {{
-            {{1.000e-08, 1.000e-08, 3.841e-08}, {3.891e-04, 9.280e-06, 1.321e-05}},
-            {{1.000e-08, 1.000e-08, 2.128e-08}, {5.035e-04, 9.215e-06, 1.053e-05}},
-            {{1.000e-08, 7.166e-08, 6.374e-08}, {7.476e-04, 7.374e-06, 7.463e-06}},
-            {{1.000e-08, 2.895e-07, 3.087e-07}, {9.677e-04, 4.947e-06, 4.188e-06}},
-            {{1.000e-08, 7.605e-07, 7.614e-07}, {1.500e-03, 7.653e-06, 5.846e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.499e-04, 3.647e-04, 3.140e-04, 3.643e-04}},
+     {{
+         {{1.000e-08, 1.000e-08, 3.841e-08}, {3.891e-04, 9.280e-06, 1.321e-05}},
+         {{1.000e-08, 1.000e-08, 2.128e-08}, {5.035e-04, 9.215e-06, 1.053e-05}},
+         {{1.000e-08, 7.166e-08, 6.374e-08}, {7.476e-04, 7.374e-06, 7.463e-06}},
+         {{1.000e-08, 2.895e-07, 3.087e-07}, {9.677e-04, 4.947e-06, 4.188e-06}},
+         {{1.000e-08, 7.605e-07, 7.614e-07}, {1.500e-03, 7.653e-06, 5.846e-06}},
+     }}},
     // ISO 400
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.396e-04, 4.238e-04, 3.977e-04, 4.217e-04}},
-        {{
-            {{1.000e-08, 1.000e-08, 7.723e-08}, {4.263e-04, 1.306e-05, 2.182e-05}},
-            {{1.000e-08, 1.000e-08, 1.239e-08}, {5.113e-04, 1.186e-05, 1.652e-05}},
-            {{1.000e-08, 6.741e-08, 5.787e-08}, {7.483e-04, 8.636e-06, 9.625e-06}},
-            {{1.000e-08, 2.841e-07, 2.978e-07}, {9.675e-04, 5.337e-06, 4.905e-06}},
-            {{1.000e-08, 7.600e-07, 7.671e-07}, {1.494e-03, 7.795e-06, 5.757e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.396e-04, 4.238e-04, 3.977e-04, 4.217e-04}},
+     {{
+         {{1.000e-08, 1.000e-08, 7.723e-08}, {4.263e-04, 1.306e-05, 2.182e-05}},
+         {{1.000e-08, 1.000e-08, 1.239e-08}, {5.113e-04, 1.186e-05, 1.652e-05}},
+         {{1.000e-08, 6.741e-08, 5.787e-08}, {7.483e-04, 8.636e-06, 9.625e-06}},
+         {{1.000e-08, 2.841e-07, 2.978e-07}, {9.675e-04, 5.337e-06, 4.905e-06}},
+         {{1.000e-08, 7.600e-07, 7.671e-07}, {1.494e-03, 7.795e-06, 5.757e-06}},
+     }}},
     // ISO 800
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.018e-03, 5.322e-04, 5.686e-04, 5.297e-04}},
-        {{
-            {{1.000e-08, 6.604e-08, 2.035e-07}, {4.924e-04, 2.036e-05, 3.801e-05}},
-            {{1.000e-08, 1.000e-08, 3.925e-08}, {5.207e-04, 1.685e-05, 2.784e-05}},
-            {{1.000e-08, 7.534e-08, 5.754e-08}, {7.531e-04, 1.069e-05, 1.390e-05}},
-            {{1.000e-08, 2.722e-07, 2.967e-07}, {9.571e-04, 6.101e-06, 5.980e-06}},
-            {{1.000e-08, 7.695e-07, 7.782e-07}, {1.472e-03, 8.027e-06, 6.125e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.018e-03, 5.322e-04, 5.686e-04, 5.297e-04}},
+     {{
+         {{1.000e-08, 6.604e-08, 2.035e-07}, {4.924e-04, 2.036e-05, 3.801e-05}},
+         {{1.000e-08, 1.000e-08, 3.925e-08}, {5.207e-04, 1.685e-05, 2.784e-05}},
+         {{1.000e-08, 7.534e-08, 5.754e-08}, {7.531e-04, 1.069e-05, 1.390e-05}},
+         {{1.000e-08, 2.722e-07, 2.967e-07}, {9.571e-04, 6.101e-06, 5.980e-06}},
+         {{1.000e-08, 7.695e-07, 7.782e-07}, {1.472e-03, 8.027e-06, 6.125e-06}},
+     }}},
     // ISO 1600
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.717e-03, 7.571e-04, 9.241e-04, 7.550e-04}},
-        {{
-            {{1.000e-08, 1.857e-07, 3.453e-07}, {6.393e-04, 3.485e-05, 7.274e-05}},
-            {{1.000e-08, 8.949e-08, 1.677e-07}, {5.405e-04, 2.620e-05, 4.922e-05}},
-            {{1.000e-08, 8.995e-08, 7.926e-08}, {7.525e-04, 1.464e-05, 2.207e-05}},
-            {{1.000e-08, 2.768e-07, 3.090e-07}, {9.602e-04, 7.266e-06, 8.327e-06}},
-            {{1.000e-08, 7.649e-07, 7.682e-07}, {1.473e-03, 8.244e-06, 6.902e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.717e-03, 7.571e-04, 9.241e-04, 7.550e-04}},
+     {{
+         {{1.000e-08, 1.857e-07, 3.453e-07}, {6.393e-04, 3.485e-05, 7.274e-05}},
+         {{1.000e-08, 8.949e-08, 1.677e-07}, {5.405e-04, 2.620e-05, 4.922e-05}},
+         {{1.000e-08, 8.995e-08, 7.926e-08}, {7.525e-04, 1.464e-05, 2.207e-05}},
+         {{1.000e-08, 2.768e-07, 3.090e-07}, {9.602e-04, 7.266e-06, 8.327e-06}},
+         {{1.000e-08, 7.649e-07, 7.682e-07}, {1.473e-03, 8.244e-06, 6.902e-06}},
+     }}},
     // ISO 3200
-    {
-        {{1.660e-05, 1.000e-08, 1.000e-08, 1.000e-08}, {2.888e-03, 1.320e-03, 1.644e-03, 1.325e-03}},
-        {{
-            {{1.000e-08, 5.176e-07, 7.774e-07}, {9.818e-04, 6.376e-05, 1.439e-04}},
-            {{1.000e-08, 2.866e-07, 4.436e-07}, {5.614e-04, 4.559e-05, 9.371e-05}},
-            {{1.000e-08, 1.398e-07, 1.546e-07}, {7.514e-04, 2.278e-05, 3.856e-05}},
-            {{1.000e-08, 2.900e-07, 3.274e-07}, {9.181e-04, 9.926e-06, 1.301e-05}},
-            {{1.000e-08, 8.220e-07, 8.594e-07}, {1.381e-03, 8.419e-06, 7.551e-06}},
-        }}
-    },
+    {{{1.660e-05, 1.000e-08, 1.000e-08, 1.000e-08}, {2.888e-03, 1.320e-03, 1.644e-03, 1.325e-03}},
+     {{
+         {{1.000e-08, 5.176e-07, 7.774e-07}, {9.818e-04, 6.376e-05, 1.439e-04}},
+         {{1.000e-08, 2.866e-07, 4.436e-07}, {5.614e-04, 4.559e-05, 9.371e-05}},
+         {{1.000e-08, 1.398e-07, 1.546e-07}, {7.514e-04, 2.278e-05, 3.856e-05}},
+         {{1.000e-08, 2.900e-07, 3.274e-07}, {9.181e-04, 9.926e-06, 1.301e-05}},
+         {{1.000e-08, 8.220e-07, 8.594e-07}, {1.381e-03, 8.419e-06, 7.551e-06}},
+     }}},
     // ISO 6400
-    {
-        {{4.137e-05, 1.000e-08, 4.311e-06, 1.000e-08}, {5.539e-03, 2.345e-03, 3.110e-03, 2.352e-03}},
-        {{
-            {{1.634e-06, 1.265e-06, 1.432e-06}, {1.585e-03, 1.157e-04, 2.866e-04}},
-            {{1.000e-08, 6.595e-07, 9.218e-07}, {6.463e-04, 8.421e-05, 1.826e-04}},
-            {{1.000e-08, 2.738e-07, 3.553e-07}, {7.587e-04, 3.806e-05, 6.996e-05}},
-            {{1.000e-08, 3.175e-07, 3.725e-07}, {8.731e-04, 1.458e-05, 2.216e-05}},
-            {{1.000e-08, 9.064e-07, 9.689e-07}, {1.236e-03, 8.252e-06, 8.845e-06}},
-        }}
-    },
+    {{{4.137e-05, 1.000e-08, 4.311e-06, 1.000e-08}, {5.539e-03, 2.345e-03, 3.110e-03, 2.352e-03}},
+     {{
+         {{1.634e-06, 1.265e-06, 1.432e-06}, {1.585e-03, 1.157e-04, 2.866e-04}},
+         {{1.000e-08, 6.595e-07, 9.218e-07}, {6.463e-04, 8.421e-05, 1.826e-04}},
+         {{1.000e-08, 2.738e-07, 3.553e-07}, {7.587e-04, 3.806e-05, 6.996e-05}},
+         {{1.000e-08, 3.175e-07, 3.725e-07}, {8.731e-04, 1.458e-05, 2.216e-05}},
+         {{1.000e-08, 9.064e-07, 9.689e-07}, {1.236e-03, 8.252e-06, 8.845e-06}},
+     }}},
     // ISO 12800
-    {
-        {{6.766e-05, 2.051e-06, 1.645e-05, 2.807e-06}, {1.142e-02, 4.548e-03, 6.092e-03, 4.585e-03}},
-        {{
-            {{2.206e-05, 3.045e-06, 3.033e-06}, {2.528e-03, 2.095e-04, 5.749e-04}},
-            {{1.000e-08, 1.672e-06, 1.998e-06}, {8.673e-04, 1.579e-04, 3.680e-04}},
-            {{1.000e-08, 5.859e-07, 7.594e-07}, {7.845e-04, 6.907e-05, 1.366e-04}},
-            {{1.000e-08, 3.830e-07, 4.875e-07}, {9.025e-04, 2.413e-05, 4.117e-05}},
-            {{1.000e-08, 8.809e-07, 9.512e-07}, {1.303e-03, 1.116e-05, 1.463e-05}},
-        }}
-    },
+    {{{6.766e-05, 2.051e-06, 1.645e-05, 2.807e-06}, {1.142e-02, 4.548e-03, 6.092e-03, 4.585e-03}},
+     {{
+         {{2.206e-05, 3.045e-06, 3.033e-06}, {2.528e-03, 2.095e-04, 5.749e-04}},
+         {{1.000e-08, 1.672e-06, 1.998e-06}, {8.673e-04, 1.579e-04, 3.680e-04}},
+         {{1.000e-08, 5.859e-07, 7.594e-07}, {7.845e-04, 6.907e-05, 1.366e-04}},
+         {{1.000e-08, 3.830e-07, 4.875e-07}, {9.025e-04, 2.413e-05, 4.117e-05}},
+         {{1.000e-08, 8.809e-07, 9.512e-07}, {1.303e-03, 1.116e-05, 1.463e-05}},
+     }}},
     // ISO 25600
-    {
-        {{1.579e-04, 1.000e-08, 1.000e-08, 3.245e-07}, {1.696e-02, 9.136e-03, 1.286e-02, 9.248e-03}},
-        {{
-            {{7.544e-05, 7.086e-06, 3.769e-06}, {4.212e-03, 3.907e-04, 1.213e-03}},
-            {{1.000e-08, 3.283e-06, 3.365e-06}, {1.327e-03, 3.095e-04, 7.497e-04}},
-            {{1.000e-08, 1.072e-06, 1.201e-06}, {8.396e-04, 1.341e-04, 2.781e-04}},
-            {{1.000e-08, 5.847e-07, 7.495e-07}, {8.875e-04, 4.236e-05, 7.692e-05}},
-            {{1.000e-08, 9.475e-07, 1.120e-06}, {1.221e-03, 1.611e-05, 2.217e-05}},
-        }}
-    },
+    {{{1.579e-04, 1.000e-08, 1.000e-08, 3.245e-07}, {1.696e-02, 9.136e-03, 1.286e-02, 9.248e-03}},
+     {{
+         {{7.544e-05, 7.086e-06, 3.769e-06}, {4.212e-03, 3.907e-04, 1.213e-03}},
+         {{1.000e-08, 3.283e-06, 3.365e-06}, {1.327e-03, 3.095e-04, 7.497e-04}},
+         {{1.000e-08, 1.072e-06, 1.201e-06}, {8.396e-04, 1.341e-04, 2.781e-04}},
+         {{1.000e-08, 5.847e-07, 7.495e-07}, {8.875e-04, 4.236e-05, 7.692e-05}},
+         {{1.000e-08, 9.475e-07, 1.120e-06}, {1.221e-03, 1.611e-05, 2.217e-05}},
+     }}},
     // ISO 51200
-    {
-        {{2.426e-04, 1.000e-08, 1.693e-06, 1.000e-08}, {1.800e-02, 1.339e-02, 1.708e-02, 1.357e-02}},
-        {{
-            {{1.611e-04, 1.476e-05, 1.097e-05}, {4.615e-03, 5.094e-04, 1.937e-03}},
-            {{7.772e-06, 6.942e-06, 8.358e-06}, {1.925e-03, 5.114e-04, 1.327e-03}},
-            {{1.000e-08, 2.492e-06, 2.101e-06}, {1.032e-03, 2.499e-04, 5.670e-04}},
-            {{1.000e-08, 7.571e-07, 1.032e-06}, {9.193e-04, 8.701e-05, 1.658e-04}},
-            {{1.000e-08, 1.040e-06, 1.307e-06}, {1.208e-03, 2.773e-05, 4.544e-05}},
-        }}
-    },
+    {{{2.426e-04, 1.000e-08, 1.693e-06, 1.000e-08}, {1.800e-02, 1.339e-02, 1.708e-02, 1.357e-02}},
+     {{
+         {{1.611e-04, 1.476e-05, 1.097e-05}, {4.615e-03, 5.094e-04, 1.937e-03}},
+         {{7.772e-06, 6.942e-06, 8.358e-06}, {1.925e-03, 5.114e-04, 1.327e-03}},
+         {{1.000e-08, 2.492e-06, 2.101e-06}, {1.032e-03, 2.499e-04, 5.670e-04}},
+         {{1.000e-08, 7.571e-07, 1.032e-06}, {9.193e-04, 8.701e-05, 1.658e-04}},
+         {{1.000e-08, 1.040e-06, 1.307e-06}, {1.208e-03, 2.773e-05, 4.544e-05}},
+     }}},
     // ISO 102400
-    {
-        {{2.763e-04, 1.000e-08, 5.632e-05, 1.000e-08}, {2.324e-02, 2.530e-02, 2.491e-02, 2.492e-02}},
-        {{
-            {{3.416e-04, 6.339e-05, 5.365e-05}, {6.797e-03, 2.545e-04, 3.741e-03}},
-            {{3.558e-05, 1.744e-05, 2.873e-05}, {3.637e-03, 1.092e-03, 2.794e-03}},
-            {{1.000e-08, 2.768e-06, 2.035e-06}, {1.652e-03, 5.720e-04, 1.284e-03}},
-            {{1.000e-08, 6.270e-07, 8.442e-07}, {1.133e-03, 1.931e-04, 3.861e-04}},
-            {{1.000e-08, 1.104e-06, 1.611e-06}, {1.372e-03, 5.371e-05, 1.010e-04}},
-        }}
-    },
+    {{{2.763e-04, 1.000e-08, 5.632e-05, 1.000e-08}, {2.324e-02, 2.530e-02, 2.491e-02, 2.492e-02}},
+     {{
+         {{3.416e-04, 6.339e-05, 5.365e-05}, {6.797e-03, 2.545e-04, 3.741e-03}},
+         {{3.558e-05, 1.744e-05, 2.873e-05}, {3.637e-03, 1.092e-03, 2.794e-03}},
+         {{1.000e-08, 2.768e-06, 2.035e-06}, {1.652e-03, 5.720e-04, 1.284e-03}},
+         {{1.000e-08, 6.270e-07, 8.442e-07}, {1.133e-03, 1.931e-04, 3.861e-04}},
+         {{1.000e-08, 1.104e-06, 1.611e-06}, {1.372e-03, 5.371e-05, 1.010e-04}},
+     }}},
 }};

--- a/src/LeicaQ2Calibration.cpp
+++ b/src/LeicaQ2Calibration.cpp
@@ -13,17 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CameraCalibration.hpp"
-
 #include <array>
 #include <cmath>
 #include <filesystem>
+
+#include "CameraCalibration.hpp"
 
 template <size_t levels = 5>
 class LeicaQ2Calibration : public CameraCalibration<levels> {
     static const std::array<NoiseModel<levels>, 10> NLFData;
 
-public:
+   public:
     NoiseModel<levels> nlfFromIso(int iso) const override {
         iso = std::clamp(iso, 100, 50000);
         if (iso >= 100 && iso < 200) {
@@ -56,86 +56,73 @@ public:
         }
     }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override {
-        const float nlf_alpha = std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const override {
+        const float nlf_alpha =
+            std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
 
-        std::cout << "LeicaQ2 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        std::cout << "LeicaQ2 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+                  << std::endl;
 
         float lerp = 0.5 * std::lerp(0.125f, 2.0f, nlf_alpha);
         float lerp_c = std::lerp(0.5f, 2.0f, nlf_alpha);
 
         // Default Good
-        float lmult[5] = { 0.25, 1, 0.25, 0.125, 0.125 / 2 };
-        float cmult[5] = { 1, 1, 0.5, 0.25, 0.125 };
+        float lmult[5] = {0.25, 1, 0.25, 0.125, 0.125 / 2};
+        float cmult[5] = {1, 1, 0.5, 0.25, 0.125};
 
         float chromaBoost = 8;
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{
-            {
-                .luma = lmult[0] * lerp,
-                .chroma = cmult[0] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = 32,
-                .sharpening = 1.2, // Sharpen HF in LTM
-            },
-            {
-                .luma = lmult[1] * lerp,
-                .chroma = cmult[1] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1.1
-            },
-            {
-                .luma = lmult[2] * lerp,
-                .chroma = cmult[2] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[3] * lerp,
-                .chroma = cmult[3] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[4] * lerp,
-                .chroma = cmult[4] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1
-            }
-        }};
+        std::array<DenoiseParameters, 5> denoiseParameters = {
+            {{
+                 .luma = lmult[0] * lerp,
+                 .chroma = cmult[0] * lerp_c,
+                 .chromaBoost = chromaBoost,
+                 .gradientBoost = 32,
+                 .sharpening = 1.2,  // Sharpen HF in LTM
+             },
+             {.luma = lmult[1] * lerp,
+              .chroma = cmult[1] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1.1},
+             {.luma = lmult[2] * lerp,
+              .chroma = cmult[2] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1},
+             {.luma = lmult[3] * lerp,
+              .chroma = cmult[3] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1},
+             {.luma = lmult[4] * lerp,
+              .chroma = cmult[4] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1}}};
 
-        return { nlf_alpha, denoiseParameters };
+        return {nlf_alpha, denoiseParameters};
     }
 
     DemosaicParameters buildDemosaicParameters() const override {
-        return {
-            .rgbConversionParameters = {
-                .contrast = 1.05,
-                .saturation = 1.0,
-                .toneCurveSlope = 3.5,
-                .localToneMapping = false
-            },
-            .ltmParameters = {
-                .eps = 0.01,
-                .shadows = 0.7,
-                .highlights = 1.3,
-                .detail = { 1, 1.05, 1.3 }
-            }
-        };
+        return {.rgbConversionParameters = {.contrast = 1.05,
+                                            .saturation = 1.0,
+                                            .toneCurveSlope = 3.5,
+                                            .localToneMapping = false},
+                .ltmParameters = {
+                    .eps = 0.01, .shadows = 0.7, .highlights = 1.3, .detail = {1, 1.05, 1.3}}};
     }
 
-    void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const override {
+    void calibrate(RawConverter* rawConverter,
+                   const std::filesystem::path& input_dir) const override {
         std::array<CalibrationEntry, 10> calibration_files = {{
-            { 100,   "L1010611.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 200,   "L1010614.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 400,   "L1010617.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 800,   "L1010620.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 1600,  "L1010623.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 3200,  "L1010626.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 6400,  "L1010629.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 12500, "L1010632.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 25000, "L1010635.DNG", { 3440, 777, 1549, 1006 }, false },
-            { 50000, "L1010638.DNG", { 3440, 777, 1549, 1006 }, false },
+            {100, "L1010611.DNG", {3440, 777, 1549, 1006}, false},
+            {200, "L1010614.DNG", {3440, 777, 1549, 1006}, false},
+            {400, "L1010617.DNG", {3440, 777, 1549, 1006}, false},
+            {800, "L1010620.DNG", {3440, 777, 1549, 1006}, false},
+            {1600, "L1010623.DNG", {3440, 777, 1549, 1006}, false},
+            {3200, "L1010626.DNG", {3440, 777, 1549, 1006}, false},
+            {6400, "L1010629.DNG", {3440, 777, 1549, 1006}, false},
+            {12500, "L1010632.DNG", {3440, 777, 1549, 1006}, false},
+            {25000, "L1010635.DNG", {3440, 777, 1549, 1006}, false},
+            {50000, "L1010638.DNG", {3440, 777, 1549, 1006}, false},
         }};
 
         std::array<NoiseModel<5>, 10> noiseModel;
@@ -144,16 +131,17 @@ public:
             auto& entry = calibration_files[i];
             const auto input_path = input_dir / entry.fileName;
 
-            DemosaicParameters demosaicParameters = {
-                .rgbConversionParameters = {
-                    .contrast = 1.05,
-                    .saturation = 1.0,
-                    .toneCurveSlope = 3.5,
-                }
-            };
+            DemosaicParameters demosaicParameters = {.rgbConversionParameters = {
+                                                         .contrast = 1.05,
+                                                         .saturation = 1.0,
+                                                         .toneCurveSlope = 3.5,
+                                                     }};
 
-            const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/ true);
+            const auto rgb_image = CameraCalibration<5>::calibrate(
+                rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
+            rgb_image->write_png_file(
+                (input_path.parent_path() / input_path.stem()).string() + "_cal.png",
+                /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -172,128 +160,112 @@ void calibrateiLeicaQ2(RawConverter* rawConverter, const std::filesystem::path& 
     calibration.calibrate(rawConverter, input_dir);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicLeicaQ2DNG(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaicLeicaQ2DNG(RawConverter* rawConverter,
+                                                          const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
     LeicaQ2Calibration calibration;
-    auto demosaicParameters = calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
+    auto demosaicParameters =
+        calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
 
-    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters.get(), /*calibrateFromImage=*/ false));
+    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(
+        *inputImage, demosaicParameters.get(), /*calibrateFromImage=*/false));
 }
 
 // --- NLFData ---
 
-template<>
+template <>
 const std::array<NoiseModel<5>, 10> LeicaQ2Calibration<5>::NLFData = {{
     // ISO 100
-    {
-        {{6.998e-07, 1.030e-06, 1.000e-08, 1.034e-06}, {2.054e-04, 1.487e-04, 1.564e-04, 1.496e-04}},
-        {{
-            {{1.799e-06, 8.381e-08, 1.363e-07}, {1.126e-04, 5.149e-06, 9.256e-06}},
-            {{1.216e-06, 1.331e-07, 1.399e-07}, {1.449e-04, 5.173e-06, 9.835e-06}},
-            {{1.000e-08, 1.963e-07, 1.392e-07}, {3.046e-04, 5.064e-06, 9.020e-06}},
-            {{1.000e-08, 3.895e-07, 3.640e-07}, {4.822e-04, 3.695e-06, 4.990e-06}},
-            {{3.280e-06, 8.278e-07, 7.503e-07}, {8.459e-04, 3.336e-06, 4.069e-06}},
-        }}
-    },
+    {{{6.998e-07, 1.030e-06, 1.000e-08, 1.034e-06}, {2.054e-04, 1.487e-04, 1.564e-04, 1.496e-04}},
+     {{
+         {{1.799e-06, 8.381e-08, 1.363e-07}, {1.126e-04, 5.149e-06, 9.256e-06}},
+         {{1.216e-06, 1.331e-07, 1.399e-07}, {1.449e-04, 5.173e-06, 9.835e-06}},
+         {{1.000e-08, 1.963e-07, 1.392e-07}, {3.046e-04, 5.064e-06, 9.020e-06}},
+         {{1.000e-08, 3.895e-07, 3.640e-07}, {4.822e-04, 3.695e-06, 4.990e-06}},
+         {{3.280e-06, 8.278e-07, 7.503e-07}, {8.459e-04, 3.336e-06, 4.069e-06}},
+     }}},
     // ISO 200
-    {
-        {{1.191e-06, 1.083e-06, 1.759e-07, 1.085e-06}, {2.934e-04, 1.866e-04, 1.979e-04, 1.877e-04}},
-        {{
-            {{1.467e-06, 9.428e-08, 1.595e-07}, {1.451e-04, 7.415e-06, 1.352e-05}},
-            {{5.287e-07, 1.272e-07, 1.289e-07}, {1.674e-04, 6.833e-06, 1.315e-05}},
-            {{1.000e-08, 1.845e-07, 1.301e-07}, {3.147e-04, 5.711e-06, 1.013e-05}},
-            {{1.000e-08, 3.817e-07, 3.526e-07}, {4.921e-04, 3.975e-06, 5.410e-06}},
-            {{3.041e-06, 8.249e-07, 7.452e-07}, {8.473e-04, 3.471e-06, 4.177e-06}},
-        }}
-    },
+    {{{1.191e-06, 1.083e-06, 1.759e-07, 1.085e-06}, {2.934e-04, 1.866e-04, 1.979e-04, 1.877e-04}},
+     {{
+         {{1.467e-06, 9.428e-08, 1.595e-07}, {1.451e-04, 7.415e-06, 1.352e-05}},
+         {{5.287e-07, 1.272e-07, 1.289e-07}, {1.674e-04, 6.833e-06, 1.315e-05}},
+         {{1.000e-08, 1.845e-07, 1.301e-07}, {3.147e-04, 5.711e-06, 1.013e-05}},
+         {{1.000e-08, 3.817e-07, 3.526e-07}, {4.921e-04, 3.975e-06, 5.410e-06}},
+         {{3.041e-06, 8.249e-07, 7.452e-07}, {8.473e-04, 3.471e-06, 4.177e-06}},
+     }}},
     // ISO 400
-    {
-        {{3.958e-06, 1.725e-06, 1.034e-06, 1.796e-06}, {4.618e-04, 2.518e-04, 2.760e-04, 2.514e-04}},
-        {{
-            {{2.204e-06, 1.560e-07, 3.370e-07}, {1.748e-04, 1.123e-05, 2.002e-05}},
-            {{1.854e-06, 1.854e-07, 2.580e-07}, {1.356e-04, 8.494e-06, 1.635e-05}},
-            {{1.000e-08, 1.991e-07, 1.736e-07}, {2.961e-04, 6.421e-06, 1.128e-05}},
-            {{1.000e-08, 3.837e-07, 3.489e-07}, {4.757e-04, 4.078e-06, 5.632e-06}},
-            {{3.239e-06, 8.168e-07, 7.303e-07}, {8.478e-04, 3.457e-06, 4.195e-06}},
-        }}
-    },
+    {{{3.958e-06, 1.725e-06, 1.034e-06, 1.796e-06}, {4.618e-04, 2.518e-04, 2.760e-04, 2.514e-04}},
+     {{
+         {{2.204e-06, 1.560e-07, 3.370e-07}, {1.748e-04, 1.123e-05, 2.002e-05}},
+         {{1.854e-06, 1.854e-07, 2.580e-07}, {1.356e-04, 8.494e-06, 1.635e-05}},
+         {{1.000e-08, 1.991e-07, 1.736e-07}, {2.961e-04, 6.421e-06, 1.128e-05}},
+         {{1.000e-08, 3.837e-07, 3.489e-07}, {4.757e-04, 4.078e-06, 5.632e-06}},
+         {{3.239e-06, 8.168e-07, 7.303e-07}, {8.478e-04, 3.457e-06, 4.195e-06}},
+     }}},
     // ISO 800
-    {
-        {{2.363e-06, 1.214e-06, 4.945e-07, 1.225e-06}, {7.903e-04, 3.970e-04, 4.453e-04, 3.973e-04}},
-        {{
-            {{1.558e-06, 1.511e-07, 3.277e-07}, {2.689e-04, 1.924e-05, 3.380e-05}},
-            {{2.717e-06, 1.867e-07, 2.462e-07}, {1.225e-04, 1.315e-05, 2.493e-05}},
-            {{1.368e-06, 2.265e-07, 2.077e-07}, {2.392e-04, 7.270e-06, 1.317e-05}},
-            {{1.000e-08, 3.802e-07, 3.550e-07}, {4.512e-04, 4.344e-06, 6.233e-06}},
-            {{4.148e-06, 7.913e-07, 7.030e-07}, {8.511e-04, 3.671e-06, 4.395e-06}},
-        }}
-    },
+    {{{2.363e-06, 1.214e-06, 4.945e-07, 1.225e-06}, {7.903e-04, 3.970e-04, 4.453e-04, 3.973e-04}},
+     {{
+         {{1.558e-06, 1.511e-07, 3.277e-07}, {2.689e-04, 1.924e-05, 3.380e-05}},
+         {{2.717e-06, 1.867e-07, 2.462e-07}, {1.225e-04, 1.315e-05, 2.493e-05}},
+         {{1.368e-06, 2.265e-07, 2.077e-07}, {2.392e-04, 7.270e-06, 1.317e-05}},
+         {{1.000e-08, 3.802e-07, 3.550e-07}, {4.512e-04, 4.344e-06, 6.233e-06}},
+         {{4.148e-06, 7.913e-07, 7.030e-07}, {8.511e-04, 3.671e-06, 4.395e-06}},
+     }}},
     // ISO 1600
-    {
-        {{9.809e-06, 2.366e-06, 2.335e-06, 2.392e-06}, {1.393e-03, 6.724e-04, 7.647e-04, 6.734e-04}},
-        {{
-            {{1.233e-06, 2.787e-07, 5.380e-07}, {4.597e-04, 3.461e-05, 6.461e-05}},
-            {{2.931e-06, 2.541e-07, 4.522e-07}, {1.410e-04, 2.271e-05, 4.236e-05}},
-            {{1.524e-06, 2.574e-07, 2.653e-07}, {2.417e-04, 1.049e-05, 1.967e-05}},
-            {{1.000e-08, 3.805e-07, 3.722e-07}, {4.583e-04, 5.347e-06, 7.898e-06}},
-            {{3.902e-06, 7.645e-07, 6.842e-07}, {8.740e-04, 4.197e-06, 4.936e-06}},
-        }}
-    },
+    {{{9.809e-06, 2.366e-06, 2.335e-06, 2.392e-06}, {1.393e-03, 6.724e-04, 7.647e-04, 6.734e-04}},
+     {{
+         {{1.233e-06, 2.787e-07, 5.380e-07}, {4.597e-04, 3.461e-05, 6.461e-05}},
+         {{2.931e-06, 2.541e-07, 4.522e-07}, {1.410e-04, 2.271e-05, 4.236e-05}},
+         {{1.524e-06, 2.574e-07, 2.653e-07}, {2.417e-04, 1.049e-05, 1.967e-05}},
+         {{1.000e-08, 3.805e-07, 3.722e-07}, {4.583e-04, 5.347e-06, 7.898e-06}},
+         {{3.902e-06, 7.645e-07, 6.842e-07}, {8.740e-04, 4.197e-06, 4.936e-06}},
+     }}},
     // ISO 3200
-    {
-        {{3.768e-05, 5.565e-06, 8.192e-06, 5.303e-06}, {2.369e-03, 1.296e-03, 1.449e-03, 1.300e-03}},
-        {{
-            {{2.221e-06, 5.268e-07, 1.259e-06}, {5.725e-04, 4.954e-05, 9.645e-05}},
-            {{2.481e-06, 4.588e-07, 1.015e-06}, {1.830e-04, 3.584e-05, 6.827e-05}},
-            {{5.040e-07, 3.114e-07, 4.412e-07}, {2.801e-04, 1.765e-05, 3.258e-05}},
-            {{1.000e-08, 3.950e-07, 4.219e-07}, {4.762e-04, 7.721e-06, 1.174e-05}},
-            {{3.730e-06, 7.698e-07, 7.015e-07}, {8.663e-04, 4.620e-06, 5.787e-06}},
-        }}
-    },
+    {{{3.768e-05, 5.565e-06, 8.192e-06, 5.303e-06}, {2.369e-03, 1.296e-03, 1.449e-03, 1.300e-03}},
+     {{
+         {{2.221e-06, 5.268e-07, 1.259e-06}, {5.725e-04, 4.954e-05, 9.645e-05}},
+         {{2.481e-06, 4.588e-07, 1.015e-06}, {1.830e-04, 3.584e-05, 6.827e-05}},
+         {{5.040e-07, 3.114e-07, 4.412e-07}, {2.801e-04, 1.765e-05, 3.258e-05}},
+         {{1.000e-08, 3.950e-07, 4.219e-07}, {4.762e-04, 7.721e-06, 1.174e-05}},
+         {{3.730e-06, 7.698e-07, 7.015e-07}, {8.663e-04, 4.620e-06, 5.787e-06}},
+     }}},
     // ISO 6400
-    {
-        {{1.039e-04, 2.017e-05, 2.782e-05, 1.939e-05}, {4.812e-03, 2.575e-03, 2.917e-03, 2.570e-03}},
-        {{
-            {{1.006e-05, 1.720e-06, 4.254e-06}, {1.023e-03, 9.434e-05, 1.818e-04}},
-            {{1.724e-06, 1.188e-06, 2.901e-06}, {3.120e-04, 6.891e-05, 1.319e-04}},
-            {{1.000e-08, 5.880e-07, 1.150e-06}, {3.495e-04, 3.142e-05, 5.841e-05}},
-            {{1.000e-08, 4.616e-07, 6.068e-07}, {5.282e-04, 1.238e-05, 1.995e-05}},
-            {{2.550e-06, 7.758e-07, 7.540e-07}, {8.911e-04, 6.384e-06, 8.372e-06}},
-        }}
-    },
+    {{{1.039e-04, 2.017e-05, 2.782e-05, 1.939e-05}, {4.812e-03, 2.575e-03, 2.917e-03, 2.570e-03}},
+     {{
+         {{1.006e-05, 1.720e-06, 4.254e-06}, {1.023e-03, 9.434e-05, 1.818e-04}},
+         {{1.724e-06, 1.188e-06, 2.901e-06}, {3.120e-04, 6.891e-05, 1.319e-04}},
+         {{1.000e-08, 5.880e-07, 1.150e-06}, {3.495e-04, 3.142e-05, 5.841e-05}},
+         {{1.000e-08, 4.616e-07, 6.068e-07}, {5.282e-04, 1.238e-05, 1.995e-05}},
+         {{2.550e-06, 7.758e-07, 7.540e-07}, {8.911e-04, 6.384e-06, 8.372e-06}},
+     }}},
     // ISO 12500
-    {
-        {{2.195e-04, 5.161e-05, 7.401e-05, 5.177e-05}, {1.078e-02, 5.789e-03, 6.282e-03, 5.753e-03}},
-        {{
-            {{4.046e-05, 4.901e-06, 1.062e-05}, {1.699e-03, 1.817e-04, 3.807e-04}},
-            {{6.159e-06, 3.386e-06, 7.547e-06}, {4.451e-04, 1.341e-04, 2.709e-04}},
-            {{2.922e-06, 1.481e-06, 3.111e-06}, {2.998e-04, 5.573e-05, 1.086e-04}},
-            {{1.000e-08, 7.120e-07, 1.114e-06}, {4.866e-04, 1.934e-05, 3.600e-05}},
-            {{3.204e-06, 8.192e-07, 8.907e-07}, {9.186e-04, 8.184e-06, 1.244e-05}},
-        }}
-    },
+    {{{2.195e-04, 5.161e-05, 7.401e-05, 5.177e-05}, {1.078e-02, 5.789e-03, 6.282e-03, 5.753e-03}},
+     {{
+         {{4.046e-05, 4.901e-06, 1.062e-05}, {1.699e-03, 1.817e-04, 3.807e-04}},
+         {{6.159e-06, 3.386e-06, 7.547e-06}, {4.451e-04, 1.341e-04, 2.709e-04}},
+         {{2.922e-06, 1.481e-06, 3.111e-06}, {2.998e-04, 5.573e-05, 1.086e-04}},
+         {{1.000e-08, 7.120e-07, 1.114e-06}, {4.866e-04, 1.934e-05, 3.600e-05}},
+         {{3.204e-06, 8.192e-07, 8.907e-07}, {9.186e-04, 8.184e-06, 1.244e-05}},
+     }}},
     // ISO 25000
-    {
-        {{3.535e-04, 1.000e-08, 1.848e-05, 1.000e-08}, {1.635e-02, 1.747e-02, 1.901e-02, 1.724e-02}},
-        {{
-            {{1.245e-04, 1.038e-05, 2.442e-05}, {2.697e-03, 3.841e-04, 9.292e-04}},
-            {{1.365e-05, 7.146e-06, 1.869e-05}, {8.140e-04, 2.908e-04, 6.195e-04}},
-            {{3.276e-06, 3.055e-06, 7.791e-06}, {4.234e-04, 1.187e-04, 2.411e-04}},
-            {{1.000e-08, 1.155e-06, 2.576e-06}, {5.546e-04, 3.762e-05, 7.448e-05}},
-            {{1.000e-08, 8.494e-07, 1.311e-06}, {1.089e-03, 1.374e-05, 2.215e-05}},
-        }}
-    },
+    {{{3.535e-04, 1.000e-08, 1.848e-05, 1.000e-08}, {1.635e-02, 1.747e-02, 1.901e-02, 1.724e-02}},
+     {{
+         {{1.245e-04, 1.038e-05, 2.442e-05}, {2.697e-03, 3.841e-04, 9.292e-04}},
+         {{1.365e-05, 7.146e-06, 1.869e-05}, {8.140e-04, 2.908e-04, 6.195e-04}},
+         {{3.276e-06, 3.055e-06, 7.791e-06}, {4.234e-04, 1.187e-04, 2.411e-04}},
+         {{1.000e-08, 1.155e-06, 2.576e-06}, {5.546e-04, 3.762e-05, 7.448e-05}},
+         {{1.000e-08, 8.494e-07, 1.311e-06}, {1.089e-03, 1.374e-05, 2.215e-05}},
+     }}},
     // ISO 50000
-    {
-        {{3.935e-04, 8.987e-05, 1.992e-04, 9.729e-05}, {2.093e-02, 2.559e-02, 2.317e-02, 2.536e-02}},
-        {{
-            {{2.639e-04, 2.425e-05, 5.775e-05}, {5.571e-03, 9.186e-04, 2.664e-03}},
-            {{2.772e-05, 1.394e-05, 4.626e-05}, {1.708e-03, 6.921e-04, 1.482e-03}},
-            {{3.829e-06, 5.552e-06, 1.622e-05}, {7.120e-04, 2.864e-04, 6.102e-04}},
-            {{1.000e-08, 1.865e-06, 5.662e-06}, {6.533e-04, 8.928e-05, 1.719e-04}},
-            {{1.000e-08, 9.447e-07, 2.523e-06}, {1.270e-03, 2.686e-05, 4.426e-05}},
-        }}
-    },
+    {{{3.935e-04, 8.987e-05, 1.992e-04, 9.729e-05}, {2.093e-02, 2.559e-02, 2.317e-02, 2.536e-02}},
+     {{
+         {{2.639e-04, 2.425e-05, 5.775e-05}, {5.571e-03, 9.186e-04, 2.664e-03}},
+         {{2.772e-05, 1.394e-05, 4.626e-05}, {1.708e-03, 6.921e-04, 1.482e-03}},
+         {{3.829e-06, 5.552e-06, 1.622e-05}, {7.120e-04, 2.864e-04, 6.102e-04}},
+         {{1.000e-08, 1.865e-06, 5.662e-06}, {6.533e-04, 8.928e-05, 1.719e-04}},
+         {{1.000e-08, 9.447e-07, 2.523e-06}, {1.270e-03, 2.686e-05, 4.426e-05}},
+     }}},
 }};

--- a/src/OpenCL/demosaic.cl
+++ b/src/OpenCL/demosaic.cl
@@ -1803,9 +1803,9 @@ float4 variance(STATS* stats) { return stats->M2 / (stats->n - 1.0); }
 
 float4 standardDeviation(STATS* stats) { return sqrt(variance(stats)); }
 
-float4 skewness(STATS* stats) { return sqrt(float(stats->n)) * stats->M3 / pow(stats->M2, 1.5); }
+float4 skewness(STATS* stats) { return sqrt((float)(stats->n)) * stats->M3 / pow(stats->M2, 1.5); }
 
-float4 kurtosis(STATS* stats) { return float(stats->n) * stats->M4 / (stats->M2 * stats->M2) - 3.0; }
+float4 kurtosis(STATS* stats) { return (float)(stats->n) * stats->M4 / (stats->M2 * stats->M2) - 3.0; }
 
 kernel void rawNoiseStatistics(read_only image2d_t rawImage, int bayerPattern,
                                read_only image2d_t sobelImage,

--- a/src/RicohGRIIICalibration.cpp
+++ b/src/RicohGRIIICalibration.cpp
@@ -13,20 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CameraCalibration.hpp"
-
-#include "demosaic.hpp"
-#include "raw_converter.hpp"
-
 #include <array>
 #include <cmath>
 #include <filesystem>
+
+#include "CameraCalibration.hpp"
+#include "demosaic.hpp"
+#include "raw_converter.hpp"
 
 template <size_t levels = 5>
 class RicohGRIIICalibration : public CameraCalibration<levels> {
     static const std::array<NoiseModel<levels>, 7> NLFData;
 
-public:
+   public:
     NoiseModel<levels> nlfFromIso(int iso) const override {
         iso = std::clamp(iso, 100, 6400);
         if (iso >= 100 && iso < 200) {
@@ -50,79 +49,66 @@ public:
         }
     }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override {
-        const float nlf_alpha = std::clamp((log2(iso) - log2(100)) / (log2(6400) - log2(100)), 0.0, 1.0);
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const override {
+        const float nlf_alpha =
+            std::clamp((log2(iso) - log2(100)) / (log2(6400) - log2(100)), 0.0, 1.0);
 
-        std::cout << "RicohGRIIIDenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        std::cout << "RicohGRIIIDenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+                  << std::endl;
 
         float lerp = std::lerp(0.125f, 1.2f, nlf_alpha);
         float lerp_c = std::lerp(0.5f, 1.2f, nlf_alpha);
 
         // Default Good
-        float lmult[5] = { 0.125, 1, 0.5, 0.25, 0.125 };
-        float cmult[5] = { 1, 1, 0.5, 0.25, 0.125 };
+        float lmult[5] = {0.125, 1, 0.5, 0.25, 0.125};
+        float cmult[5] = {1, 1, 0.5, 0.25, 0.125};
 
         float chromaBoost = 8;
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{
-            {
-                .luma = lmult[0] * lerp,
-                .chroma = cmult[0] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = std::lerp(1.3f, 1.0f, nlf_alpha)
-            },
-            {
-                .luma = lmult[1] * lerp,
-                .chroma = cmult[1] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1, // 1.1
-            },
-            {
-                .luma = lmult[2] * lerp,
-                .chroma = cmult[2] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[3] * lerp,
-                .chroma = cmult[3] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[4] * lerp,
-                .chroma = cmult[4] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .sharpening = 1
-            }
-        }};
+        std::array<DenoiseParameters, 5> denoiseParameters = {
+            {{.luma = lmult[0] * lerp,
+              .chroma = cmult[0] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = std::lerp(1.3f, 1.0f, nlf_alpha)},
+             {
+                 .luma = lmult[1] * lerp,
+                 .chroma = cmult[1] * lerp_c,
+                 .chromaBoost = chromaBoost,
+                 .sharpening = 1,  // 1.1
+             },
+             {.luma = lmult[2] * lerp,
+              .chroma = cmult[2] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1},
+             {.luma = lmult[3] * lerp,
+              .chroma = cmult[3] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1},
+             {.luma = lmult[4] * lerp,
+              .chroma = cmult[4] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .sharpening = 1}}};
 
-        return { nlf_alpha, denoiseParameters };
+        return {nlf_alpha, denoiseParameters};
     }
 
     DemosaicParameters buildDemosaicParameters() const override {
-        return {
-            .rgbConversionParameters = {
-                .localToneMapping = false
-            },
-            .ltmParameters = {
-                .eps = 0.01,
-                .shadows = 0.6,
-                .highlights = 1.2,
-                .detail = { 1, 1.05, 1.5 }
-            }
-        };
+        return {.rgbConversionParameters = {.localToneMapping = false},
+                .ltmParameters = {
+                    .eps = 0.01, .shadows = 0.6, .highlights = 1.2, .detail = {1, 1.05, 1.5}}};
     }
 
-    void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const override {
+    void calibrate(RawConverter* rawConverter,
+                   const std::filesystem::path& input_dir) const override {
         std::array<CalibrationEntry, 7> calibration_files = {{
-            { 100,  "R0000914_ISO100.DNG",  { 2437, 506, 1123, 733 }, false },
-            { 200,  "R0000917_ISO200.DNG",  { 2437, 506, 1123, 733 }, false },
-            { 400,  "R0000920_ISO400.DNG",  { 2437, 506, 1123, 733 }, false },
-            { 800,  "R0000923_ISO800.DNG",  { 2437, 506, 1123, 733 }, false },
-            { 1600, "R0000926_ISO1600.DNG", { 2437, 506, 1123, 733 }, false },
-            { 3200, "R0000929_ISO3200.DNG", { 2437, 506, 1123, 733 }, false },
-            { 6400, "R0000932_ISO6400.DNG", { 2437, 506, 1123, 733 }, false },
+            {100, "R0000914_ISO100.DNG", {2437, 506, 1123, 733}, false},
+            {200, "R0000917_ISO200.DNG", {2437, 506, 1123, 733}, false},
+            {400, "R0000920_ISO400.DNG", {2437, 506, 1123, 733}, false},
+            {800, "R0000923_ISO800.DNG", {2437, 506, 1123, 733}, false},
+            {1600, "R0000926_ISO1600.DNG", {2437, 506, 1123, 733}, false},
+            {3200, "R0000929_ISO3200.DNG", {2437, 506, 1123, 733}, false},
+            {6400, "R0000932_ISO6400.DNG", {2437, 506, 1123, 733}, false},
         }};
 
         std::array<NoiseModel<5>, 7> noiseModel;
@@ -132,13 +118,13 @@ public:
             const auto input_path = input_dir / entry.fileName;
 
             DemosaicParameters demosaicParameters = {
-                .rgbConversionParameters = {
-                    .localToneMapping = false
-                }
-            };
+                .rgbConversionParameters = {.localToneMapping = false}};
 
-            const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/ true);
+            const auto rgb_image = CameraCalibration<5>::calibrate(
+                rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
+            rgb_image->write_png_file(
+                (input_path.parent_path() / input_path.stem()).string() + "_cal.png",
+                /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -153,95 +139,85 @@ void calibrateRicohGRIII(RawConverter* rawConverter, const std::filesystem::path
     calibration.calibrate(rawConverter, input_dir);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicRicohGRIIIDNG(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaicRicohGRIIIDNG(
+    RawConverter* rawConverter, const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
     RicohGRIIICalibration calibration;
-    auto demosaicParameters = calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
+    auto demosaicParameters =
+        calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
 
-    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters.get(), /*calibrateFromImage=*/ true));
+    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(
+        *inputImage, demosaicParameters.get(), /*calibrateFromImage=*/true));
 }
 
 // --- NLFData ---
 
-template<>
+template <>
 const std::array<NoiseModel<5>, 7> RicohGRIIICalibration<5>::NLFData = {{
     // ISO 100
-    {
-        {{1.038e-06, 1.520e-06, 6.685e-07, 1.474e-06}, {2.471e-04, 1.567e-04, 1.622e-04, 1.570e-04}},
-        {{
-            {{4.090e-07, 4.088e-08, 4.067e-08}, {1.728e-04, 6.495e-06, 9.137e-06}},
-            {{1.000e-08, 6.513e-08, 5.563e-08}, {2.604e-04, 6.792e-06, 8.006e-06}},
-            {{1.000e-08, 1.816e-07, 1.449e-07}, {4.299e-04, 5.170e-06, 4.954e-06}},
-            {{1.000e-08, 3.603e-07, 3.471e-07}, {7.393e-04, 3.703e-06, 2.719e-06}},
-            {{6.411e-06, 7.370e-07, 6.175e-07}, {1.514e-03, 5.357e-06, 3.448e-06}},
-        }}
-    },
+    {{{1.038e-06, 1.520e-06, 6.685e-07, 1.474e-06}, {2.471e-04, 1.567e-04, 1.622e-04, 1.570e-04}},
+     {{
+         {{4.090e-07, 4.088e-08, 4.067e-08}, {1.728e-04, 6.495e-06, 9.137e-06}},
+         {{1.000e-08, 6.513e-08, 5.563e-08}, {2.604e-04, 6.792e-06, 8.006e-06}},
+         {{1.000e-08, 1.816e-07, 1.449e-07}, {4.299e-04, 5.170e-06, 4.954e-06}},
+         {{1.000e-08, 3.603e-07, 3.471e-07}, {7.393e-04, 3.703e-06, 2.719e-06}},
+         {{6.411e-06, 7.370e-07, 6.175e-07}, {1.514e-03, 5.357e-06, 3.448e-06}},
+     }}},
     // ISO 200
-    {
-        {{6.774e-07, 1.522e-06, 6.695e-07, 1.492e-06}, {3.559e-04, 1.890e-04, 2.060e-04, 1.888e-04}},
-        {{
-            {{4.913e-07, 4.885e-08, 4.957e-08}, {1.924e-04, 8.555e-06, 1.394e-05}},
-            {{1.000e-08, 6.647e-08, 5.844e-08}, {2.627e-04, 8.052e-06, 1.101e-05}},
-            {{1.000e-08, 1.762e-07, 1.402e-07}, {4.286e-04, 5.636e-06, 6.113e-06}},
-            {{1.000e-08, 3.603e-07, 3.406e-07}, {7.375e-04, 3.784e-06, 3.127e-06}},
-            {{6.107e-06, 7.397e-07, 6.167e-07}, {1.523e-03, 5.281e-06, 3.601e-06}},
-        }}
-    },
+    {{{6.774e-07, 1.522e-06, 6.695e-07, 1.492e-06}, {3.559e-04, 1.890e-04, 2.060e-04, 1.888e-04}},
+     {{
+         {{4.913e-07, 4.885e-08, 4.957e-08}, {1.924e-04, 8.555e-06, 1.394e-05}},
+         {{1.000e-08, 6.647e-08, 5.844e-08}, {2.627e-04, 8.052e-06, 1.101e-05}},
+         {{1.000e-08, 1.762e-07, 1.402e-07}, {4.286e-04, 5.636e-06, 6.113e-06}},
+         {{1.000e-08, 3.603e-07, 3.406e-07}, {7.375e-04, 3.784e-06, 3.127e-06}},
+         {{6.107e-06, 7.397e-07, 6.167e-07}, {1.523e-03, 5.281e-06, 3.601e-06}},
+     }}},
     // ISO 400
-    {
-        {{1.000e-08, 1.539e-06, 2.484e-07, 1.444e-06}, {4.044e-04, 2.274e-04, 2.334e-04, 2.286e-04}},
-        {{
-            {{1.121e-07, 3.441e-08, 1.000e-08}, {2.233e-04, 9.187e-06, 1.554e-05}},
-            {{1.000e-08, 4.889e-08, 1.000e-08}, {2.720e-04, 9.163e-06, 1.352e-05}},
-            {{1.000e-08, 1.637e-07, 1.198e-07}, {4.488e-04, 6.700e-06, 8.075e-06}},
-            {{1.000e-08, 3.551e-07, 3.377e-07}, {7.385e-04, 4.292e-06, 3.883e-06}},
-            {{6.059e-06, 7.512e-07, 6.308e-07}, {1.476e-03, 5.381e-06, 3.771e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.539e-06, 2.484e-07, 1.444e-06}, {4.044e-04, 2.274e-04, 2.334e-04, 2.286e-04}},
+     {{
+         {{1.121e-07, 3.441e-08, 1.000e-08}, {2.233e-04, 9.187e-06, 1.554e-05}},
+         {{1.000e-08, 4.889e-08, 1.000e-08}, {2.720e-04, 9.163e-06, 1.352e-05}},
+         {{1.000e-08, 1.637e-07, 1.198e-07}, {4.488e-04, 6.700e-06, 8.075e-06}},
+         {{1.000e-08, 3.551e-07, 3.377e-07}, {7.385e-04, 4.292e-06, 3.883e-06}},
+         {{6.059e-06, 7.512e-07, 6.308e-07}, {1.476e-03, 5.381e-06, 3.771e-06}},
+     }}},
     // ISO 800
-    {
-        {{1.000e-08, 1.589e-06, 1.000e-08, 1.515e-06}, {4.766e-04, 3.106e-04, 2.908e-04, 3.119e-04}},
-        {{
-            {{1.000e-08, 4.296e-08, 1.000e-08}, {2.753e-04, 9.690e-06, 1.680e-05}},
-            {{1.000e-08, 3.193e-08, 1.000e-08}, {2.844e-04, 1.082e-05, 1.707e-05}},
-            {{1.000e-08, 1.483e-07, 1.071e-07}, {4.690e-04, 8.413e-06, 1.145e-05}},
-            {{1.000e-08, 3.524e-07, 3.401e-07}, {7.264e-04, 4.891e-06, 5.204e-06}},
-            {{5.845e-06, 7.774e-07, 6.506e-07}, {1.418e-03, 5.329e-06, 4.005e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.589e-06, 1.000e-08, 1.515e-06}, {4.766e-04, 3.106e-04, 2.908e-04, 3.119e-04}},
+     {{
+         {{1.000e-08, 4.296e-08, 1.000e-08}, {2.753e-04, 9.690e-06, 1.680e-05}},
+         {{1.000e-08, 3.193e-08, 1.000e-08}, {2.844e-04, 1.082e-05, 1.707e-05}},
+         {{1.000e-08, 1.483e-07, 1.071e-07}, {4.690e-04, 8.413e-06, 1.145e-05}},
+         {{1.000e-08, 3.524e-07, 3.401e-07}, {7.264e-04, 4.891e-06, 5.204e-06}},
+         {{5.845e-06, 7.774e-07, 6.506e-07}, {1.418e-03, 5.329e-06, 4.005e-06}},
+     }}},
     // ISO 1600
-    {
-        {{1.000e-08, 1.583e-06, 1.000e-08, 1.425e-06}, {7.822e-04, 5.526e-04, 5.005e-04, 5.573e-04}},
-        {{
-            {{1.000e-08, 5.347e-08, 1.000e-08}, {4.387e-04, 1.369e-05, 2.504e-05}},
-            {{1.000e-08, 1.000e-08, 1.000e-08}, {3.128e-04, 1.317e-05, 2.094e-05}},
-            {{1.000e-08, 1.093e-07, 3.429e-08}, {4.485e-04, 9.681e-06, 1.376e-05}},
-            {{1.000e-08, 3.749e-07, 3.469e-07}, {6.509e-04, 5.415e-06, 7.139e-06}},
-            {{4.570e-06, 8.712e-07, 7.275e-07}, {1.266e-03, 5.309e-06, 4.898e-06}},
-        }}
-    },
+    {{{1.000e-08, 1.583e-06, 1.000e-08, 1.425e-06}, {7.822e-04, 5.526e-04, 5.005e-04, 5.573e-04}},
+     {{
+         {{1.000e-08, 5.347e-08, 1.000e-08}, {4.387e-04, 1.369e-05, 2.504e-05}},
+         {{1.000e-08, 1.000e-08, 1.000e-08}, {3.128e-04, 1.317e-05, 2.094e-05}},
+         {{1.000e-08, 1.093e-07, 3.429e-08}, {4.485e-04, 9.681e-06, 1.376e-05}},
+         {{1.000e-08, 3.749e-07, 3.469e-07}, {6.509e-04, 5.415e-06, 7.139e-06}},
+         {{4.570e-06, 8.712e-07, 7.275e-07}, {1.266e-03, 5.309e-06, 4.898e-06}},
+     }}},
     // ISO 3200
-    {
-        {{1.000e-08, 2.810e-06, 1.000e-08, 2.834e-06}, {1.255e-03, 9.297e-04, 8.122e-04, 9.316e-04}},
-        {{
-            {{9.165e-08, 1.062e-07, 1.000e-08}, {6.671e-04, 2.087e-05, 4.058e-05}},
-            {{1.000e-08, 1.000e-08, 1.000e-08}, {3.338e-04, 1.786e-05, 3.181e-05}},
-            {{1.000e-08, 1.059e-07, 3.176e-08}, {4.731e-04, 1.311e-05, 2.093e-05}},
-            {{1.000e-08, 3.411e-07, 3.604e-07}, {7.081e-04, 7.767e-06, 1.087e-05}},
-            {{5.374e-06, 7.988e-07, 6.865e-07}, {1.392e-03, 5.982e-06, 6.196e-06}},
-        }}
-    },
+    {{{1.000e-08, 2.810e-06, 1.000e-08, 2.834e-06}, {1.255e-03, 9.297e-04, 8.122e-04, 9.316e-04}},
+     {{
+         {{9.165e-08, 1.062e-07, 1.000e-08}, {6.671e-04, 2.087e-05, 4.058e-05}},
+         {{1.000e-08, 1.000e-08, 1.000e-08}, {3.338e-04, 1.786e-05, 3.181e-05}},
+         {{1.000e-08, 1.059e-07, 3.176e-08}, {4.731e-04, 1.311e-05, 2.093e-05}},
+         {{1.000e-08, 3.411e-07, 3.604e-07}, {7.081e-04, 7.767e-06, 1.087e-05}},
+         {{5.374e-06, 7.988e-07, 6.865e-07}, {1.392e-03, 5.982e-06, 6.196e-06}},
+     }}},
     // ISO 6400
-    {
-        {{1.000e-08, 5.618e-06, 4.201e-06, 5.653e-06}, {2.028e-03, 2.034e-03, 1.683e-03, 2.040e-03}},
-        {{
-            {{2.432e-06, 8.597e-08, 1.000e-08}, {9.223e-04, 3.517e-05, 6.895e-05}},
-            {{1.000e-08, 1.863e-08, 1.000e-08}, {4.041e-04, 2.811e-05, 5.327e-05}},
-            {{1.000e-08, 8.511e-08, 1.000e-08}, {4.799e-04, 1.958e-05, 3.412e-05}},
-            {{1.000e-08, 4.279e-07, 5.243e-07}, {7.042e-04, 1.071e-05, 1.869e-05}},
-            {{3.600e-06, 9.221e-07, 8.745e-07}, {1.288e-03, 7.740e-06, 9.474e-06}},
-        }}
-    },
+    {{{1.000e-08, 5.618e-06, 4.201e-06, 5.653e-06}, {2.028e-03, 2.034e-03, 1.683e-03, 2.040e-03}},
+     {{
+         {{2.432e-06, 8.597e-08, 1.000e-08}, {9.223e-04, 3.517e-05, 6.895e-05}},
+         {{1.000e-08, 1.863e-08, 1.000e-08}, {4.041e-04, 2.811e-05, 5.327e-05}},
+         {{1.000e-08, 8.511e-08, 1.000e-08}, {4.799e-04, 1.958e-05, 3.412e-05}},
+         {{1.000e-08, 4.279e-07, 5.243e-07}, {7.042e-04, 1.071e-05, 1.869e-05}},
+         {{3.600e-06, 9.221e-07, 8.745e-07}, {1.288e-03, 7.740e-06, 9.474e-06}},
+     }}},
 }};

--- a/src/SURF.cpp
+++ b/src/SURF.cpp
@@ -21,1798 +21,1629 @@
 #include <iostream>
 #include <mutex>
 
-#include "gls_cl_image.hpp"
-
-#include "feature2d.hpp"
-
 #include "ThreadPool.hpp"
+#include "feature2d.hpp"
+#include "gls_cl_image.hpp"
 
 #define USE_OPENCL true
 #define USE_OPENCL_INTEGRAL false
 #define USE_INTEGRAL_PYRAMID true
 
-namespace gls
-{
+namespace gls {
 
-    static const int SURF_ORI_SEARCH_INC = 5;
-    static const float SURF_ORI_SIGMA = 2.5f;
-    static const float SURF_DESC_SIGMA = 3.3f;
+static const int SURF_ORI_SEARCH_INC = 5;
+static const float SURF_ORI_SIGMA = 2.5f;
+static const float SURF_DESC_SIGMA = 3.3f;
 
-    // Wavelet size at first layer of first octave.
-    static const int SURF_HAAR_SIZE0 = 9;
+// Wavelet size at first layer of first octave.
+static const int SURF_HAAR_SIZE0 = 9;
 
-    // Wavelet size increment between layers. This should be an even number,
-    // such that the wavelet sizes in an octave are either all even or all odd.
-    // This ensures that when looking for the neighbours of a sample, the layers
-    // above and below are aligned correctly.
-    static const int SURF_HAAR_SIZE_INC = 6;
+// Wavelet size increment between layers. This should be an even number,
+// such that the wavelet sizes in an octave are either all even or all odd.
+// This ensures that when looking for the neighbours of a sample, the layers
+// above and below are aligned correctly.
+static const int SURF_HAAR_SIZE_INC = 6;
 
-    template <typename T>
-    void integral(const gls::image<float> &img, gls::image<T> *sum)
-    {
-        // Zero the first row and the first column of the sum
-        for (int i = 0; i < sum->width; i++)
-        {
-            (*sum)[0][i] = 0;
-        }
-        for (int j = 1; j < sum->height; j++)
-        {
-            (*sum)[j][0] = 0;
-        }
-
-        for (int j = 1; j < sum->height; j++)
-        {
-            for (int i = 1; i < sum->width; i++)
-            {
-                // Use Signed Offset Pixel Representation to improve Integral Image precision
-                // See: Hensley et al.: "Fast Summed-Area Table Generation and its Applications".
-                (*sum)[j][i] = (img[j - 1][i - 1] - 0.5) +
-                               (*sum)[j][i - 1] + (*sum)[j - 1][i] - (*sum)[j - 1][i - 1];
-            }
-        }
+template <typename T>
+void integral(const gls::image<float>& img, gls::image<T>* sum) {
+    // Zero the first row and the first column of the sum
+    for (int i = 0; i < sum->width; i++) {
+        (*sum)[0][i] = 0;
+    }
+    for (int j = 1; j < sum->height; j++) {
+        (*sum)[j][0] = 0;
     }
 
-    struct SurfHF
-    {
-        std::array<gls::point, 4> p;
-        float w;
+    for (int j = 1; j < sum->height; j++) {
+        for (int i = 1; i < sum->width; i++) {
+            // Use Signed Offset Pixel Representation to improve Integral Image precision
+            // See: Hensley et al.: "Fast Summed-Area Table Generation and its Applications".
+            (*sum)[j][i] = (img[j - 1][i - 1] - 0.5) + (*sum)[j][i - 1] + (*sum)[j - 1][i] -
+                           (*sum)[j - 1][i - 1];
+        }
+    }
+}
 
-        SurfHF() : p({gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}}), w(0) {}
+struct SurfHF {
+    std::array<gls::point, 4> p;
+    float w;
+
+    SurfHF() : p({gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}}), w(0) {}
+};
+
+inline std::ostream& operator<<(std::ostream& os, const SurfHF& hf) {
+    os << "SurfHF - " << hf.p[0] << ", " << hf.p[1] << ", " << hf.p[2] << ", " << hf.p[3] << ", "
+       << std::endl;
+    return os;
+}
+
+float integralRectangle(float topRight, float topLeft, float bottomRight, float bottomLeft) {
+    // Use Signed Offset Pixel Representation to improve Integral Image precision, see Integral
+    // Image code below
+    return 0.5 + (topRight - topLeft) - (bottomRight - bottomLeft);
+}
+
+template <size_t N>
+static inline float calcHaarPattern(const gls::image<float>& sum, const gls::point& p,
+                                    const std::array<SurfHF, N>& f) {
+    float d = 0;
+    for (int k = 0; k < N; k++) {
+        const auto& fk = f[k];
+
+        float p0 = sum[p.y + fk.p[0].y][p.x + fk.p[0].x];
+        float p1 = sum[p.y + fk.p[1].y][p.x + fk.p[1].x];
+        float p2 = sum[p.y + fk.p[2].y][p.x + fk.p[2].x];
+        float p3 = sum[p.y + fk.p[3].y][p.x + fk.p[3].x];
+
+        d += fk.w * integralRectangle(p0, p1, p2, p3);
+    }
+    return d;
+}
+
+template <size_t N>
+static void resizeHaarPattern(const int src[N][5], std::array<SurfHF, N>* dst, int oldSize,
+                              int newSize) {
+    float ratio = (float)newSize / oldSize;
+    for (int k = 0; k < N; k++) {
+        int dx1 = (int)lrint(ratio * src[k][0]);
+        int dy1 = (int)lrint(ratio * src[k][1]);
+        int dx2 = (int)lrint(ratio * src[k][2]);
+        int dy2 = (int)lrint(ratio * src[k][3]);
+        (*dst)[k].p = {gls::point{dx1, dy1}, gls::point{dx1, dy2}, gls::point{dx2, dy1},
+                       gls::point{dx2, dy2}};
+        (*dst)[k].w = src[k][4] / ((float)(dx2 - dx1) * (dy2 - dy1));
+    }
+}
+
+static void calcDetAndTrace(const gls::image<float>& sum, gls::image<float>* det,
+                            gls::image<float>* trace, int x, int y, int sampleStep,
+                            const std::array<SurfHF, 3>& Dx, const std::array<SurfHF, 3>& Dy,
+                            const std::array<SurfHF, 4>& Dxy) {
+    const gls::point p = {x * sampleStep, y * sampleStep};
+
+    float dx = calcHaarPattern(sum, p, Dx);
+    float dy = calcHaarPattern(sum, p, Dy);
+    float dxy = calcHaarPattern(sum, p, Dxy);
+
+    (*det)[y][x] = dx * dy - 0.81f * dxy * dxy;
+    (*trace)[y][x] = dx + dy;
+}
+
+/*
+ * Maxima location interpolation as described in "Invariant Features from
+ * Interest Point Groups" by Matthew Brown and David Lowe. This is performed by
+ * fitting a 3D quadratic to a set of neighbouring samples.
+ *
+ * The gradient vector and Hessian matrix at the initial keypoint location are
+ * approximated using central differences. The linear system Ax = b is then
+ * solved, where A is the Hessian, b is the negative gradient, and x is the
+ * offset of the interpolated maxima coordinates from the initial estimate.
+ * This is equivalent to an iteration of Netwon's optimisation algorithm.
+ *
+ * N9 contains the samples in the 3x3x3 neighbourhood of the maxima
+ * dx is the sampling step in x
+ * dy is the sampling step in y
+ * ds is the sampling step in size
+ * point contains the keypoint coordinates and scale to be modified
+ *
+ * Return value is 1 if interpolation was successful, 0 on failure.
+ */
+
+inline float determinant(const gls::Matrix<3, 3>& A) {
+    return A[0][0] * (A[1][1] * A[2][2] - A[1][2] * A[2][1]) -
+           A[0][1] * (A[1][0] * A[2][2] - A[1][2] * A[2][0]) +
+           A[0][2] * (A[1][0] * A[2][1] - A[1][1] * A[2][0]);
+}
+
+inline bool solve3x3(const gls::Matrix<3, 3>& A, const gls::Vector<3>& b, gls::Vector<3>* x) {
+    float det = determinant(A);
+
+    if (det != 0) {
+        return gls::Vector<3>{determinant({b, A[1], A[2]}), determinant({A[0], b, A[2]}),
+                              determinant({A[0], A[1], b})} /
+               det;
+        return true;
+    }
+    printf("solve3x3: Singular Matrix!\n");
+    return false;
+}
+
+static bool interpolateKeypoint(const std::array<gls::image<float>, 3>& N9, int dx, int dy, int ds,
+                                KeyPoint* kpt) {
+    gls::Vector<3> B = {
+        -(N9[1][0][1] - N9[1][0][-1]) / 2,  // Negative 1st deriv with respect to x
+        -(N9[1][1][0] - N9[1][-1][0]) / 2,  // Negative 1st deriv with respect to y
+        -(N9[2][0][0] - N9[0][0][0]) / 2    // Negative 1st deriv with respect to s
     };
-
-    inline std::ostream &operator<<(std::ostream &os, const SurfHF &hf)
-    {
-        os << "SurfHF - " << hf.p[0] << ", " << hf.p[1] << ", " << hf.p[2] << ", " << hf.p[3] << ", " << std::endl;
-        return os;
-    }
-
-    float integralRectangle(float topRight, float topLeft, float bottomRight, float bottomLeft)
-    {
-        // Use Signed Offset Pixel Representation to improve Integral Image precision, see Integral Image code below
-        return 0.5 + (topRight - topLeft) - (bottomRight - bottomLeft);
-    }
-
-    template <size_t N>
-    static inline float calcHaarPattern(const gls::image<float> &sum, const gls::point &p, const std::array<SurfHF, N> &f)
-    {
-        float d = 0;
-        for (int k = 0; k < N; k++)
-        {
-            const auto &fk = f[k];
-
-            float p0 = sum[p.y + fk.p[0].y][p.x + fk.p[0].x];
-            float p1 = sum[p.y + fk.p[1].y][p.x + fk.p[1].x];
-            float p2 = sum[p.y + fk.p[2].y][p.x + fk.p[2].x];
-            float p3 = sum[p.y + fk.p[3].y][p.x + fk.p[3].x];
-
-            d += fk.w * integralRectangle(p0, p1, p2, p3);
-        }
-        return d;
-    }
-
-    template <size_t N>
-    static void resizeHaarPattern(const int src[N][5], std::array<SurfHF, N> *dst, int oldSize, int newSize)
-    {
-        float ratio = (float)newSize / oldSize;
-        for (int k = 0; k < N; k++)
-        {
-            int dx1 = (int)lrint(ratio * src[k][0]);
-            int dy1 = (int)lrint(ratio * src[k][1]);
-            int dx2 = (int)lrint(ratio * src[k][2]);
-            int dy2 = (int)lrint(ratio * src[k][3]);
-            (*dst)[k].p = {
-                gls::point{dx1, dy1},
-                gls::point{dx1, dy2},
-                gls::point{dx2, dy1},
-                gls::point{dx2, dy2}};
-            (*dst)[k].w = src[k][4] / ((float)(dx2 - dx1) * (dy2 - dy1));
-        }
-    }
-
-    static void calcDetAndTrace(const gls::image<float> &sum,
-                                gls::image<float> *det,
-                                gls::image<float> *trace,
-                                int x, int y, int sampleStep,
-                                const std::array<SurfHF, 3> &Dx,
-                                const std::array<SurfHF, 3> &Dy,
-                                const std::array<SurfHF, 4> &Dxy)
-    {
-        const gls::point p = {x * sampleStep, y * sampleStep};
-
-        float dx = calcHaarPattern(sum, p, Dx);
-        float dy = calcHaarPattern(sum, p, Dy);
-        float dxy = calcHaarPattern(sum, p, Dxy);
-
-        (*det)[y][x] = dx * dy - 0.81f * dxy * dxy;
-        (*trace)[y][x] = dx + dy;
-    }
-
-    /*
-     * Maxima location interpolation as described in "Invariant Features from
-     * Interest Point Groups" by Matthew Brown and David Lowe. This is performed by
-     * fitting a 3D quadratic to a set of neighbouring samples.
-     *
-     * The gradient vector and Hessian matrix at the initial keypoint location are
-     * approximated using central differences. The linear system Ax = b is then
-     * solved, where A is the Hessian, b is the negative gradient, and x is the
-     * offset of the interpolated maxima coordinates from the initial estimate.
-     * This is equivalent to an iteration of Netwon's optimisation algorithm.
-     *
-     * N9 contains the samples in the 3x3x3 neighbourhood of the maxima
-     * dx is the sampling step in x
-     * dy is the sampling step in y
-     * ds is the sampling step in size
-     * point contains the keypoint coordinates and scale to be modified
-     *
-     * Return value is 1 if interpolation was successful, 0 on failure.
-     */
-
-    inline float determinant(const gls::Matrix<3, 3> &A)
-    {
-        return A[0][0] * (A[1][1] * A[2][2] - A[1][2] * A[2][1]) -
-               A[0][1] * (A[1][0] * A[2][2] - A[1][2] * A[2][0]) +
-               A[0][2] * (A[1][0] * A[2][1] - A[1][1] * A[2][0]);
-    }
-
-    inline bool solve3x3(const gls::Matrix<3, 3> &A, const gls::Vector<3> &b, gls::Vector<3> *x)
-    {
-        float det = determinant(A);
-
-        if (det != 0)
-        {
-            return gls::Vector<3>{
-                       determinant({b, A[1], A[2]}),
-                       determinant({A[0], b, A[2]}),
-                       determinant({A[0], A[1], b})} /
-                   det;
-            return true;
-        }
-        printf("solve3x3: Singular Matrix!\n");
-        return false;
-    }
-
-    static bool interpolateKeypoint(const std::array<gls::image<float>, 3> &N9, int dx, int dy, int ds, KeyPoint *kpt)
-    {
-        gls::Vector<3> B = {
-            -(N9[1][0][1] - N9[1][0][-1]) / 2, // Negative 1st deriv with respect to x
-            -(N9[1][1][0] - N9[1][-1][0]) / 2, // Negative 1st deriv with respect to y
-            -(N9[2][0][0] - N9[0][0][0]) / 2   // Negative 1st deriv with respect to s
-        };
-        gls::Matrix<3, 3> A = {
-            {N9[1][0][-1] - 2 * N9[1][0][0] + N9[1][0][1],                    // 2nd deriv x, x
-             (N9[1][1][1] - N9[1][1][-1] - N9[1][-1][1] + N9[1][-1][-1]) / 4, // 2nd deriv x, y
-             (N9[2][0][1] - N9[2][0][-1] - N9[0][0][1] + N9[0][0][-1]) / 4},  // 2nd deriv x, s
-            {(N9[1][1][1] - N9[1][1][-1] - N9[1][-1][1] + N9[1][-1][-1]) / 4, // 2nd deriv x, y
-             N9[1][-1][0] - 2 * N9[1][0][0] + N9[1][1][0],                    // 2nd deriv y, y
-             (N9[2][1][0] - N9[2][-1][0] - N9[0][1][0] + N9[0][-1][0]) / 4},  // 2nd deriv y, s
-            {(N9[2][0][1] - N9[2][0][-1] - N9[0][0][1] + N9[0][0][-1]) / 4,   // 2nd deriv x, s
-             (N9[2][1][0] - N9[2][-1][0] - N9[0][1][0] + N9[0][-1][0]) / 4,   // 2nd deriv y, s
-             N9[0][0][0] - 2 * N9[1][0][0] + N9[2][0][0]}                     // 2nd deriv s, s
-        };
-        gls::Vector<3> x;
-        bool ok = solve3x3(A, B, &x);
-        ok = ok && (x[0] != 0 || x[1] != 0 || x[2] != 0) &&
-             std::abs(x[0]) <= 1 && std::abs(x[1]) <= 1 && std::abs(x[2]) <= 1;
-
-        if (ok)
-        {
-            kpt->pt.x += x[0] * dx;
-            kpt->pt.y += x[1] * dy;
-            kpt->size = rint(kpt->size + x[2] * ds);
-        }
-        return ok;
-    }
-
-    struct clSurfHF
-    {
-        cl_int8 p_dx[2];
-        cl_int8 p_dy[2];
-        cl_int8 p_dxy[4];
-
-        clSurfHF(const std::array<SurfHF, 3> &Dx, const std::array<SurfHF, 3> &Dy, const std::array<SurfHF, 4> &Dxy)
-        {
-            /*
-             NOTE: Removed repeating offsets from Dx and Dy, see note in SURF.cl
-             */
-
-            p_dx[0] = {Dx[0].p[0].x, Dx[0].p[0].y, Dx[0].p[1].x, Dx[0].p[1].y, Dx[0].p[2].x, Dx[0].p[2].y, Dx[0].p[3].x, Dx[0].p[3].y};
-            p_dx[1] = {Dx[1].p[2].x, Dx[1].p[2].y, Dx[1].p[3].x, Dx[1].p[3].y, Dx[2].p[2].x, Dx[2].p[2].y, Dx[2].p[3].x, Dx[2].p[3].y};
-
-            p_dy[0] = {Dy[0].p[0].x, Dy[0].p[0].y, Dy[0].p[1].x, Dy[0].p[1].y, Dy[0].p[2].x, Dy[0].p[2].y, Dy[0].p[3].x, Dy[0].p[3].y};
-            p_dy[1] = {Dy[1].p[1].x, Dy[1].p[1].y, Dy[1].p[3].x, Dy[1].p[3].y, Dy[2].p[1].x, Dy[2].p[1].y, Dy[2].p[3].x, Dy[2].p[3].y};
-
-            for (int i = 0; i < 4; i++)
-            {
-                p_dxy[i] = {Dxy[i].p[0].x, Dxy[i].p[0].y, Dxy[i].p[1].x, Dxy[i].p[1].y, Dxy[i].p[2].x, Dxy[i].p[2].y, Dxy[i].p[3].x, Dxy[i].p[3].y};
-            }
-        }
+    gls::Matrix<3, 3> A = {
+        {N9[1][0][-1] - 2 * N9[1][0][0] + N9[1][0][1],                     // 2nd deriv x, x
+         (N9[1][1][1] - N9[1][1][-1] - N9[1][-1][1] + N9[1][-1][-1]) / 4,  // 2nd deriv x, y
+         (N9[2][0][1] - N9[2][0][-1] - N9[0][0][1] + N9[0][0][-1]) / 4},   // 2nd deriv x, s
+        {(N9[1][1][1] - N9[1][1][-1] - N9[1][-1][1] + N9[1][-1][-1]) / 4,  // 2nd deriv x, y
+         N9[1][-1][0] - 2 * N9[1][0][0] + N9[1][1][0],                     // 2nd deriv y, y
+         (N9[2][1][0] - N9[2][-1][0] - N9[0][1][0] + N9[0][-1][0]) / 4},   // 2nd deriv y, s
+        {(N9[2][0][1] - N9[2][0][-1] - N9[0][0][1] + N9[0][0][-1]) / 4,    // 2nd deriv x, s
+         (N9[2][1][0] - N9[2][-1][0] - N9[0][1][0] + N9[0][-1][0]) / 4,    // 2nd deriv y, s
+         N9[0][0][0] - 2 * N9[1][0][0] + N9[2][0][0]}                      // 2nd deriv s, s
     };
+    gls::Vector<3> x;
+    bool ok = solve3x3(A, B, &x);
+    ok = ok && (x[0] != 0 || x[1] != 0 || x[2] != 0) && std::abs(x[0]) <= 1 &&
+         std::abs(x[1]) <= 1 && std::abs(x[2]) <= 1;
 
-    struct DetAndTraceHaarPattern
-    {
-        static const int NX = 3, NY = 3, NXY = 4;
+    if (ok) {
+        kpt->pt.x += x[0] * dx;
+        kpt->pt.y += x[1] * dy;
+        kpt->size = rint(kpt->size + x[2] * ds);
+    }
+    return ok;
+}
 
-        std::array<SurfHF, NX> Dx;
-        std::array<SurfHF, NY> Dy;
-        std::array<SurfHF, NXY> Dxy;
+struct clSurfHF {
+    cl_int8 p_dx[2];
+    cl_int8 p_dy[2];
+    cl_int8 p_dxy[4];
 
-        const gls::rectangle margin_crop;
+    clSurfHF(const std::array<SurfHF, 3>& Dx, const std::array<SurfHF, 3>& Dy,
+             const std::array<SurfHF, 4>& Dxy) {
+        /*
+         NOTE: Removed repeating offsets from Dx and Dy, see note in SURF.cl
+         */
 
-        DetAndTraceHaarPattern(int sum_width, int sum_height, int size, int sampleStep) : margin_crop((size / 2) / sampleStep, // Ignore pixels where some of the kernel is outside the image
-                                                                                                      (size / 2) / sampleStep,
-                                                                                                      1 + (sum_width - 1 - size) / sampleStep, // The integral image 'sum' is one pixel bigger than the source image
-                                                                                                      1 + (sum_height - 1 - size) / sampleStep)
-        {
-            const int dx_s[NX][5] = {
-                {0, 2, 3, 7, 1},
-                {3, 2, 6, 7, -2},
-                {6, 2, 9, 7, 1}};
-            const int dy_s[NY][5] = {
-                {2, 0, 7, 3, 1},
-                {2, 3, 7, 6, -2},
-                {2, 6, 7, 9, 1}};
-            const int dxy_s[NXY][5] = {
-                {1, 1, 4, 4, 1},
-                {5, 1, 8, 4, -1},
-                {1, 5, 4, 8, -1},
-                {5, 5, 8, 8, 1}};
+        p_dx[0] = {Dx[0].p[0].x, Dx[0].p[0].y, Dx[0].p[1].x, Dx[0].p[1].y,
+                   Dx[0].p[2].x, Dx[0].p[2].y, Dx[0].p[3].x, Dx[0].p[3].y};
+        p_dx[1] = {Dx[1].p[2].x, Dx[1].p[2].y, Dx[1].p[3].x, Dx[1].p[3].y,
+                   Dx[2].p[2].x, Dx[2].p[2].y, Dx[2].p[3].x, Dx[2].p[3].y};
 
-            assert(size <= (sum_height - 1) || size > (sum_width - 1));
+        p_dy[0] = {Dy[0].p[0].x, Dy[0].p[0].y, Dy[0].p[1].x, Dy[0].p[1].y,
+                   Dy[0].p[2].x, Dy[0].p[2].y, Dy[0].p[3].x, Dy[0].p[3].y};
+        p_dy[1] = {Dy[1].p[1].x, Dy[1].p[1].y, Dy[1].p[3].x, Dy[1].p[3].y,
+                   Dy[2].p[1].x, Dy[2].p[1].y, Dy[2].p[3].x, Dy[2].p[3].y};
 
-            resizeHaarPattern(dx_s, &Dx, 9, size);
-            resizeHaarPattern(dy_s, &Dy, 9, size);
-            resizeHaarPattern(dxy_s, &Dxy, 9, size);
+        for (int i = 0; i < 4; i++) {
+            p_dxy[i] = {Dxy[i].p[0].x, Dxy[i].p[0].y, Dxy[i].p[1].x, Dxy[i].p[1].y,
+                        Dxy[i].p[2].x, Dxy[i].p[2].y, Dxy[i].p[3].x, Dxy[i].p[3].y};
         }
+    }
+};
 
-        // Rescale sampling points to the pyramid level
-        void rescale(int scale)
-        {
-            for (auto &entry : Dx)
-            {
-                for (auto &pi : entry.p)
-                {
-                    pi /= scale;
-                }
-            }
-            for (auto &entry : Dy)
-            {
-                for (auto &pi : entry.p)
-                {
-                    pi /= scale;
-                }
-            }
-            for (auto &entry : Dxy)
-            {
-                for (auto &pi : entry.p)
-                {
-                    pi /= scale;
-                }
-            }
-        }
+struct DetAndTraceHaarPattern {
+    static const int NX = 3, NY = 3, NXY = 4;
 
-        // Rescale sampling points to the pyramid level
-        void upscale(int scale)
-        {
-            for (auto &entry : Dx)
-            {
-                for (auto &pi : entry.p)
-                {
-                    pi *= scale;
-                }
-            }
-            for (auto &entry : Dy)
-            {
-                for (auto &pi : entry.p)
-                {
-                    pi *= scale;
-                }
-            }
-            for (auto &entry : Dxy)
-            {
-                for (auto &pi : entry.p)
-                {
-                    pi *= scale;
-                }
+    std::array<SurfHF, NX> Dx;
+    std::array<SurfHF, NY> Dy;
+    std::array<SurfHF, NXY> Dxy;
+
+    const gls::rectangle margin_crop;
+
+    DetAndTraceHaarPattern(int sum_width, int sum_height, int size, int sampleStep)
+        : margin_crop(
+              (size / 2) /
+                  sampleStep,  // Ignore pixels where some of the kernel is outside the image
+              (size / 2) / sampleStep,
+              1 + (sum_width - 1 - size) / sampleStep,  // The integral image 'sum' is one pixel
+                                                        // bigger than the source image
+              1 + (sum_height - 1 - size) / sampleStep) {
+        const int dx_s[NX][5] = {{0, 2, 3, 7, 1}, {3, 2, 6, 7, -2}, {6, 2, 9, 7, 1}};
+        const int dy_s[NY][5] = {{2, 0, 7, 3, 1}, {2, 3, 7, 6, -2}, {2, 6, 7, 9, 1}};
+        const int dxy_s[NXY][5] = {
+            {1, 1, 4, 4, 1}, {5, 1, 8, 4, -1}, {1, 5, 4, 8, -1}, {5, 5, 8, 8, 1}};
+
+        assert(size <= (sum_height - 1) || size > (sum_width - 1));
+
+        resizeHaarPattern(dx_s, &Dx, 9, size);
+        resizeHaarPattern(dy_s, &Dy, 9, size);
+        resizeHaarPattern(dxy_s, &Dxy, 9, size);
+    }
+
+    // Rescale sampling points to the pyramid level
+    void rescale(int scale) {
+        for (auto& entry : Dx) {
+            for (auto& pi : entry.p) {
+                pi /= scale;
             }
         }
-    };
-
-    void calcLayerDetAndTrace(const gls::image<float> &sum, int size, int sampleStep,
-                              gls::image<float> *det, gls::image<float> *trace)
-    {
-        DetAndTraceHaarPattern haarPattern(sum.width, sum.height, size, sampleStep);
-
-        gls::image<float> detCpu = gls::image<float>(det, haarPattern.margin_crop);
-        gls::image<float> traceCpu = gls::image<float>(*trace, haarPattern.margin_crop);
-
-        for (int y = 0; y < haarPattern.margin_crop.height; y++)
-        {
-            for (int x = 0; x < haarPattern.margin_crop.width; x++)
-            {
-                calcDetAndTrace(sum, &detCpu, &traceCpu, x, y, sampleStep, haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
+        for (auto& entry : Dy) {
+            for (auto& pi : entry.p) {
+                pi /= scale;
+            }
+        }
+        for (auto& entry : Dxy) {
+            for (auto& pi : entry.p) {
+                pi /= scale;
             }
         }
     }
 
-    void findMaximaInLayer(int width, int height,
-                           const std::array<gls::image<float> *, 3> &dets, const gls::image<float> &trace,
-                           const std::array<int, 3> &sizes, std::vector<KeyPoint> *keypoints, int octave,
-                           float hessianThreshold, int sampleStep, std::mutex &keypointsMutex)
-    {
-        const int size = sizes[1];
-
-        const int layer_height = width / sampleStep;
-        const int layer_width = height / sampleStep;
-
-        // Ignore pixels without a 3x3x3 neighbourhood in the layer above
-        const int margin = (sizes[2] / 2) / sampleStep + 1;
-
-        const gls::image<float> &det0 = *dets[0];
-        const gls::image<float> &det1 = *dets[1];
-        const gls::image<float> &det2 = *dets[2];
-
-        int keyPointMaxima = 0;
-        for (int y = margin; y < layer_height - margin; y++)
-        {
-            for (int x = margin; x < layer_width - margin; x++)
-            {
-                const float val0 = (*dets[1])[y][x];
-
-                if (val0 > hessianThreshold)
-                {
-                    /* Coordinates for the start of the wavelet in the sum image. There
-                       is some integer division involved, so don't try to simplify this
-                       (cancel out sampleStep) without checking the result is the same */
-                    int sum_y = sampleStep * (y - (size / 2) / sampleStep);
-                    int sum_x = sampleStep * (x - (size / 2) / sampleStep);
-
-                    /* The 3x3x3 neighbouring samples around the maxima.
-                       The maxima is included at N9[1][0][0] */
-
-                    const std::array<gls::image<float>, 3> N9 = {
-                        gls::image<float>(det0, {x, y, 1, 1}),
-                        gls::image<float>(det1, {x, y, 1, 1}),
-                        gls::image<float>(det2, {x, y, 1, 1}),
-                    };
-
-                    /* Non-maxima suppression. val0 is at N9[1][0][0] */
-                    if (val0 > N9[0][-1][-1] && val0 > N9[0][-1][0] && val0 > N9[0][-1][1] &&
-                        val0 > N9[0][0][-1] && val0 > N9[0][0][0] && val0 > N9[0][0][1] &&
-                        val0 > N9[0][1][-1] && val0 > N9[0][1][0] && val0 > N9[0][1][1] &&
-                        val0 > N9[1][-1][-1] && val0 > N9[1][-1][0] && val0 > N9[1][-1][1] &&
-                        val0 > N9[1][0][-1] && val0 > N9[1][0][1] &&
-                        val0 > N9[1][1][-1] && val0 > N9[1][1][0] && val0 > N9[1][1][1] &&
-                        val0 > N9[2][-1][-1] && val0 > N9[2][-1][0] && val0 > N9[2][-1][1] &&
-                        val0 > N9[2][0][-1] && val0 > N9[2][0][0] && val0 > N9[2][0][1] &&
-                        val0 > N9[2][1][-1] && val0 > N9[2][1][0] && val0 > N9[2][1][1])
-                    {
-                        /* Calculate the wavelet center coordinates for the maxima */
-                        float center_y = sum_y + (size - 1) * 0.5f;
-                        float center_x = sum_x + (size - 1) * 0.5f;
-                        KeyPoint kpt = {{center_x, center_y}, (float)sizes[1], -1, val0, octave, trace[y][x] > 0};
-
-                        /* Interpolate maxima location within the 3x3x3 neighbourhood  */
-                        int ds = size - sizes[0];
-                        int interp_ok = interpolateKeypoint(N9, sampleStep, sampleStep, ds, &kpt);
-
-                        /* Sometimes the interpolation step gives a negative size etc. */
-                        if (interp_ok)
-                        {
-                            std::lock_guard<std::mutex> guard(keypointsMutex);
-                            keypoints->push_back(kpt);
-                            keyPointMaxima++;
-                        }
-                    }
-                }
+    // Rescale sampling points to the pyramid level
+    void upscale(int scale) {
+        for (auto& entry : Dx) {
+            for (auto& pi : entry.p) {
+                pi *= scale;
             }
         }
-        std::cout << "keyPointMaxima: " << keyPointMaxima << std::endl;
-    }
-
-    std::vector<float> getGaussianKernel(int n, float sigma)
-    {
-        const int SMALL_GAUSSIAN_SIZE = 7;
-        static const float small_gaussian_tab[][SMALL_GAUSSIAN_SIZE] = {
-            {1.f},
-            {0.25f, 0.5f, 0.25f},
-            {0.0625f, 0.25f, 0.375f, 0.25f, 0.0625f},
-            {0.03125f, 0.109375f, 0.21875f, 0.28125f, 0.21875f, 0.109375f, 0.03125f}};
-
-        const float *fixed_kernel = n % 2 == 1 && n <= SMALL_GAUSSIAN_SIZE && sigma <= 0 ? small_gaussian_tab[n >> 1] : nullptr;
-
-        float sigmaX = sigma > 0 ? sigma : ((n - 1) * 0.5 - 1) * 0.3 + 0.8;
-        float scale2X = -0.5 / (sigmaX * sigmaX);
-        float sum = 0;
-
-        std::vector<float> kernel(n);
-        for (int i = 0; i < n; i++)
-        {
-            float x = i - (n - 1) * 0.5;
-            float t = fixed_kernel ? (float)fixed_kernel[i] : std::exp(scale2X * x * x);
-            kernel[i] = t;
-            sum += kernel[i];
+        for (auto& entry : Dy) {
+            for (auto& pi : entry.p) {
+                pi *= scale;
+            }
         }
-
-        sum = 1. / sum;
-        for (auto &v : kernel)
-        {
-            v *= sum;
+        for (auto& entry : Dxy) {
+            for (auto& pi : entry.p) {
+                pi *= scale;
+            }
         }
-
-        return kernel;
     }
+};
 
-    void resizeVV(const gls::image<float> &src, gls::image<float> *dst, int interpolation)
-    {
-        // Note that src and dst represent square matrices
+void calcLayerDetAndTrace(const gls::image<float>& sum, int size, int sampleStep,
+                          gls::image<float>* det, gls::image<float>* trace) {
+    DetAndTraceHaarPattern haarPattern(sum.width, sum.height, size, sampleStep);
 
-        float dsize = (float)src.height / dst->height;
-        if (dst->height && dst->width)
-        {
-            for (int i = 0; i < dst->height; i++)
-            {
-                for (int j = 0; j < dst->width; j++)
-                {
-                    int _i = (int)i * dsize;      // integer part
-                    float _idec = i * dsize - _i; // fractional part
-                    int _j = (int)j * dsize;
-                    float _jdec = j * dsize - _j;
-                    if (_j >= 0 && _j < (src.height - 1) && _i >= 0 && _i < (src.height - 1))
-                    {
-                        // Bilinear interpolation
-                        (*dst)[i][j] = (1 - _idec) * (1 - _jdec) * src[_i][_j] + _idec * (1 - _jdec) * src[_i + 1][_j] +
-                                       _jdec * (1 - _idec) * src[_j][_j + 1] + _idec * _jdec * src[_i + 1][_j + 1];
+    gls::image<float> detCpu = gls::image<float>(det, haarPattern.margin_crop);
+    gls::image<float> traceCpu = gls::image<float>(*trace, haarPattern.margin_crop);
+
+    for (int y = 0; y < haarPattern.margin_crop.height; y++) {
+        for (int x = 0; x < haarPattern.margin_crop.width; x++) {
+            calcDetAndTrace(sum, &detCpu, &traceCpu, x, y, sampleStep, haarPattern.Dx,
+                            haarPattern.Dy, haarPattern.Dxy);
+        }
+    }
+}
+
+void findMaximaInLayer(int width, int height, const std::array<gls::image<float>*, 3>& dets,
+                       const gls::image<float>& trace, const std::array<int, 3>& sizes,
+                       std::vector<KeyPoint>* keypoints, int octave, float hessianThreshold,
+                       int sampleStep, std::mutex& keypointsMutex) {
+    const int size = sizes[1];
+
+    const int layer_height = width / sampleStep;
+    const int layer_width = height / sampleStep;
+
+    // Ignore pixels without a 3x3x3 neighbourhood in the layer above
+    const int margin = (sizes[2] / 2) / sampleStep + 1;
+
+    const gls::image<float>& det0 = *dets[0];
+    const gls::image<float>& det1 = *dets[1];
+    const gls::image<float>& det2 = *dets[2];
+
+    int keyPointMaxima = 0;
+    for (int y = margin; y < layer_height - margin; y++) {
+        for (int x = margin; x < layer_width - margin; x++) {
+            const float val0 = (*dets[1])[y][x];
+
+            if (val0 > hessianThreshold) {
+                /* Coordinates for the start of the wavelet in the sum image. There
+                   is some integer division involved, so don't try to simplify this
+                   (cancel out sampleStep) without checking the result is the same */
+                int sum_y = sampleStep * (y - (size / 2) / sampleStep);
+                int sum_x = sampleStep * (x - (size / 2) / sampleStep);
+
+                /* The 3x3x3 neighbouring samples around the maxima.
+                   The maxima is included at N9[1][0][0] */
+
+                const std::array<gls::image<float>, 3> N9 = {
+                    gls::image<float>(det0, {x, y, 1, 1}),
+                    gls::image<float>(det1, {x, y, 1, 1}),
+                    gls::image<float>(det2, {x, y, 1, 1}),
+                };
+
+                /* Non-maxima suppression. val0 is at N9[1][0][0] */
+                if (val0 > N9[0][-1][-1] && val0 > N9[0][-1][0] && val0 > N9[0][-1][1] &&
+                    val0 > N9[0][0][-1] && val0 > N9[0][0][0] && val0 > N9[0][0][1] &&
+                    val0 > N9[0][1][-1] && val0 > N9[0][1][0] && val0 > N9[0][1][1] &&
+                    val0 > N9[1][-1][-1] && val0 > N9[1][-1][0] && val0 > N9[1][-1][1] &&
+                    val0 > N9[1][0][-1] && val0 > N9[1][0][1] && val0 > N9[1][1][-1] &&
+                    val0 > N9[1][1][0] && val0 > N9[1][1][1] && val0 > N9[2][-1][-1] &&
+                    val0 > N9[2][-1][0] && val0 > N9[2][-1][1] && val0 > N9[2][0][-1] &&
+                    val0 > N9[2][0][0] && val0 > N9[2][0][1] && val0 > N9[2][1][-1] &&
+                    val0 > N9[2][1][0] && val0 > N9[2][1][1]) {
+                    /* Calculate the wavelet center coordinates for the maxima */
+                    float center_y = sum_y + (size - 1) * 0.5f;
+                    float center_x = sum_x + (size - 1) * 0.5f;
+                    KeyPoint kpt = {{center_x, center_y}, (float)sizes[1], -1, val0, octave,
+                                    trace[y][x] > 0};
+
+                    /* Interpolate maxima location within the 3x3x3 neighbourhood  */
+                    int ds = size - sizes[0];
+                    int interp_ok = interpolateKeypoint(N9, sampleStep, sampleStep, ds, &kpt);
+
+                    /* Sometimes the interpolation step gives a negative size etc. */
+                    if (interp_ok) {
+                        std::lock_guard<std::mutex> guard(keypointsMutex);
+                        keypoints->push_back(kpt);
+                        keyPointMaxima++;
                     }
                 }
             }
         }
     }
+    std::cout << "keyPointMaxima: " << keyPointMaxima << std::endl;
+}
 
-    struct SURFInvoker
-    {
-        enum
-        {
-            ORI_RADIUS = 6,
-            ORI_WIN = 60,
-            PATCH_SZ = 20
-        };
+std::vector<float> getGaussianKernel(int n, float sigma) {
+    const int SMALL_GAUSSIAN_SIZE = 7;
+    static const float small_gaussian_tab[][SMALL_GAUSSIAN_SIZE] = {
+        {1.f},
+        {0.25f, 0.5f, 0.25f},
+        {0.0625f, 0.25f, 0.375f, 0.25f, 0.0625f},
+        {0.03125f, 0.109375f, 0.21875f, 0.28125f, 0.21875f, 0.109375f, 0.03125f}};
+
+    const float* fixed_kernel =
+        n % 2 == 1 && n <= SMALL_GAUSSIAN_SIZE && sigma <= 0 ? small_gaussian_tab[n >> 1] : nullptr;
+
+    float sigmaX = sigma > 0 ? sigma : ((n - 1) * 0.5 - 1) * 0.3 + 0.8;
+    float scale2X = -0.5 / (sigmaX * sigmaX);
+    float sum = 0;
+
+    std::vector<float> kernel(n);
+    for (int i = 0; i < n; i++) {
+        float x = i - (n - 1) * 0.5;
+        float t = fixed_kernel ? (float)fixed_kernel[i] : std::exp(scale2X * x * x);
+        kernel[i] = t;
+        sum += kernel[i];
+    }
+
+    sum = 1. / sum;
+    for (auto& v : kernel) {
+        v *= sum;
+    }
+
+    return kernel;
+}
+
+void resizeVV(const gls::image<float>& src, gls::image<float>* dst, int interpolation) {
+    // Note that src and dst represent square matrices
+
+    float dsize = (float)src.height / dst->height;
+    if (dst->height && dst->width) {
+        for (int i = 0; i < dst->height; i++) {
+            for (int j = 0; j < dst->width; j++) {
+                int _i = (int)i * dsize;       // integer part
+                float _idec = i * dsize - _i;  // fractional part
+                int _j = (int)j * dsize;
+                float _jdec = j * dsize - _j;
+                if (_j >= 0 && _j < (src.height - 1) && _i >= 0 && _i < (src.height - 1)) {
+                    // Bilinear interpolation
+                    (*dst)[i][j] = (1 - _idec) * (1 - _jdec) * src[_i][_j] +
+                                   _idec * (1 - _jdec) * src[_i + 1][_j] +
+                                   _jdec * (1 - _idec) * src[_j][_j + 1] +
+                                   _idec * _jdec * src[_i + 1][_j + 1];
+                }
+            }
+        }
+    }
+}
+
+struct SURFInvoker {
+    enum { ORI_RADIUS = 6, ORI_WIN = 60, PATCH_SZ = 20 };
+
+    // Simple bound for number of grid points in circle of radius ORI_RADIUS
+    const int nOriSampleBound = (2 * ORI_RADIUS + 1) * (2 * ORI_RADIUS + 1);
+
+    // Parameters
+    const gls::image<float>& img;
+    const gls::image<float>& sum;
+    std::vector<KeyPoint>* keypoints;
+    gls::image<float>* descriptors;
+
+    // Pre-calculated values
+    int nOriSamples;
+    std::vector<Point2f> apt;
+    std::vector<float> aptw;
+    std::vector<float> DW;
+
+    SURFInvoker(const gls::image<float>& _img, const gls::image<float>& _sum,
+                std::vector<KeyPoint>* _keypoints, gls::image<float>* _descriptors)
+        : img(_img), sum(_sum), keypoints(_keypoints), descriptors(_descriptors) {
+        enum { ORI_RADIUS = 6, ORI_WIN = 60, PATCH_SZ = 20 };
 
         // Simple bound for number of grid points in circle of radius ORI_RADIUS
         const int nOriSampleBound = (2 * ORI_RADIUS + 1) * (2 * ORI_RADIUS + 1);
 
-        // Parameters
-        const gls::image<float> &img;
-        const gls::image<float> &sum;
-        std::vector<KeyPoint> *keypoints;
-        gls::image<float> *descriptors;
+        // Allocate arrays
+        apt.resize(nOriSampleBound);
+        aptw.resize(nOriSampleBound);
+        DW.resize(PATCH_SZ * PATCH_SZ);
 
-        // Pre-calculated values
-        int nOriSamples;
-        std::vector<Point2f> apt;
-        std::vector<float> aptw;
-        std::vector<float> DW;
+        /* Coordinates and weights of samples used to calculate orientation */
+        const auto G_ori = getGaussianKernel(2 * ORI_RADIUS + 1, SURF_ORI_SIGMA);
+        nOriSamples = 0;
+        for (int i = -ORI_RADIUS; i <= ORI_RADIUS; i++) {
+            for (int j = -ORI_RADIUS; j <= ORI_RADIUS; j++) {
+                if (i * i + j * j <= ORI_RADIUS * ORI_RADIUS) {
+                    apt[nOriSamples] = Point2f(i, j);
+                    aptw[nOriSamples++] = G_ori[i + ORI_RADIUS] * G_ori[j + ORI_RADIUS];
+                }
+            }
+        }
+        assert(nOriSamples <= nOriSampleBound);
 
-        SURFInvoker(const gls::image<float> &_img,
-                    const gls::image<float> &_sum,
-                    std::vector<KeyPoint> *_keypoints,
-                    gls::image<float> *_descriptors) : img(_img), sum(_sum), keypoints(_keypoints), descriptors(_descriptors)
-        {
-            enum
-            {
-                ORI_RADIUS = 6,
-                ORI_WIN = 60,
-                PATCH_SZ = 20
-            };
+        /* Gaussian used to weight descriptor samples */
+        const auto G_desc = getGaussianKernel(PATCH_SZ, SURF_DESC_SIGMA);
+        for (int i = 0; i < PATCH_SZ; i++) {
+            for (int j = 0; j < PATCH_SZ; j++) DW[i * PATCH_SZ + j] = G_desc[i] * G_desc[j];
+        }
+    }
 
-            // Simple bound for number of grid points in circle of radius ORI_RADIUS
-            const int nOriSampleBound = (2 * ORI_RADIUS + 1) * (2 * ORI_RADIUS + 1);
+    void computeRange(int k1, int k2) {
+        /* X and Y gradient wavelet data */
+        const int NX = 2, NY = 2;
+        const int dx_s[NX][5] = {{0, 0, 2, 4, -1}, {2, 0, 4, 4, 1}};
+        const int dy_s[NY][5] = {{0, 0, 4, 2, 1}, {0, 2, 4, 4, -1}};
 
-            // Allocate arrays
-            apt.resize(nOriSampleBound);
-            aptw.resize(nOriSampleBound);
-            DW.resize(PATCH_SZ * PATCH_SZ);
+        float X[nOriSampleBound], Y[nOriSampleBound], angle[nOriSampleBound];
+        gls::image<float> PATCH(PATCH_SZ + 1, PATCH_SZ + 1);
+        float DX[PATCH_SZ][PATCH_SZ], DY[PATCH_SZ][PATCH_SZ];
 
-            /* Coordinates and weights of samples used to calculate orientation */
-            const auto G_ori = getGaussianKernel(2 * ORI_RADIUS + 1, SURF_ORI_SIGMA);
-            nOriSamples = 0;
-            for (int i = -ORI_RADIUS; i <= ORI_RADIUS; i++)
-            {
-                for (int j = -ORI_RADIUS; j <= ORI_RADIUS; j++)
-                {
-                    if (i * i + j * j <= ORI_RADIUS * ORI_RADIUS)
-                    {
-                        apt[nOriSamples] = Point2f(i, j);
-                        aptw[nOriSamples++] = G_ori[i + ORI_RADIUS] * G_ori[j + ORI_RADIUS];
+        // TODO: should we also add the extended (dsize = 128) case?
+        const int dsize = 64;
+
+        float maxSize = 0;
+        for (int k = k1; k < k2; k++) {
+            maxSize = std::max(maxSize, (*keypoints)[k].size);
+        }
+
+        for (int k = k1; k < k2; k++) {
+            std::array<SurfHF, NX> dx_t;
+            std::array<SurfHF, NY> dy_t;
+            KeyPoint& kp = (*keypoints)[k];
+            float size = kp.size;
+            Point2f center = kp.pt;
+            /* The sampling intervals and wavelet sized for selecting an orientation
+             and building the keypoint descriptor are defined relative to 's' */
+            float s = size * 1.2f / 9.0f;
+            /* To find the dominant orientation, the gradients in x and y are
+             sampled in a circle of radius 6s using wavelets of size 4s.
+             We ensure the gradient wavelet size is even to ensure the
+             wavelet pattern is balanced and symmetric around its center */
+            int grad_wav_size = 2 * (int)lrint(2 * s);
+            if (sum.height < grad_wav_size || sum.width < grad_wav_size) {
+                /* when grad_wav_size is too big,
+                 * the sampling of gradient will be meaningless
+                 * mark keypoint for deletion. */
+                kp.size = -1;
+                continue;
+            }
+
+            float descriptor_dir = 360.f - 90.f;
+            resizeHaarPattern(dx_s, &dx_t, 4, grad_wav_size);
+            resizeHaarPattern(dy_s, &dy_t, 4, grad_wav_size);
+            int nangle = 0;
+            for (int kk = 0; kk < nOriSamples; kk++) {
+                // TODO: if we use round instead of lrint the result is slightly different
+
+                int x = (int)lrint(center.x + apt[kk].x * s - (float)(grad_wav_size - 1) / 2);
+                int y = (int)lrint(center.y + apt[kk].y * s - (float)(grad_wav_size - 1) / 2);
+                if (y < 0 || y >= sum.height - grad_wav_size || x < 0 ||
+                    x >= sum.width - grad_wav_size)
+                    continue;
+                float vx = calcHaarPattern(sum, {x, y}, dx_t);
+                float vy = calcHaarPattern(sum, {x, y}, dy_t);
+                X[nangle] = vx * aptw[kk];
+                Y[nangle] = vy * aptw[kk];
+                nangle++;
+            }
+            if (nangle == 0) {
+                // No gradient could be sampled because the keypoint is too
+                // near too one or more of the sides of the image. As we
+                // therefore cannot find a dominant direction, we skip this
+                // keypoint and mark it for later deletion from the sequence.
+                kp.size = -1;
+                continue;
+            }
+
+            // phase( Mat(1, nangle, CV_32F, X), Mat(1, nangle, CV_32F, Y), Mat(1, nangle, CV_32F,
+            // angle), true );
+            for (int i = 0; i < nangle; i++) {
+                float temp = atan2(Y[i], X[i]) * (180 / M_PI);
+                if (temp < 0)
+                    angle[i] = temp + 360;
+                else
+                    angle[i] = temp;
+            }
+
+            float bestx = 0, besty = 0, descriptor_mod = 0;
+            for (float i = 0; i < 360; i += SURF_ORI_SEARCH_INC) {
+                float sumx = 0, sumy = 0, temp_mod;
+                for (int j = 0; j < nangle; j++) {
+                    float d = std::abs(lrint(angle[j]) - i);
+                    if (d < ORI_WIN / 2 || d > 360 - ORI_WIN / 2) {
+                        sumx += X[j];
+                        sumy += Y[j];
+                    }
+                }
+                temp_mod = sumx * sumx + sumy * sumy;
+                if (temp_mod > descriptor_mod) {
+                    descriptor_mod = temp_mod;
+                    bestx = sumx;
+                    besty = sumy;
+                }
+            }
+            descriptor_dir = atan2(-besty, bestx);
+
+            kp.angle = descriptor_dir;
+
+            if (!descriptors) continue;
+
+            /* Extract a window of pixels around the keypoint of size 20s */
+            int win_size = (int)((PATCH_SZ + 1) * s);
+            gls::image<float> mwin(win_size, win_size);
+
+            // !upright
+            descriptor_dir *= (float)(M_PI / 180);
+            float sin_dir = -std::sin(descriptor_dir);
+            float cos_dir = std::cos(descriptor_dir);
+
+            float win_offset = -(float)(win_size - 1) / 2;
+            float start_x = center.x + win_offset * cos_dir + win_offset * sin_dir;
+            float start_y = center.y - win_offset * sin_dir + win_offset * cos_dir;
+
+            int ncols1 = img.width - 1, nrows1 = img.height - 1;
+            for (int i = 0; i < win_size; i++, start_x += sin_dir, start_y += cos_dir) {
+                float pixel_x = start_x;
+                float pixel_y = start_y;
+                for (int j = 0; j < win_size; j++, pixel_x += cos_dir, pixel_y -= sin_dir) {
+                    int ix = std::floor(pixel_x);
+                    int iy = std::floor(pixel_y);
+
+                    if ((unsigned)ix < (unsigned)ncols1 && (unsigned)iy < (unsigned)nrows1) {
+                        float a = pixel_x - ix;
+                        float b = pixel_y - iy;
+
+                        mwin[i][j] =
+                            std::round((img[iy][ix] * (1 - a) + img[iy][ix + 1] * a) * (1 - b) +
+                                       (img[iy + 1][ix] * (1 - a) + img[iy + 1][ix + 1] * a) * b);
+                    } else {
+                        int x = std::clamp((int)std::round(pixel_x), 0, ncols1);
+                        int y = std::clamp((int)std::round(pixel_y), 0, nrows1);
+                        mwin[i][j] = img[y][x];
                     }
                 }
             }
-            assert(nOriSamples <= nOriSampleBound);
 
-            /* Gaussian used to weight descriptor samples */
-            const auto G_desc = getGaussianKernel(PATCH_SZ, SURF_DESC_SIGMA);
+            // Scale the window to size PATCH_SZ so each pixel's size is s. This
+            // makes calculating the gradients with wavelets of size 2s easy
+            resizeVV(mwin, &PATCH, 0);
+
+            // Calculate gradients in x and y with wavelets of size 2s
             for (int i = 0; i < PATCH_SZ; i++)
-            {
-                for (int j = 0; j < PATCH_SZ; j++)
-                    DW[i * PATCH_SZ + j] = G_desc[i] * G_desc[j];
+                for (int j = 0; j < PATCH_SZ; j++) {
+                    float dw = DW[i * PATCH_SZ + j];
+                    float vx =
+                        (PATCH[i][j + 1] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i + 1][j]) *
+                        dw;
+                    float vy =
+                        (PATCH[i + 1][j] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i][j + 1]) *
+                        dw;
+                    DX[i][j] = vx;
+                    DY[i][j] = vy;
+                }
+
+            // Construct the descriptor
+            for (int kk = 0; kk < dsize; kk++) {
+                (*descriptors)[k][kk] = 0;
             }
-        }
+            float square_mag = 0;
 
-        void computeRange(int k1, int k2)
-        {
-            /* X and Y gradient wavelet data */
-            const int NX = 2, NY = 2;
-            const int dx_s[NX][5] = {
-                {0, 0, 2, 4, -1},
-                {2, 0, 4, 4, 1}};
-            const int dy_s[NY][5] = {
-                {0, 0, 4, 2, 1},
-                {0, 2, 4, 4, -1}};
+            // 64-bin descriptor
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 4; j++) {
+                    int index = 16 * i + 4 * j;
 
-            float X[nOriSampleBound], Y[nOriSampleBound], angle[nOriSampleBound];
-            gls::image<float> PATCH(PATCH_SZ + 1, PATCH_SZ + 1);
-            float DX[PATCH_SZ][PATCH_SZ], DY[PATCH_SZ][PATCH_SZ];
-
-            // TODO: should we also add the extended (dsize = 128) case?
-            const int dsize = 64;
-
-            float maxSize = 0;
-            for (int k = k1; k < k2; k++)
-            {
-                maxSize = std::max(maxSize, (*keypoints)[k].size);
-            }
-
-            for (int k = k1; k < k2; k++)
-            {
-                std::array<SurfHF, NX> dx_t;
-                std::array<SurfHF, NY> dy_t;
-                KeyPoint &kp = (*keypoints)[k];
-                float size = kp.size;
-                Point2f center = kp.pt;
-                /* The sampling intervals and wavelet sized for selecting an orientation
-                 and building the keypoint descriptor are defined relative to 's' */
-                float s = size * 1.2f / 9.0f;
-                /* To find the dominant orientation, the gradients in x and y are
-                 sampled in a circle of radius 6s using wavelets of size 4s.
-                 We ensure the gradient wavelet size is even to ensure the
-                 wavelet pattern is balanced and symmetric around its center */
-                int grad_wav_size = 2 * (int)lrint(2 * s);
-                if (sum.height < grad_wav_size || sum.width < grad_wav_size)
-                {
-                    /* when grad_wav_size is too big,
-                     * the sampling of gradient will be meaningless
-                     * mark keypoint for deletion. */
-                    kp.size = -1;
-                    continue;
-                }
-
-                float descriptor_dir = 360.f - 90.f;
-                resizeHaarPattern(dx_s, &dx_t, 4, grad_wav_size);
-                resizeHaarPattern(dy_s, &dy_t, 4, grad_wav_size);
-                int nangle = 0;
-                for (int kk = 0; kk < nOriSamples; kk++)
-                {
-                    // TODO: if we use round instead of lrint the result is slightly different
-
-                    int x = (int)lrint(center.x + apt[kk].x * s - (float)(grad_wav_size - 1) / 2);
-                    int y = (int)lrint(center.y + apt[kk].y * s - (float)(grad_wav_size - 1) / 2);
-                    if (y < 0 || y >= sum.height - grad_wav_size ||
-                        x < 0 || x >= sum.width - grad_wav_size)
-                        continue;
-                    float vx = calcHaarPattern(sum, {x, y}, dx_t);
-                    float vy = calcHaarPattern(sum, {x, y}, dy_t);
-                    X[nangle] = vx * aptw[kk];
-                    Y[nangle] = vy * aptw[kk];
-                    nangle++;
-                }
-                if (nangle == 0)
-                {
-                    // No gradient could be sampled because the keypoint is too
-                    // near too one or more of the sides of the image. As we
-                    // therefore cannot find a dominant direction, we skip this
-                    // keypoint and mark it for later deletion from the sequence.
-                    kp.size = -1;
-                    continue;
-                }
-
-                // phase( Mat(1, nangle, CV_32F, X), Mat(1, nangle, CV_32F, Y), Mat(1, nangle, CV_32F, angle), true );
-                for (int i = 0; i < nangle; i++)
-                {
-                    float temp = atan2(Y[i], X[i]) * (180 / M_PI);
-                    if (temp < 0)
-                        angle[i] = temp + 360;
-                    else
-                        angle[i] = temp;
-                }
-
-                float bestx = 0, besty = 0, descriptor_mod = 0;
-                for (float i = 0; i < 360; i += SURF_ORI_SEARCH_INC)
-                {
-                    float sumx = 0, sumy = 0, temp_mod;
-                    for (int j = 0; j < nangle; j++)
-                    {
-                        float d = std::abs(lrint(angle[j]) - i);
-                        if (d < ORI_WIN / 2 || d > 360 - ORI_WIN / 2)
-                        {
-                            sumx += X[j];
-                            sumy += Y[j];
+                    for (int y = i * 5; y < i * 5 + 5; y++) {
+                        for (int x = j * 5; x < j * 5 + 5; x++) {
+                            float tx = DX[y][x], ty = DY[y][x];
+                            (*descriptors)[k][index + 0] += tx;
+                            (*descriptors)[k][index + 1] += ty;
+                            (*descriptors)[k][index + 2] += (float)fabs(tx);
+                            (*descriptors)[k][index + 3] += (float)fabs(ty);
                         }
                     }
-                    temp_mod = sumx * sumx + sumy * sumy;
-                    if (temp_mod > descriptor_mod)
-                    {
-                        descriptor_mod = temp_mod;
-                        bestx = sumx;
-                        besty = sumy;
+                    for (int kk = 0; kk < 4; kk++) {
+                        float v = (*descriptors)[k][index + kk];
+                        square_mag += v * v;
                     }
-                }
-                descriptor_dir = atan2(-besty, bestx);
-
-                kp.angle = descriptor_dir;
-
-                if (!descriptors)
-                    continue;
-
-                /* Extract a window of pixels around the keypoint of size 20s */
-                int win_size = (int)((PATCH_SZ + 1) * s);
-                gls::image<float> mwin(win_size, win_size);
-
-                // !upright
-                descriptor_dir *= (float)(M_PI / 180);
-                float sin_dir = -std::sin(descriptor_dir);
-                float cos_dir = std::cos(descriptor_dir);
-
-                float win_offset = -(float)(win_size - 1) / 2;
-                float start_x = center.x + win_offset * cos_dir + win_offset * sin_dir;
-                float start_y = center.y - win_offset * sin_dir + win_offset * cos_dir;
-
-                int ncols1 = img.width - 1, nrows1 = img.height - 1;
-                for (int i = 0; i < win_size; i++, start_x += sin_dir, start_y += cos_dir)
-                {
-                    float pixel_x = start_x;
-                    float pixel_y = start_y;
-                    for (int j = 0; j < win_size; j++, pixel_x += cos_dir, pixel_y -= sin_dir)
-                    {
-                        int ix = std::floor(pixel_x);
-                        int iy = std::floor(pixel_y);
-
-                        if ((unsigned)ix < (unsigned)ncols1 &&
-                            (unsigned)iy < (unsigned)nrows1)
-                        {
-                            float a = pixel_x - ix;
-                            float b = pixel_y - iy;
-
-                            mwin[i][j] = std::round((img[iy][ix] * (1 - a) + img[iy][ix + 1] * a) * (1 - b) +
-                                                    (img[iy + 1][ix] * (1 - a) + img[iy + 1][ix + 1] * a) * b);
-                        }
-                        else
-                        {
-                            int x = std::clamp((int)std::round(pixel_x), 0, ncols1);
-                            int y = std::clamp((int)std::round(pixel_y), 0, nrows1);
-                            mwin[i][j] = img[y][x];
-                        }
-                    }
-                }
-
-                // Scale the window to size PATCH_SZ so each pixel's size is s. This
-                // makes calculating the gradients with wavelets of size 2s easy
-                resizeVV(mwin, &PATCH, 0);
-
-                // Calculate gradients in x and y with wavelets of size 2s
-                for (int i = 0; i < PATCH_SZ; i++)
-                    for (int j = 0; j < PATCH_SZ; j++)
-                    {
-                        float dw = DW[i * PATCH_SZ + j];
-                        float vx = (PATCH[i][j + 1] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i + 1][j]) * dw;
-                        float vy = (PATCH[i + 1][j] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i][j + 1]) * dw;
-                        DX[i][j] = vx;
-                        DY[i][j] = vy;
-                    }
-
-                // Construct the descriptor
-                for (int kk = 0; kk < dsize; kk++)
-                {
-                    (*descriptors)[k][kk] = 0;
-                }
-                float square_mag = 0;
-
-                // 64-bin descriptor
-                for (int i = 0; i < 4; i++)
-                {
-                    for (int j = 0; j < 4; j++)
-                    {
-                        int index = 16 * i + 4 * j;
-
-                        for (int y = i * 5; y < i * 5 + 5; y++)
-                        {
-                            for (int x = j * 5; x < j * 5 + 5; x++)
-                            {
-                                float tx = DX[y][x], ty = DY[y][x];
-                                (*descriptors)[k][index + 0] += tx;
-                                (*descriptors)[k][index + 1] += ty;
-                                (*descriptors)[k][index + 2] += (float)fabs(tx);
-                                (*descriptors)[k][index + 3] += (float)fabs(ty);
-                            }
-                        }
-                        for (int kk = 0; kk < 4; kk++)
-                        {
-                            float v = (*descriptors)[k][index + kk];
-                            square_mag += v * v;
-                        }
-                    }
-                }
-
-                // unit vector is essential for contrast invariance
-                float scale = (float)(1. / (std::sqrt(square_mag) + FLT_EPSILON));
-                for (int kk = 0; kk < dsize; kk++)
-                {
-                    (*descriptors)[k][kk] *= scale;
                 }
             }
-        }
 
-        void run()
-        {
-            const int K = (int)keypoints->size();
-
-            if (K > 32)
-            {
-                const int threads = 8;
-                ThreadPool threadPool(threads);
-
-                const int ranges = (int)std::ceil((float)K / threads);
-                for (int rr = 0; rr < ranges; rr++)
-                {
-                    int k1 = ranges * rr;
-                    int k2 = std::min(ranges * (rr + 1), K);
-
-                    threadPool.enqueue([this, k1, k2]()
-                                       { computeRange(k1, k2); });
-                }
-            }
-            else
-            {
-                computeRange(0, K);
-            }
-        }
-    };
-
-    void descriptor(const gls::image<float> &srcImg,
-                    const gls::image<float> &integralSum,
-                    std::vector<KeyPoint> *keypoints,
-                    gls::image<float> *descriptors)
-    {
-        int N = (int)keypoints->size();
-        if (N > 0)
-        {
-            SURFInvoker(srcImg, integralSum, keypoints, descriptors).run();
-        }
-    }
-
-    template <typename T, int N = 4>
-    std::array<typename gls::cl_image_2d<T>::unique_ptr, N> sumImageStack(cl::Context context, int width, int height)
-    {
-        std::array<typename gls::cl_image_2d<T>::unique_ptr, N> result;
-        for (int i = 0; i < N; i++)
-        {
-            int step = 1 << i;
-            result[i] = std::make_unique<gls::cl_image_buffer_2d<T>>(context, 1 + (width - 1) / step, 1 + (height - 1) / step);
-        }
-        return result;
-    }
-
-    void SURFBuild(const std::array<gls::image<float>::unique_ptr, 4> &sum,
-                   const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
-                   const std::vector<gls::image<float>::unique_ptr> &dets,
-                   const std::vector<gls::image<float>::unique_ptr> &traces,
-                   int nOctaves, int nOctaveLayers)
-    {
-        int N = (int)sizes.size();
-        std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
-
-        ThreadPool threadPool(8);
-
-        const int layers = nOctaveLayers + 2;
-
-        assert(nOctaves * layers == N);
-
-        for (int octave = 0; octave < nOctaves; octave++)
-        {
-            for (int layer = 0; layer < layers; layer++)
-            {
-                const int i = octave * layers + layer;
-                /*
-                     RANSAC interior point ratio - number of loops: 121 150 39
-                      Transformation matrix parameter:
-                     0.989685 0.027618 84.000000
-                    -0.030334 0.993164 119.187500
-                    -0.000002 -0.000002 1
-                 */
-                threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, i]()
-                                   { calcLayerDetAndTrace(*sum[0], sizes[i], sampleSteps[i], dets[i].get(), traces[i].get()); });
+            // unit vector is essential for contrast invariance
+            float scale = (float)(1. / (std::sqrt(square_mag) + FLT_EPSILON));
+            for (int kk = 0; kk < dsize; kk++) {
+                (*descriptors)[k][kk] *= scale;
             }
         }
     }
 
-    void SURFFind(const gls::image<float> &sum,
-                  const std::vector<gls::image<float>::unique_ptr> &dets,
-                  const std::vector<gls::image<float>::unique_ptr> &traces,
-                  const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
-                  const std::vector<int> &middleIndices, std::vector<KeyPoint> *keypoints,
-                  int nOctaveLayers, float hessianThreshold)
-    {
-        std::mutex keypointsMutex;
-        ThreadPool threadPool(8);
+    void run() {
+        const int K = (int)keypoints->size();
 
-        int M = (int)middleIndices.size();
-        std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
-        for (int i = 0; i < M; i++)
-        {
-            const int layer = middleIndices[i];
-            const int octave = i / nOctaveLayers;
+        if (K > 32) {
+            const int threads = 8;
+            ThreadPool threadPool(threads);
 
-            threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, &keypoints, &keypointsMutex,
-                                layer, octave, hessianThreshold]()
-                               {
-            auto dets0 = dets[layer-1].get();
+            const int ranges = (int)std::ceil((float)K / threads);
+            for (int rr = 0; rr < ranges; rr++) {
+                int k1 = ranges * rr;
+                int k2 = std::min(ranges * (rr + 1), K);
+
+                threadPool.enqueue([this, k1, k2]() { computeRange(k1, k2); });
+            }
+        } else {
+            computeRange(0, K);
+        }
+    }
+};
+
+void descriptor(const gls::image<float>& srcImg, const gls::image<float>& integralSum,
+                std::vector<KeyPoint>* keypoints, gls::image<float>* descriptors) {
+    int N = (int)keypoints->size();
+    if (N > 0) {
+        SURFInvoker(srcImg, integralSum, keypoints, descriptors).run();
+    }
+}
+
+template <typename T, int N = 4>
+std::array<typename gls::cl_image_2d<T>::unique_ptr, N> sumImageStack(cl::Context context,
+                                                                      int width, int height) {
+    std::array<typename gls::cl_image_2d<T>::unique_ptr, N> result;
+    for (int i = 0; i < N; i++) {
+        int step = 1 << i;
+        result[i] = std::make_unique<gls::cl_image_buffer_2d<T>>(context, 1 + (width - 1) / step,
+                                                                 1 + (height - 1) / step);
+    }
+    return result;
+}
+
+void SURFBuild(const std::array<gls::image<float>::unique_ptr, 4>& sum,
+               const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
+               const std::vector<gls::image<float>::unique_ptr>& dets,
+               const std::vector<gls::image<float>::unique_ptr>& traces, int nOctaves,
+               int nOctaveLayers) {
+    int N = (int)sizes.size();
+    std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
+
+    ThreadPool threadPool(8);
+
+    const int layers = nOctaveLayers + 2;
+
+    assert(nOctaves * layers == N);
+
+    for (int octave = 0; octave < nOctaves; octave++) {
+        for (int layer = 0; layer < layers; layer++) {
+            const int i = octave * layers + layer;
+            /*
+                 RANSAC interior point ratio - number of loops: 121 150 39
+                  Transformation matrix parameter:
+                 0.989685 0.027618 84.000000
+                -0.030334 0.993164 119.187500
+                -0.000002 -0.000002 1
+             */
+            threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, i]() {
+                calcLayerDetAndTrace(*sum[0], sizes[i], sampleSteps[i], dets[i].get(),
+                                     traces[i].get());
+            });
+        }
+    }
+}
+
+void SURFFind(const gls::image<float>& sum, const std::vector<gls::image<float>::unique_ptr>& dets,
+              const std::vector<gls::image<float>::unique_ptr>& traces,
+              const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
+              const std::vector<int>& middleIndices, std::vector<KeyPoint>* keypoints,
+              int nOctaveLayers, float hessianThreshold) {
+    std::mutex keypointsMutex;
+    ThreadPool threadPool(8);
+
+    int M = (int)middleIndices.size();
+    std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
+    for (int i = 0; i < M; i++) {
+        const int layer = middleIndices[i];
+        const int octave = i / nOctaveLayers;
+
+        threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, &keypoints, &keypointsMutex,
+                            layer, octave, hessianThreshold]() {
+            auto dets0 = dets[layer - 1].get();
             auto dets1 = dets[layer].get();
-            auto dets2 = dets[layer+1].get();
+            auto dets2 = dets[layer + 1].get();
 
             auto traceImage = traces[layer].get();
 
-            findMaximaInLayer(sum.width - 1, sum.height - 1, { dets0, dets1, dets2 },
-                              *traceImage, { sizes[layer-1], sizes[layer], sizes[layer+1] },
-                              keypoints, octave, hessianThreshold, sampleSteps[layer], keypointsMutex); });
-        }
+            findMaximaInLayer(sum.width - 1, sum.height - 1, {dets0, dets1, dets2}, *traceImage,
+                              {sizes[layer - 1], sizes[layer], sizes[layer + 1]}, keypoints, octave,
+                              hessianThreshold, sampleSteps[layer], keypointsMutex);
+        });
+    }
+}
+
+class SURF_OpenCL : public SURF {
+   private:
+    gls::OpenCLContext* _glsContext;
+
+    const int _width;
+    const int _height;
+    const int _max_features;
+    const int _nOctaves;
+    const int _nOctaveLayers;
+    const float _hessianThreshold;
+
+    gls::cl_image_buffer_2d<float>::unique_ptr _integralInputImage = nullptr;
+    cl::Buffer _integralTmpBuffer;
+    cl::Buffer _surfHFDataBuffer;
+    cl::Buffer _keyPointsBuffer;
+
+    std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _dets;
+    std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _traces;
+
+    /* Sampling step along image x and y axes at first octave. This is doubled
+    for each additional octave. WARNING: Increasing this improves speed,
+    however keypoint extraction becomes unreliable. */
+    static const int SAMPLE_STEP0 = 1;
+
+    void calcDetAndTrace(const gls::cl_image_2d<float>& sumImage, gls::cl_image_2d<float>* detImage,
+                         gls::cl_image_2d<float>* traceImage, const int sampleStep,
+                         const DetAndTraceHaarPattern& haarPattern);
+
+    void calcDetAndTrace(const gls::cl_image_2d<float>& sumImage,
+                         const std::array<gls::cl_image_2d<float>*, 4>& detImage,
+                         const std::array<gls::cl_image_2d<float>*, 4>& traceImage,
+                         const int sampleStep,
+                         const std::array<DetAndTraceHaarPattern, 4>& haarPattern);
+
+    void findMaximaInLayer(const std::array<const gls::cl_image_2d<float>*, 3>& dets,
+                           const gls::cl_image_2d<float>& traceImage,
+                           const std::array<int, 3>& sizes, int octave, float hessianThreshold,
+                           int sampleStep);
+
+    void Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
+               const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
+               const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
+               const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces);
+
+    void Find(const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
+              const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces,
+              const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
+              const std::vector<int>& middleIndices, std::vector<KeyPoint>* keypoints,
+              int nOctaveLayers, float hessianThreshold);
+
+    void fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
+                             std::vector<KeyPoint>* keypoints, int nOctaves, int nOctaveLayers,
+                             float hessianThreshold);
+
+   public:
+    SURF_OpenCL(gls::OpenCLContext* glsContext, int width, int height, int max_features = -1,
+                int nOctaves = 4, int nOctaveLayers = 2, float hessianThreshold = 0.02);
+
+    void integral(const gls::image<float>& img,
+                  const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum) override;
+
+    void detect(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& integralSum,
+                std::vector<KeyPoint>* keypoints) override {
+        fastHessianDetector(integralSum, keypoints, _nOctaves, _nOctaveLayers, _hessianThreshold);
     }
 
-    class SURF_OpenCL : public SURF
-    {
-    private:
-        gls::OpenCLContext *_glsContext;
-
-        const int _width;
-        const int _height;
-        const int _max_features;
-        const int _nOctaves;
-        const int _nOctaveLayers;
-        const float _hessianThreshold;
-
-        gls::cl_image_buffer_2d<float>::unique_ptr _integralInputImage = nullptr;
-        cl::Buffer _integralTmpBuffer;
-        cl::Buffer _surfHFDataBuffer;
-        cl::Buffer _keyPointsBuffer;
-
-        std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _dets;
-        std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _traces;
-
-        /* Sampling step along image x and y axes at first octave. This is doubled
-        for each additional octave. WARNING: Increasing this improves speed,
-        however keypoint extraction becomes unreliable. */
-        static const int SAMPLE_STEP0 = 1;
-
-        void calcDetAndTrace(const gls::cl_image_2d<float> &sumImage, gls::cl_image_2d<float> *detImage,
-                             gls::cl_image_2d<float> *traceImage, const int sampleStep,
-                             const DetAndTraceHaarPattern &haarPattern);
-
-        void calcDetAndTrace(const gls::cl_image_2d<float> &sumImage,
-                             const std::array<gls::cl_image_2d<float> *, 4> &detImage,
-                             const std::array<gls::cl_image_2d<float> *, 4> &traceImage, const int sampleStep,
-                             const std::array<DetAndTraceHaarPattern, 4> &haarPattern);
-
-        void findMaximaInLayer(const std::array<const gls::cl_image_2d<float> *, 3> &dets,
-                               const gls::cl_image_2d<float> &traceImage, const std::array<int, 3> &sizes, int octave,
-                               float hessianThreshold, int sampleStep);
-
-        void Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum, const std::vector<int> &sizes,
-                   const std::vector<int> &sampleSteps, const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
-                   const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces);
-
-        void Find(const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
-                  const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces, const std::vector<int> &sizes,
-                  const std::vector<int> &sampleSteps, const std::vector<int> &middleIndices,
-                  std::vector<KeyPoint> *keypoints, int nOctaveLayers, float hessianThreshold);
-
-        void fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum,
-                                 std::vector<KeyPoint> *keypoints, int nOctaves, int nOctaveLayers, float hessianThreshold);
-
-    public:
-        SURF_OpenCL(gls::OpenCLContext *glsContext, int width, int height,
-                    int max_features = -1, int nOctaves = 4,
-                    int nOctaveLayers = 2, float hessianThreshold = 0.02);
-
-        void integral(const gls::image<float> &img, const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum) override;
-
-        void detect(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &integralSum, std::vector<KeyPoint> *keypoints) override
-        {
-            fastHessianDetector(integralSum, keypoints, _nOctaves, _nOctaveLayers, _hessianThreshold);
-        }
-
-        void detectAndCompute(const gls::image<float> &img, std::vector<KeyPoint> *keypoints,
-                              gls::image<float>::unique_ptr *_descriptors) override
-        {
-            detectAndCompute(img, keypoints, _descriptors, {1, 1});
-        }
-
-        void detectAndCompute(const gls::image<float> &img, std::vector<KeyPoint> *keypoints,
-                              gls::image<float>::unique_ptr *_descriptors, gls::size sections = {1, 1});
-
-        std::vector<DMatch> matchKeyPoints(const gls::image<float> &descriptor1, const gls::image<float> &descriptor2)
-            override;
-    };
-
-    std::unique_ptr<SURF> SURF::makeInstance(gls::OpenCLContext *glsContext, int width, int height, int max_features, int nOctaves, int nOctaveLayers, float hessianThreshold)
-    {
-        return std::make_unique<SURF_OpenCL>(glsContext, width, height, max_features, nOctaves, nOctaveLayers, hessianThreshold);
+    void detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints,
+                          gls::image<float>::unique_ptr* _descriptors) override {
+        detectAndCompute(img, keypoints, _descriptors, {1, 1});
     }
 
-    SURF_OpenCL::SURF_OpenCL(gls::OpenCLContext *glsContext, int width, int height, int max_features, int nOctaves, int nOctaveLayers, float hessianThreshold)
-        : _glsContext(glsContext),
-          _width(width),
-          _height(height),
-          _max_features(max_features),
-          _nOctaves(nOctaves),
-          _nOctaveLayers(nOctaveLayers),
-          _hessianThreshold(hessianThreshold)
-    {
-        int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
+    void detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints,
+                          gls::image<float>::unique_ptr* _descriptors, gls::size sections = {1, 1});
 
-        if (_dets.size() != nTotalLayers)
-        {
-            printf("resizing dets and traces vectors to %d\n", nTotalLayers);
-            _dets.resize(nTotalLayers);
-            _traces.resize(nTotalLayers);
-        }
+    std::vector<DMatch> matchKeyPoints(const gls::image<float>& descriptor1,
+                                       const gls::image<float>& descriptor2) override;
+};
 
-        // Allocate space for each layer
-        int index = 0, step = SAMPLE_STEP0;
+std::unique_ptr<SURF> SURF::makeInstance(gls::OpenCLContext* glsContext, int width, int height,
+                                         int max_features, int nOctaves, int nOctaveLayers,
+                                         float hessianThreshold) {
+    return std::make_unique<SURF_OpenCL>(glsContext, width, height, max_features, nOctaves,
+                                         nOctaveLayers, hessianThreshold);
+}
 
-        for (int octave = 0; octave < nOctaves; octave++)
-        {
-            for (int layer = 0; layer < nOctaveLayers + 2; layer++)
-            {
-                /* The integral image sum is one pixel bigger than the source image*/
-                if (_dets[index] == nullptr)
-                {
-                    _dets[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(), width / step,
-                                                                                    height / step);
-                    _traces[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(),
-                                                                                      width / step, height / step);
-                }
-                index++;
+SURF_OpenCL::SURF_OpenCL(gls::OpenCLContext* glsContext, int width, int height, int max_features,
+                         int nOctaves, int nOctaveLayers, float hessianThreshold)
+    : _glsContext(glsContext),
+      _width(width),
+      _height(height),
+      _max_features(max_features),
+      _nOctaves(nOctaves),
+      _nOctaveLayers(nOctaveLayers),
+      _hessianThreshold(hessianThreshold) {
+    int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
+
+    if (_dets.size() != nTotalLayers) {
+        printf("resizing dets and traces vectors to %d\n", nTotalLayers);
+        _dets.resize(nTotalLayers);
+        _traces.resize(nTotalLayers);
+    }
+
+    // Allocate space for each layer
+    int index = 0, step = SAMPLE_STEP0;
+
+    for (int octave = 0; octave < nOctaves; octave++) {
+        for (int layer = 0; layer < nOctaveLayers + 2; layer++) {
+            /* The integral image sum is one pixel bigger than the source image*/
+            if (_dets[index] == nullptr) {
+                _dets[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(
+                    _glsContext->clContext(), width / step, height / step);
+                _traces[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(
+                    _glsContext->clContext(), width / step, height / step);
             }
-            step *= 2;
+            index++;
         }
+        step *= 2;
     }
+}
 
-    void SURF_OpenCL::integral(const gls::image<float> &img,
-                               const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum)
-    {
-        static const int tileSize = 8;
+void SURF_OpenCL::integral(const gls::image<float>& img,
+                           const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum) {
+    static const int tileSize = 8;
 
-        gls::size tmpSize(((_height + tileSize - 1) / tileSize) * tileSize, ((_width + tileSize - 1) / tileSize) * tileSize);
-        if (_integralTmpBuffer.get() == 0)
-        {
-            _integralTmpBuffer = cl::Buffer(CL_MEM_READ_WRITE, tmpSize.width * tmpSize.height * sizeof(float));
-        }
-        if (_integralInputImage == nullptr)
-        {
-            _integralInputImage = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(), img.width, img.height);
-        }
-        _integralInputImage->copyPixelsFrom(img);
-
-        // Load the shader source
-        const auto program = _glsContext->loadProgram("SURF");
-
-        // Bind the kernel parameters
-        auto integral_sum_cols = cl::KernelFunctor<cl::Image2D, // src_ptr
-                                                   cl::Buffer,  // buf_ptr
-                                                   int          // buf_width
-                                                   >(program, "integral_sum_cols_image");
-
-        // Schedule the kernel on the GPU
-        integral_sum_cols(cl::EnqueueArgs(cl::NDRange(_width), cl::NDRange(tileSize)),
-                          _integralInputImage->getImage2D(),
-                          _integralTmpBuffer,
-                          tmpSize.width);
-
-        // Bind the kernel parameters
-        auto integral_sum_rows = cl::KernelFunctor<cl::Buffer,  // buf_ptr
-                                                   int,         // buf_width
-                                                   cl::Image2D, // sum0
-                                                   cl::Image2D, // sum1
-                                                   cl::Image2D, // sum2
-                                                   cl::Image2D  // sum3
-                                                   >(program, "integral_sum_rows_image");
-
-        // Schedule the kernel on the GPU
-        integral_sum_rows(cl::EnqueueArgs(cl::NDRange(_height), cl::NDRange(tileSize)),
-                          _integralTmpBuffer,
-                          tmpSize.width,
-                          sum[0]->getImage2D(),
-                          sum[1]->getImage2D(),
-                          sum[2]->getImage2D(),
-                          sum[3]->getImage2D());
+    gls::size tmpSize(((_height + tileSize - 1) / tileSize) * tileSize,
+                      ((_width + tileSize - 1) / tileSize) * tileSize);
+    if (_integralTmpBuffer.get() == 0) {
+        _integralTmpBuffer =
+            cl::Buffer(CL_MEM_READ_WRITE, tmpSize.width * tmpSize.height * sizeof(float));
     }
+    if (_integralInputImage == nullptr) {
+        _integralInputImage = std::make_unique<gls::cl_image_buffer_2d<float>>(
+            _glsContext->clContext(), img.width, img.height);
+    }
+    _integralInputImage->copyPixelsFrom(img);
 
-    void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float> &sumImage,
-                                      gls::cl_image_2d<float> *detImage,
-                                      gls::cl_image_2d<float> *traceImage,
-                                      const int sampleStep,
-                                      const DetAndTraceHaarPattern &haarPattern)
-    {
-        // Load the shader source
-        const auto program = _glsContext->loadProgram("SURF");
+    // Load the shader source
+    const auto program = _glsContext->loadProgram("SURF");
 
-        // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D, // sumImage
-                                        cl::Image2D, // detImage
-                                        cl::Image2D, // traceImage
-                                        int,         // sampleStep
-                                        cl_float2,   // w
-                                        cl_int2,     // margin
-                                        cl::Buffer   // surfHFData
-                                        >(program, "calcDetAndTrace");
+    // Bind the kernel parameters
+    auto integral_sum_cols = cl::KernelFunctor<cl::Image2D,  // src_ptr
+                                               cl::Buffer,   // buf_ptr
+                                               int           // buf_width
+                                               >(program, "integral_sum_cols_image");
 
-        const clSurfHF surfHFData(haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
+    // Schedule the kernel on the GPU
+    integral_sum_cols(cl::EnqueueArgs(cl::NDRange(_width), cl::NDRange(tileSize)),
+                      _integralInputImage->getImage2D(), _integralTmpBuffer, tmpSize.width);
 
-        if (_surfHFDataBuffer.get() == 0)
-        {
-            _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(clSurfHF));
-        }
-        cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(clSurfHF), &surfHFData);
+    // Bind the kernel parameters
+    auto integral_sum_rows = cl::KernelFunctor<cl::Buffer,   // buf_ptr
+                                               int,          // buf_width
+                                               cl::Image2D,  // sum0
+                                               cl::Image2D,  // sum1
+                                               cl::Image2D,  // sum2
+                                               cl::Image2D   // sum3
+                                               >(program, "integral_sum_rows_image");
 
-        const auto &margin_crop = haarPattern.margin_crop;
+    // Schedule the kernel on the GPU
+    integral_sum_rows(cl::EnqueueArgs(cl::NDRange(_height), cl::NDRange(tileSize)),
+                      _integralTmpBuffer, tmpSize.width, sum[0]->getImage2D(), sum[1]->getImage2D(),
+                      sum[2]->getImage2D(), sum[3]->getImage2D());
+}
 
-        // Schedule the kernel on the GPU
-        kernel(
+void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float>& sumImage,
+                                  gls::cl_image_2d<float>* detImage,
+                                  gls::cl_image_2d<float>* traceImage, const int sampleStep,
+                                  const DetAndTraceHaarPattern& haarPattern) {
+    // Load the shader source
+    const auto program = _glsContext->loadProgram("SURF");
+
+    // Bind the kernel parameters
+    auto kernel = cl::KernelFunctor<cl::Image2D,  // sumImage
+                                    cl::Image2D,  // detImage
+                                    cl::Image2D,  // traceImage
+                                    int,          // sampleStep
+                                    cl_float2,    // w
+                                    cl_int2,      // margin
+                                    cl::Buffer    // surfHFData
+                                    >(program, "calcDetAndTrace");
+
+    const clSurfHF surfHFData(haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
+
+    if (_surfHFDataBuffer.get() == 0) {
+        _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(clSurfHF));
+    }
+    cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(clSurfHF), &surfHFData);
+
+    const auto& margin_crop = haarPattern.margin_crop;
+
+    // Schedule the kernel on the GPU
+    kernel(
 #if __APPLE__
-            gls::OpenCLContext::buildEnqueueArgs(margin_crop.width, margin_crop.height),
+        gls::OpenCLContext::buildEnqueueArgs(margin_crop.width, margin_crop.height),
 #else
-            cl::EnqueueArgs(cl::NDRange(margin_crop.width, margin_crop.height), cl::NDRange(32, 32)),
+        cl::EnqueueArgs(cl::NDRange(margin_crop.width, margin_crop.height), cl::NDRange(32, 32)),
 #endif
-            sumImage.getImage2D(), detImage->getImage2D(), traceImage->getImage2D(),
-            sampleStep, {haarPattern.Dx[0].w, haarPattern.Dxy[0].w}, {margin_crop.x, margin_crop.y}, _surfHFDataBuffer);
+        sumImage.getImage2D(), detImage->getImage2D(), traceImage->getImage2D(), sampleStep,
+        {haarPattern.Dx[0].w, haarPattern.Dxy[0].w}, {margin_crop.x, margin_crop.y},
+        _surfHFDataBuffer);
+}
+
+void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float>& sumImage,
+                                  const std::array<gls::cl_image_2d<float>*, 4>& detImage,
+                                  const std::array<gls::cl_image_2d<float>*, 4>& traceImage,
+                                  const int sampleStep,
+                                  const std::array<DetAndTraceHaarPattern, 4>& haarPattern) {
+    // Load the shader source
+    const auto program = _glsContext->loadProgram("SURF");
+
+    // Bind the kernel parameters
+    auto kernel =
+        cl::KernelFunctor<cl::Image2D,                                         // sumImage
+                          cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D,  // detImage
+                          cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D,  // traceImage
+                          cl_int,                                              // sampleStep
+                          cl_float8,                                           // w
+                          cl_int4,                                             // margin
+                          cl::Buffer                                           // surfHFData
+                          >(program, "calcDetAndTrace4");
+
+    const std::array<clSurfHF, 4> surfHFData = {
+        clSurfHF(haarPattern[0].Dx, haarPattern[0].Dy, haarPattern[0].Dxy),
+        clSurfHF(haarPattern[1].Dx, haarPattern[1].Dy, haarPattern[1].Dxy),
+        clSurfHF(haarPattern[2].Dx, haarPattern[2].Dy, haarPattern[2].Dxy),
+        clSurfHF(haarPattern[3].Dx, haarPattern[3].Dy, haarPattern[3].Dxy)};
+
+    if (_surfHFDataBuffer.get() == 0) {
+        _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(surfHFData));
     }
+    cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(surfHFData), &surfHFData);
 
-    void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float> &sumImage,
-                                      const std::array<gls::cl_image_2d<float> *, 4> &detImage,
-                                      const std::array<gls::cl_image_2d<float> *, 4> &traceImage,
-                                      const int sampleStep,
-                                      const std::array<DetAndTraceHaarPattern, 4> &haarPattern)
-    {
-        // Load the shader source
-        const auto program = _glsContext->loadProgram("SURF");
-
-        // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D,                                        // sumImage
-                                        cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D, // detImage
-                                        cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D, // traceImage
-                                        cl_int,                                             // sampleStep
-                                        cl_float8,                                          // w
-                                        cl_int4,                                            // margin
-                                        cl::Buffer                                          // surfHFData
-                                        >(program, "calcDetAndTrace4");
-
-        const std::array<clSurfHF, 4> surfHFData = {
-            clSurfHF(haarPattern[0].Dx, haarPattern[0].Dy, haarPattern[0].Dxy),
-            clSurfHF(haarPattern[1].Dx, haarPattern[1].Dy, haarPattern[1].Dxy),
-            clSurfHF(haarPattern[2].Dx, haarPattern[2].Dy, haarPattern[2].Dxy),
-            clSurfHF(haarPattern[3].Dx, haarPattern[3].Dy, haarPattern[3].Dxy)};
-
-        if (_surfHFDataBuffer.get() == 0)
-        {
-            _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(surfHFData));
-        }
-        cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(surfHFData), &surfHFData);
-
-        kernel(
+    kernel(
 #if __APPLE__
-            gls::OpenCLContext::buildEnqueueArgs(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height),
+        gls::OpenCLContext::buildEnqueueArgs(haarPattern[0].margin_crop.width,
+                                             haarPattern[0].margin_crop.height),
 #else
-            cl::EnqueueArgs(cl::NDRange(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height), cl::NDRange(32, 32)),
+        cl::EnqueueArgs(
+            cl::NDRange(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height),
+            cl::NDRange(32, 32)),
 #endif
-            sumImage.getImage2D(),
-            detImage[0]->getImage2D(), detImage[1]->getImage2D(), detImage[2]->getImage2D(), detImage[3]->getImage2D(),
-            traceImage[0]->getImage2D(), traceImage[1]->getImage2D(), traceImage[2]->getImage2D(), traceImage[3]->getImage2D(),
-            sampleStep,
-            {haarPattern[0].Dx[0].w, haarPattern[0].Dxy[0].w,
-             haarPattern[1].Dx[0].w, haarPattern[1].Dxy[0].w,
-             haarPattern[2].Dx[0].w, haarPattern[2].Dxy[0].w,
-             haarPattern[3].Dx[0].w, haarPattern[3].Dxy[0].w},
-            {haarPattern[0].margin_crop.x, haarPattern[1].margin_crop.x, haarPattern[2].margin_crop.x, haarPattern[3].margin_crop.x},
-            _surfHFDataBuffer);
-    }
+        sumImage.getImage2D(), detImage[0]->getImage2D(), detImage[1]->getImage2D(),
+        detImage[2]->getImage2D(), detImage[3]->getImage2D(), traceImage[0]->getImage2D(),
+        traceImage[1]->getImage2D(), traceImage[2]->getImage2D(), traceImage[3]->getImage2D(),
+        sampleStep,
+        {haarPattern[0].Dx[0].w, haarPattern[0].Dxy[0].w, haarPattern[1].Dx[0].w,
+         haarPattern[1].Dxy[0].w, haarPattern[2].Dx[0].w, haarPattern[2].Dxy[0].w,
+         haarPattern[3].Dx[0].w, haarPattern[3].Dxy[0].w},
+        {haarPattern[0].margin_crop.x, haarPattern[1].margin_crop.x, haarPattern[2].margin_crop.x,
+         haarPattern[3].margin_crop.x},
+        _surfHFDataBuffer);
+}
 
-    void SURF_OpenCL::Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum,
-                            const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
-                            const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
-                            const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces)
-    {
-        int N = (int)sizes.size();
-        std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
+void SURF_OpenCL::Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
+                        const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
+                        const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
+                        const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces) {
+    int N = (int)sizes.size();
+    std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
 
-        const int layers = _nOctaveLayers + 2;
+    const int layers = _nOctaveLayers + 2;
 
-        assert(_nOctaves * layers == N);
+    assert(_nOctaves * layers == N);
 
-        for (int octave = 0; octave < _nOctaves; octave++)
-        {
+    for (int octave = 0; octave < _nOctaves; octave++) {
 #if __ANDROID__
-            const int i = octave * layers;
+        const int i = octave * layers;
 
-            std::array<DetAndTraceHaarPattern, 4> haarPatterns = {
-                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]),
-                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 1], sampleSteps[i + 1]),
-                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 2], sampleSteps[i + 2]),
-                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 3], sampleSteps[i + 3])};
+        std::array<DetAndTraceHaarPattern, 4> haarPatterns = {
+            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]),
+            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 1], sampleSteps[i + 1]),
+            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 2], sampleSteps[i + 2]),
+            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 3],
+                                   sampleSteps[i + 3])};
 
 #if USE_INTEGRAL_PYRAMID
-            for (auto &haarPattern : haarPatterns)
-            {
-                // Rescale sampling points to the pyramid level
-                haarPattern.rescale(sampleSteps[i]);
-            }
-            int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2
-                                            : sampleSteps[i] == 2   ? 1
-                                                                    : 0;
-            calcDetAndTrace(*sum[idx], {dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get()},
-                            {traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get()},
-                            1 /* sampleSteps[i] */, haarPatterns);
+        for (auto& haarPattern : haarPatterns) {
+            // Rescale sampling points to the pyramid level
+            haarPattern.rescale(sampleSteps[i]);
+        }
+        int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2 : sampleSteps[i] == 2 ? 1 : 0;
+        calcDetAndTrace(
+            *sum[idx], {dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get()},
+            {traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get()},
+            1 /* sampleSteps[i] */, haarPatterns);
 #else
-            //        // Emulate the integral pyramid scaling roundoff
-            //        for (auto& haarPattern : haarPatterns) {
+        //        // Emulate the integral pyramid scaling roundoff
+        //        for (auto& haarPattern : haarPatterns) {
+        //            haarPattern.rescale(sampleSteps[i]);
+        //            haarPattern.upscale(sampleSteps[i]);
+        //        }
+
+        calcDetAndTrace(
+            *sum[0], {dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get()},
+            {traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get()},
+            sampleSteps[i], haarPatterns);
+#endif
+#else
+        for (int layer = 0; layer < layers; layer++) {
+            const int i = octave * layers + layer;
+            DetAndTraceHaarPattern haarPattern(sum[0]->width, sum[0]->height, sizes[i],
+                                               sampleSteps[i]);
+
+            //            std::cout << "DetAndTraceHaarPattern: " << sum[0]->width << ", " <<
+            //            sum[0]->height << ", " << sizes[i] << ", " << sampleSteps[i] << std::endl;
+
+#if USE_INTEGRAL_PYRAMID
+            // Rescale sampling points to the pyramid level
+            haarPattern.rescale(sampleSteps[i]);
+
+            const int idx =
+                sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2 : sampleSteps[i] == 2 ? 1 : 0;
+            calcDetAndTrace(*sum[idx], dets[i].get(), traces[i].get(), 1, haarPattern);
+#else
+            //            // Emulate the integral pyramid scaling roundoff
             //            haarPattern.rescale(sampleSteps[i]);
             //            haarPattern.upscale(sampleSteps[i]);
-            //        }
 
-            calcDetAndTrace(*sum[0], {dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get()},
-                            {traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get()},
-                            sampleSteps[i], haarPatterns);
-#endif
-#else
-            for (int layer = 0; layer < layers; layer++)
-            {
-                const int i = octave * layers + layer;
-                DetAndTraceHaarPattern haarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]);
-
-                //            std::cout << "DetAndTraceHaarPattern: " << sum[0]->width << ", " << sum[0]->height << ", " << sizes[i] << ", " << sampleSteps[i] << std::endl;
-
-#if USE_INTEGRAL_PYRAMID
-                // Rescale sampling points to the pyramid level
-                haarPattern.rescale(sampleSteps[i]);
-
-                const int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2
-                                                      : sampleSteps[i] == 2   ? 1
-                                                                              : 0;
-                calcDetAndTrace(*sum[idx], dets[i].get(), traces[i].get(), 1, haarPattern);
-#else
-                //            // Emulate the integral pyramid scaling roundoff
-                //            haarPattern.rescale(sampleSteps[i]);
-                //            haarPattern.upscale(sampleSteps[i]);
-
-                calcDetAndTrace(*sum[0], dets[i].get(), traces[i].get(), sampleSteps[i], haarPattern);
-#endif
-            }
+            calcDetAndTrace(*sum[0], dets[i].get(), traces[i].get(), sampleSteps[i], haarPattern);
 #endif
         }
+#endif
+    }
+}
+
+/*
+ * Find the maxima in the determinant of the Hessian in a layer of the
+ * scale-space pyramid
+ */
+
+typedef struct KeyPointMaxima {
+    static constexpr int MaxCount = 64000;
+    int count;
+    KeyPoint keyPoints[MaxCount];
+} KeyPointMaxima;
+
+void SURF_OpenCL::findMaximaInLayer(const std::array<const gls::cl_image_2d<float>*, 3>& dets,
+                                    const gls::cl_image_2d<float>& traceImage,
+                                    const std::array<int, 3>& sizes, int octave,
+                                    float hessianThreshold, int sampleStep) {
+    // Load the shader source
+    const auto program = _glsContext->loadProgram("SURF");
+
+    // Bind the kernel parameters
+    auto kernel = cl::KernelFunctor<cl::Image2D,  // detImage0
+                                    cl::Image2D,  // detImage1
+                                    cl::Image2D,  // detImage2
+                                    cl::Image2D,  // traceImage
+                                    cl_int3,      // sizes
+                                    cl::Buffer,   // keypoints
+                                    int,          // margin
+                                    int,          // octave
+                                    float,        // hessianThreshold
+                                    int           // sampleStep
+                                    >(program, "findMaximaInLayer");
+
+    if (_keyPointsBuffer() == 0) {
+        _keyPointsBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(KeyPointMaxima));
     }
 
-    /*
-     * Find the maxima in the determinant of the Hessian in a layer of the
-     * scale-space pyramid
-     */
+    const int layer_height = _height / sampleStep;
+    const int layer_width = _width / sampleStep;
 
-    typedef struct KeyPointMaxima
-    {
-        static constexpr int MaxCount = 64000;
-        int count;
-        KeyPoint keyPoints[MaxCount];
-    } KeyPointMaxima;
+    // Ignore pixels without a 3x3x3 neighbourhood in the layer above
+    const int margin = (sizes[2] / 2) / sampleStep + 1;
 
-    void SURF_OpenCL::findMaximaInLayer(const std::array<const gls::cl_image_2d<float> *, 3> &dets,
-                                        const gls::cl_image_2d<float> &traceImage,
-                                        const std::array<int, 3> &sizes,
-                                        int octave, float hessianThreshold, int sampleStep)
-    {
-        // Load the shader source
-        const auto program = _glsContext->loadProgram("SURF");
-
-        // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D, // detImage0
-                                        cl::Image2D, // detImage1
-                                        cl::Image2D, // detImage2
-                                        cl::Image2D, // traceImage
-                                        cl_int3,     // sizes
-                                        cl::Buffer,  // keypoints
-                                        int,         // margin
-                                        int,         // octave
-                                        float,       // hessianThreshold
-                                        int          // sampleStep
-                                        >(program, "findMaximaInLayer");
-
-        if (_keyPointsBuffer() == 0)
-        {
-            _keyPointsBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(KeyPointMaxima));
-        }
-
-        const int layer_height = _height / sampleStep;
-        const int layer_width = _width / sampleStep;
-
-        // Ignore pixels without a 3x3x3 neighbourhood in the layer above
-        const int margin = (sizes[2] / 2) / sampleStep + 1;
-
-        // Schedule the kernel on the GPU
-        kernel(
+    // Schedule the kernel on the GPU
+    kernel(
 #if __APPLE__
-            gls::OpenCLContext::buildEnqueueArgs(layer_width - 2 * margin, layer_height - 2 * margin),
+        gls::OpenCLContext::buildEnqueueArgs(layer_width - 2 * margin, layer_height - 2 * margin),
 #else
-            cl::EnqueueArgs(cl::NDRange(layer_width - 2 * margin, layer_height - 2 * margin), cl::NDRange(32, 32)),
+        cl::EnqueueArgs(cl::NDRange(layer_width - 2 * margin, layer_height - 2 * margin),
+                        cl::NDRange(32, 32)),
 #endif
-            dets[0]->getImage2D(), dets[1]->getImage2D(), dets[2]->getImage2D(),
-            traceImage.getImage2D(),
-            {sizes[0], sizes[1], sizes[2]}, _keyPointsBuffer,
-            margin, octave, hessianThreshold, sampleStep);
+        dets[0]->getImage2D(), dets[1]->getImage2D(), dets[2]->getImage2D(),
+        traceImage.getImage2D(), {sizes[0], sizes[1], sizes[2]}, _keyPointsBuffer, margin, octave,
+        hessianThreshold, sampleStep);
+}
+
+void SURF_OpenCL::Find(const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
+                       const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces,
+                       const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
+                       const std::vector<int>& middleIndices, std::vector<KeyPoint>* keypoints,
+                       int nOctaveLayers, float hessianThreshold) {
+    int M = (int)middleIndices.size();
+    std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
+    for (int i = 0; i < M; i++) {
+        const int layer = middleIndices[i];
+        const int octave = i / nOctaveLayers;
+
+        const std::array<const gls::cl_image_2d<float>*, 3> detImages = {
+            dets[layer - 1].get(), dets[layer].get(), dets[layer + 1].get()};
+
+        const auto traceImage = traces[layer].get();
+
+        findMaximaInLayer(detImages, *traceImage,
+                          {sizes[layer - 1], sizes[layer], sizes[layer + 1]}, octave,
+                          hessianThreshold, sampleSteps[layer]);
     }
 
-    void SURF_OpenCL::Find(const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
-                           const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces,
-                           const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
-                           const std::vector<int> &middleIndices, std::vector<KeyPoint> *keypoints,
-                           int nOctaveLayers, float hessianThreshold)
-    {
-        int M = (int)middleIndices.size();
-        std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
-        for (int i = 0; i < M; i++)
-        {
-            const int layer = middleIndices[i];
-            const int octave = i / nOctaveLayers;
+    // Collect results
+    const auto keyPointMaxima = (KeyPointMaxima*)cl::enqueueMapBuffer(
+        _keyPointsBuffer, true, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(KeyPointMaxima));
 
-            const std::array<const gls::cl_image_2d<float> *, 3> detImages = {
-                dets[layer - 1].get(),
-                dets[layer].get(),
-                dets[layer + 1].get()};
+    std::cout << "keyPointMaxima: " << keyPointMaxima->count << std::endl;
+    std::span<KeyPoint> newElements(keyPointMaxima->keyPoints,
+                                    std::min(keyPointMaxima->count, KeyPointMaxima::MaxCount));
+    keypoints->insert(end(*keypoints), begin(newElements), end(newElements));
 
-            const auto traceImage = traces[layer].get();
+    // Reset count
+    keyPointMaxima->count = 0;
 
-            findMaximaInLayer(detImages, *traceImage,
-                              {sizes[layer - 1], sizes[layer], sizes[layer + 1]},
-                              octave, hessianThreshold, sampleSteps[layer]);
-        }
+    cl::enqueueUnmapMemObject(_keyPointsBuffer, (void*)keyPointMaxima);
+}
 
-        // Collect results
-        const auto keyPointMaxima = (KeyPointMaxima *)cl::enqueueMapBuffer(_keyPointsBuffer, true, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(KeyPointMaxima));
-
-        std::cout << "keyPointMaxima: " << keyPointMaxima->count << std::endl;
-        std::span<KeyPoint> newElements(keyPointMaxima->keyPoints, std::min(keyPointMaxima->count, KeyPointMaxima::MaxCount));
-        keypoints->insert(end(*keypoints), begin(newElements), end(newElements));
-
-        // Reset count
-        keyPointMaxima->count = 0;
-
-        cl::enqueueUnmapMemObject(_keyPointsBuffer, (void *)keyPointMaxima);
+struct KeypointGreater {
+    inline bool operator()(const KeyPoint& kp1, const KeyPoint& kp2) const {
+        if (kp1.response > kp2.response) return true;
+        if (kp1.response < kp2.response) return false;
+        if (kp1.size > kp2.size) return true;
+        if (kp1.size < kp2.size) return false;
+        if (kp1.octave > kp2.octave) return true;
+        if (kp1.octave < kp2.octave) return false;
+        if (kp1.pt.y < kp2.pt.y) return false;
+        if (kp1.pt.y > kp2.pt.y) return true;
+        return kp1.pt.x < kp2.pt.x;
     }
+};
 
-    struct KeypointGreater
-    {
-        inline bool operator()(const KeyPoint &kp1, const KeyPoint &kp2) const
-        {
-            if (kp1.response > kp2.response)
-                return true;
-            if (kp1.response < kp2.response)
-                return false;
-            if (kp1.size > kp2.size)
-                return true;
-            if (kp1.size < kp2.size)
-                return false;
-            if (kp1.octave > kp2.octave)
-                return true;
-            if (kp1.octave < kp2.octave)
-                return false;
-            if (kp1.pt.y < kp2.pt.y)
-                return false;
-            if (kp1.pt.y > kp2.pt.y)
-                return true;
-            return kp1.pt.x < kp2.pt.x;
-        }
-    };
+void SURF_OpenCL::fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
+                                      std::vector<KeyPoint>* keypoints, int nOctaves,
+                                      int nOctaveLayers, float hessianThreshold) {
+    int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
+    int nMiddleLayers = nOctaveLayers * nOctaves;
 
-    void SURF_OpenCL::fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum,
-                                          std::vector<KeyPoint> *keypoints,
-                                          int nOctaves, int nOctaveLayers, float hessianThreshold)
-    {
-        int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
-        int nMiddleLayers = nOctaveLayers * nOctaves;
+    std::vector<int> sizes(nTotalLayers);
+    std::vector<int> sampleSteps(nTotalLayers);
+    std::vector<int> middleIndices(nMiddleLayers);
 
-        std::vector<int> sizes(nTotalLayers);
-        std::vector<int> sampleSteps(nTotalLayers);
-        std::vector<int> middleIndices(nMiddleLayers);
+    // Calculate properties of each layer
+    int index = 0, middleIndex = 0, step = SAMPLE_STEP0;
 
-        // Calculate properties of each layer
-        int index = 0, middleIndex = 0, step = SAMPLE_STEP0;
+    for (int octave = 0; octave < nOctaves; octave++) {
+        for (int layer = 0; layer < nOctaveLayers + 2; layer++) {
+            sizes[index] = (SURF_HAAR_SIZE0 + SURF_HAAR_SIZE_INC * layer) << octave;
+            sampleSteps[index] = step;
 
-        for (int octave = 0; octave < nOctaves; octave++)
-        {
-            for (int layer = 0; layer < nOctaveLayers + 2; layer++)
-            {
-                sizes[index] = (SURF_HAAR_SIZE0 + SURF_HAAR_SIZE_INC * layer) << octave;
-                sampleSteps[index] = step;
-
-                if (0 < layer && layer <= nOctaveLayers)
-                {
-                    middleIndices[middleIndex++] = index;
-                }
-                index++;
+            if (0 < layer && layer <= nOctaveLayers) {
+                middleIndices[middleIndex++] = index;
             }
-            step *= 2;
+            index++;
         }
-
-        auto t_start = std::chrono::high_resolution_clock::now();
-
-        // Calculate hessian determinant and trace samples in each layer
-        Build(sum, sizes, sampleSteps, _dets, _traces);
-
-        // Find maxima in the determinant of the hessian
-        Find(_dets, _traces, sizes, sampleSteps, middleIndices, keypoints, nOctaveLayers, hessianThreshold);
-
-        auto t_end = std::chrono::high_resolution_clock::now();
-        double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-        printf("Features Finding Time: %.2fms\n", elapsed_time_ms);
-
-        sort(keypoints->begin(), keypoints->end(), KeypointGreater());
+        step *= 2;
     }
 
-    static inline float L2Norm(const float *p1, const float *p2, int n)
-    {
-        float sum = 0;
-        for (int i = 0; i < n; i++)
-        {
-            float diff = p1[i] - p2[i];
-            sum += diff * diff;
-        }
-        return sqrtf(sum);
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    // Calculate hessian determinant and trace samples in each layer
+    Build(sum, sizes, sampleSteps, _dets, _traces);
+
+    // Find maxima in the determinant of the hessian
+    Find(_dets, _traces, sizes, sampleSteps, middleIndices, keypoints, nOctaveLayers,
+         hessianThreshold);
+
+    auto t_end = std::chrono::high_resolution_clock::now();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+    printf("Features Finding Time: %.2fms\n", elapsed_time_ms);
+
+    sort(keypoints->begin(), keypoints->end(), KeypointGreater());
+}
+
+static inline float L2Norm(const float* p1, const float* p2, int n) {
+    float sum = 0;
+    for (int i = 0; i < n; i++) {
+        float diff = p1[i] - p2[i];
+        sum += diff * diff;
     }
+    return sqrtf(sum);
+}
 
 #ifdef __APPLE__
-    typedef std::chrono::steady_clock::time_point time_point;
+typedef std::chrono::steady_clock::time_point time_point;
 #elif __linux__
-    typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point;
+typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point;
 #else
-    typedef std::chrono::system_clock::time_point time_point;
+typedef std::chrono::system_clock::time_point time_point;
 #endif
 
-    double timeDiff(time_point t_start, time_point t_end)
-    {
-        return std::chrono::duration<double, std::milli>(t_end - t_start).count();
+double timeDiff(time_point t_start, time_point t_end) {
+    return std::chrono::duration<double, std::milli>(t_end - t_start).count();
+}
+
+static bool keypointsAvailable(const std::vector<size_t>& kptIndices,
+                               const std::vector<size_t>& kptSizes) {
+    for (int i = 0; i < kptIndices.size(); i++) {
+        if (kptIndices[i] < kptSizes[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int maxKeypointIndex(
+    const std::vector<size_t>& kptIndices,
+    const std::vector<std::unique_ptr<std::vector<KeyPoint>>>& allKeypoints) {
+    int maxIndex = -1;
+    for (int i = 0; i < kptIndices.size(); i++) {
+        if (kptIndices[i] < allKeypoints[i]->size()) {
+            maxIndex = i;
+        }
+    }
+    for (int i = maxIndex + 1; i < kptIndices.size(); i++) {
+        if (kptIndices[i] < allKeypoints[i]->size() &&
+            KeypointGreater()((*allKeypoints[i])[kptIndices[i]],
+                              (*allKeypoints[maxIndex])[kptIndices[maxIndex]])) {
+            maxIndex = i;
+        }
+    }
+    return maxIndex;
+}
+
+// Merge individually sorted keypoint vectors into a single keypoint vector
+static void mergeKeypoints(const std::vector<std::unique_ptr<std::vector<KeyPoint>>>& allKeypoints,
+                           std::vector<KeyPoint>* keypoints,
+                           const std::vector<gls::image<float>::unique_ptr>& allDescriptors,
+                           gls::image<float>::unique_ptr* descriptors) {
+    // Find out how many keypoints we have
+    int keypointsCount = 0;
+    for (const auto& kps : allKeypoints) {
+        keypointsCount += kps->size();
     }
 
-    static bool keypointsAvailable(const std::vector<size_t> &kptIndices,
-                                   const std::vector<size_t> &kptSizes)
-    {
-        for (int i = 0; i < kptIndices.size(); i++)
-        {
-            if (kptIndices[i] < kptSizes[i])
-            {
-                return true;
-            }
+    // Make sure we have corresponding descriptors for all keypoints
+    if (descriptors) {
+        assert(allKeypoints.size() == allDescriptors.size());
+
+        int descriptorsCount = 0;
+        for (const auto& d : allDescriptors) {
+            descriptorsCount += d->height;
         }
-        return false;
+        assert(keypointsCount == descriptorsCount);
     }
 
-    static int maxKeypointIndex(const std::vector<size_t> &kptIndices,
-                                const std::vector<std::unique_ptr<std::vector<KeyPoint>>> &allKeypoints)
-    {
-        int maxIndex = -1;
-        for (int i = 0; i < kptIndices.size(); i++)
-        {
-            if (kptIndices[i] < allKeypoints[i]->size())
-            {
-                maxIndex = i;
-            }
-        }
-        for (int i = maxIndex + 1; i < kptIndices.size(); i++)
-        {
-            if (kptIndices[i] < allKeypoints[i]->size() &&
-                KeypointGreater()((*allKeypoints[i])[kptIndices[i]],
-                                  (*allKeypoints[maxIndex])[kptIndices[maxIndex]]))
-            {
-                maxIndex = i;
-            }
-        }
-        return maxIndex;
+    // Allocate space for the result
+    keypoints->clear();
+    keypoints->resize(keypointsCount);
+
+    if (descriptors != nullptr) {
+        *descriptors = std::make_unique<gls::image<float>>(64, keypointsCount);
     }
 
-    // Merge individually sorted keypoint vectors into a single keypoint vector
-    static void mergeKeypoints(const std::vector<std::unique_ptr<std::vector<KeyPoint>>> &allKeypoints,
-                               std::vector<KeyPoint> *keypoints,
-                               const std::vector<gls::image<float>::unique_ptr> &allDescriptors,
-                               gls::image<float>::unique_ptr *descriptors)
-    {
-        // Find out how many keypoints we have
-        int keypointsCount = 0;
-        for (const auto &kps : allKeypoints)
-        {
-            keypointsCount += kps->size();
-        }
-
-        // Make sure we have corresponding descriptors for all keypoints
-        if (descriptors)
-        {
-            assert(allKeypoints.size() == allDescriptors.size());
-
-            int descriptorsCount = 0;
-            for (const auto &d : allDescriptors)
-            {
-                descriptorsCount += d->height;
-            }
-            assert(keypointsCount == descriptorsCount);
-        }
-
-        // Allocate space for the result
-        keypoints->clear();
-        keypoints->resize(keypointsCount);
-
-        if (descriptors != nullptr)
-        {
-            *descriptors = std::make_unique<gls::image<float>>(64, keypointsCount);
-        }
-
-        std::vector<size_t> kptIndices(allKeypoints.size());
-        std::vector<size_t> kptSizes(allKeypoints.size());
-        for (int i = 0; i < allKeypoints.size(); i++)
-        {
-            kptIndices[i] = 0;
-            kptSizes[i] = allKeypoints[i]->size();
-        }
-
-        int outIndex = 0;
-        while (keypointsAvailable(kptIndices, kptSizes))
-        {
-            assert(outIndex < keypointsCount);
-
-            // Find max keypoint index
-            int maxIndex = maxKeypointIndex(kptIndices, allKeypoints);
-
-            // Copy keypoint to output
-            (*keypoints)[outIndex] = (*allKeypoints[maxIndex])[kptIndices[maxIndex]];
-
-            // Copy descriptor to output
-            if (descriptors != nullptr)
-            {
-                float *outPtr = (**descriptors)[outIndex];
-                float *descPtr = (*allDescriptors[maxIndex])[(int)kptIndices[maxIndex]];
-
-                memcpy(outPtr, descPtr, 64 * sizeof(float));
-            }
-            kptIndices[maxIndex]++;
-            outIndex++;
-        }
-
-        assert(outIndex == keypointsCount);
+    std::vector<size_t> kptIndices(allKeypoints.size());
+    std::vector<size_t> kptSizes(allKeypoints.size());
+    for (int i = 0; i < allKeypoints.size(); i++) {
+        kptIndices[i] = 0;
+        kptSizes[i] = allKeypoints[i]->size();
     }
 
-    void SURF_OpenCL::detectAndCompute(const gls::image<float> &img,
-                                       std::vector<KeyPoint> *keypoints,
-                                       gls::image<float>::unique_ptr *descriptors,
-                                       gls::size sections)
-    {
-        std::vector<gls::rectangle> tiles(sections.width * sections.height);
+    int outIndex = 0;
+    while (keypointsAvailable(kptIndices, kptSizes)) {
+        assert(outIndex < keypointsCount);
 
-        const int tile_width = img.width / sections.width;
-        const int tile_height = img.height / sections.height;
+        // Find max keypoint index
+        int maxIndex = maxKeypointIndex(kptIndices, allKeypoints);
 
-        std::cout << "Tile size: " << tile_width << " x " << tile_height << std::endl;
+        // Copy keypoint to output
+        (*keypoints)[outIndex] = (*allKeypoints[maxIndex])[kptIndices[maxIndex]];
 
-        // TODO: Add a skirt overlap between tiles
-        int y_pos = 0;
-        for (int j = 0; j < sections.height; j++)
-        {
-            int x_pos = 0;
-            for (int i = 0; i < sections.width; i++)
-            {
-                tiles[j * sections.width + i] = gls::rectangle({x_pos, y_pos, tile_width, tile_height});
-                x_pos += tile_width;
-            }
-            y_pos += tile_height;
+        // Copy descriptor to output
+        if (descriptors != nullptr) {
+            float* outPtr = (**descriptors)[outIndex];
+            float* descPtr = (*allDescriptors[maxIndex])[(int)kptIndices[maxIndex]];
+
+            memcpy(outPtr, descPtr, 64 * sizeof(float));
+        }
+        kptIndices[maxIndex]++;
+        outIndex++;
+    }
+
+    assert(outIndex == keypointsCount);
+}
+
+void SURF_OpenCL::detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints,
+                                   gls::image<float>::unique_ptr* descriptors, gls::size sections) {
+    std::vector<gls::rectangle> tiles(sections.width * sections.height);
+
+    const int tile_width = img.width / sections.width;
+    const int tile_height = img.height / sections.height;
+
+    std::cout << "Tile size: " << tile_width << " x " << tile_height << std::endl;
+
+    // TODO: Add a skirt overlap between tiles
+    int y_pos = 0;
+    for (int j = 0; j < sections.height; j++) {
+        int x_pos = 0;
+        for (int i = 0; i < sections.width; i++) {
+            tiles[j * sections.width + i] = gls::rectangle({x_pos, y_pos, tile_width, tile_height});
+            x_pos += tile_width;
+        }
+        y_pos += tile_height;
+    }
+
+    std::vector<gls::image<float>::unique_ptr> allDescriptors;
+    std::vector<std::unique_ptr<std::vector<KeyPoint>>> allKeypoints;
+
+    auto sum = sumImageStack<float>(_glsContext->clContext(), tile_width + 1, tile_height + 1);
+
+    for (const auto& tile : tiles) {
+        const auto tileImage = gls::image<float>(img, tile);
+
+        integral(tileImage, sum);
+
+        auto tileKeypoints = std::make_unique<std::vector<KeyPoint>>();
+
+        fastHessianDetector(sum, tileKeypoints.get(), _nOctaves, _nOctaveLayers, _hessianThreshold);
+
+        // Limit the max number of feature points
+        if (tileKeypoints->size() > _max_features) {
+            printf("detectAndCompute - dropping: %d features out of %d\n",
+                   (int)tileKeypoints->size() - _max_features, (int)tileKeypoints->size());
+            tileKeypoints->erase(tileKeypoints->begin() + _max_features, tileKeypoints->end());
         }
 
-        std::vector<gls::image<float>::unique_ptr> allDescriptors;
-        std::vector<std::unique_ptr<std::vector<KeyPoint>>> allKeypoints;
+        int N = (int)tileKeypoints->size();
 
-        auto sum = sumImageStack<float>(_glsContext->clContext(), tile_width + 1, tile_height + 1);
+        std::cout << "tileKeypoints: " << N << std::endl;
 
-        for (const auto &tile : tiles)
-        {
-            const auto tileImage = gls::image<float>(img, tile);
+        auto tileDescriptors =
+            descriptors != nullptr ? std::make_unique<gls::image<float>>(64, N) : nullptr;
 
-            integral(tileImage, sum);
+        auto t_start_descriptor = std::chrono::high_resolution_clock::now();
 
-            auto tileKeypoints = std::make_unique<std::vector<KeyPoint>>();
+        const auto integralSumCpu = sum[0]->mapImage(CL_MAP_READ);
 
-            fastHessianDetector(sum, tileKeypoints.get(), _nOctaves, _nOctaveLayers, _hessianThreshold);
-
-            // Limit the max number of feature points
-            if (tileKeypoints->size() > _max_features)
-            {
-                printf("detectAndCompute - dropping: %d features out of %d\n", (int)tileKeypoints->size() - _max_features, (int)tileKeypoints->size());
-                tileKeypoints->erase(tileKeypoints->begin() + _max_features, tileKeypoints->end());
-            }
-
-            int N = (int)tileKeypoints->size();
-
-            std::cout << "tileKeypoints: " << N << std::endl;
-
-            auto tileDescriptors = descriptors != nullptr ? std::make_unique<gls::image<float>>(64, N) : nullptr;
-
-            auto t_start_descriptor = std::chrono::high_resolution_clock::now();
-
-            const auto integralSumCpu = sum[0]->mapImage(CL_MAP_READ);
-
-            // we call SURFInvoker in any case, even if we do not need descriptors,
-            // since it computes orientation of each feature.
-            descriptor(tileImage, integralSumCpu, tileKeypoints.get(), descriptors != nullptr ? tileDescriptors.get() : nullptr);
+        // we call SURFInvoker in any case, even if we do not need descriptors,
+        // since it computes orientation of each feature.
+        descriptor(tileImage, integralSumCpu, tileKeypoints.get(),
+                   descriptors != nullptr ? tileDescriptors.get() : nullptr);
 
 #if DEBUG_RECONSTRUCTED_IMAGE
-            static int count = 0;
-            gls::image<gls::luma_pixel> reconstructed(integralSumCpu.width - 1, integralSumCpu.height - 1);
-            reconstructed.apply([&integralSumCpu](gls::luma_pixel *p, int x, int y)
-                                {
-            float value = integralRectangle(integralSumCpu[y+1][x+1], integralSumCpu[y+1][x], integralSumCpu[y][x+1], integralSumCpu[y][x]);
-            *p = std::clamp((int) (255 * value), 0, 255); });
-            reconstructed.write_png_file("/Users/fabio/reconstructed" + std::to_string(count++) + ".png");
+        static int count = 0;
+        gls::image<gls::luma_pixel> reconstructed(integralSumCpu.width - 1,
+                                                  integralSumCpu.height - 1);
+        reconstructed.apply([&integralSumCpu](gls::luma_pixel* p, int x, int y) {
+            float value = integralRectangle(integralSumCpu[y + 1][x + 1], integralSumCpu[y + 1][x],
+                                            integralSumCpu[y][x + 1], integralSumCpu[y][x]);
+            *p = std::clamp((int)(255 * value), 0, 255);
+        });
+        reconstructed.write_png_file("/Users/fabio/reconstructed" + std::to_string(count++) +
+                                     ".png");
 #endif
-            sum[0]->unmapImage(integralSumCpu);
+        sum[0]->unmapImage(integralSumCpu);
 
-            // Translate tile keypoints to their full image locations
-            for (auto &kp : *tileKeypoints)
-            {
-                kp.pt += Point2f(tile.x, tile.y);
+        // Translate tile keypoints to their full image locations
+        for (auto& kp : *tileKeypoints) {
+            kp.pt += Point2f(tile.x, tile.y);
+        }
+        allKeypoints.push_back(std::move(tileKeypoints));
+
+        if (descriptors != nullptr) {
+            allDescriptors.push_back(std::move(tileDescriptors));
+        }
+
+        auto t_end_descriptor = std::chrono::high_resolution_clock::now();
+        printf("--> descriptor Time: %.2fms\n", timeDiff(t_start_descriptor, t_end_descriptor));
+    }
+
+    mergeKeypoints(allKeypoints, keypoints, allDescriptors, descriptors);
+
+    std::cout << "Collected " << keypoints->size() << " keypoints and " << (**descriptors).height
+              << " descriptors" << std::endl;
+}
+
+void matchKeyPoints(const gls::image<float>& descriptor1, const gls::image<float>& descriptor2,
+                    std::vector<DMatch>* matchedPoints) {
+    for (int i = 0; i < descriptor1.height; i++) {
+        const float* p1 = descriptor1[i];
+        float distance_min = 100;
+        int j_min = 0, i_min = 0;
+
+        for (int j = 0; j < descriptor2.height; j++) {
+            const float* p2 = descriptor2[j];
+            // calculate distance
+            float distance_t = L2Norm(p1, p2, 64);
+            if (distance_t < distance_min) {
+                distance_min = distance_t;
+                i_min = i;
+                j_min = j;
             }
-            allKeypoints.push_back(std::move(tileKeypoints));
-
-            if (descriptors != nullptr)
-            {
-                allDescriptors.push_back(std::move(tileDescriptors));
-            }
-
-            auto t_end_descriptor = std::chrono::high_resolution_clock::now();
-            printf("--> descriptor Time: %.2fms\n", timeDiff(t_start_descriptor, t_end_descriptor));
         }
 
-        mergeKeypoints(allKeypoints, keypoints, allDescriptors, descriptors);
+        matchedPoints->push_back(DMatch(i_min, j_min, distance_min));
+    }
+}
 
-        std::cout << "Collected " << keypoints->size() << " keypoints and " << (**descriptors).height << " descriptors" << std::endl;
+template <typename T>
+cl::Buffer bufferFromImage(const gls::image<T>& source) {
+    int bufferSize = source.stride * source.height * sizeof(float);
+    auto buffer = cl::Buffer(CL_MEM_READ_WRITE, bufferSize);
+    const auto bufferPtr = (float*)cl::enqueueMapBuffer(buffer, true, CL_MAP_WRITE, 0, bufferSize);
+    memcpy(bufferPtr, source.pixels().data(), bufferSize);
+    cl::enqueueUnmapMemObject(buffer, (void*)bufferPtr);
+    return buffer;
+}
+
+struct refineMatch {
+    inline bool operator()(const DMatch& mp1, const DMatch& mp2) const {
+        if (mp1.distance < mp2.distance) return true;
+        if (mp1.distance > mp2.distance) return false;
+        // if (mp1.queryIdx < mp2.queryIdx) return true;
+        // if (mp1.queryIdx > mp2.queryIdx) return false;
+        /*if (mp1.octave > mp2.octave) return true;
+        if (mp1.octave < mp2.octave) return false;
+        if (mp1.pt.y < mp2.pt.y) return false;
+        if (mp1.pt.y > mp2.pt.y) return true;*/
+        return mp1.queryIdx < mp2.queryIdx;
+    }
+};
+
+std::vector<DMatch> SURF_OpenCL::matchKeyPoints(const gls::image<float>& descriptor1,
+                                                const gls::image<float>& descriptor2) {
+    auto descriptor1Buffer = bufferFromImage(descriptor1);
+    auto descriptor2Buffer = bufferFromImage(descriptor2);
+
+    auto matchesBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(DMatch) * descriptor1.height);
+
+    // Load the shader source
+    const auto program = _glsContext->loadProgram("SURF");
+
+    // Bind the kernel parameters
+    auto kernel = cl::KernelFunctor<cl::Buffer,  // descriptor1
+                                    int,         // descriptor1_stride
+                                    cl::Buffer,  // descriptor2
+                                    int,         // descriptor2_stride
+                                    int,         // descriptor2_height
+                                    cl::Buffer   // matchedPoints
+                                    >(program, "matchKeyPoints");
+
+    int groups = 24;
+    kernel(cl::EnqueueArgs(cl::NDRange(descriptor1.height, groups), cl::NDRange(1, groups)),
+           descriptor1Buffer, descriptor1.stride, descriptor2Buffer, descriptor2.stride,
+           descriptor2.height, matchesBuffer);
+
+    // Collect results
+    const auto matches = (DMatch*)cl::enqueueMapBuffer(matchesBuffer, true, CL_MAP_READ, 0,
+                                                       sizeof(DMatch) * descriptor1.height);
+
+    // Build result vector
+    std::span<DMatch> newElements(matches, descriptor1.height);
+    std::vector<DMatch> matchedPoints(begin(newElements), end(newElements));
+
+    cl::enqueueUnmapMemObject(matchesBuffer, (void*)matches);
+
+    std::sort(matchedPoints.begin(), matchedPoints.end(), refineMatch());  // feature point sorting
+
+    return matchedPoints;
+}
+
+std::vector<std::pair<Point2f, Point2f>> SURF::detection(gls::OpenCLContext* cLContext,
+                                                         const gls::image<float>& image1,
+                                                         const gls::image<float>& image2) {
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    auto surf = SURF::makeInstance(cLContext, image1.width, image1.height, /*max_features=*/1500,
+                                   /*nOctaves=*/4, /*nOctaveLayers=*/2, /*hessianThreshold=*/0.02);
+
+    auto t_surf = std::chrono::high_resolution_clock::now();
+    printf("--> SURF Creation Time: %.2fms\n", timeDiff(t_start, t_surf));
+
+    auto keypoints1 = std::make_unique<std::vector<KeyPoint>>();
+    auto keypoints2 = std::make_unique<std::vector<KeyPoint>>();
+    gls::image<float>::unique_ptr descriptor1, descriptor2;
+
+    surf->detectAndCompute(image1, keypoints1.get(), &descriptor1);
+    surf->detectAndCompute(image2, keypoints2.get(), &descriptor2);
+
+    auto t_detect = std::chrono::high_resolution_clock::now();
+    printf("--> detectAndCompute Time: %.2fms\n", timeDiff(t_surf, t_detect));
+
+    printf(" ---------- \n Detected feature points: %ld, %ld\n", keypoints1->size(),
+           keypoints2->size());
+
+    // (4) Match feature points
+    std::vector<DMatch> matchedPoints = surf->matchKeyPoints(*descriptor1, *descriptor2);
+
+    auto t_match = std::chrono::high_resolution_clock::now();
+    printf("--> Keypoint Matching: %.2fms\n", timeDiff(t_detect, t_match));
+
+    auto t_sort = std::chrono::high_resolution_clock::now();
+    printf("--> Keypoint Sorting: %.2fms\n", timeDiff(t_match, t_sort));
+
+    // Convert to Point2D format
+    std::vector<std::pair<Point2f, Point2f>> result(matchedPoints.size());
+    for (int i = 0; i < matchedPoints.size(); i++) {
+        result[i] = std::pair{(*keypoints1)[matchedPoints[i].queryIdx].pt,
+                              (*keypoints2)[matchedPoints[i].trainIdx].pt};
     }
 
-    void matchKeyPoints(const gls::image<float> &descriptor1,
-                        const gls::image<float> &descriptor2,
-                        std::vector<DMatch> *matchedPoints)
-    {
-        for (int i = 0; i < descriptor1.height; i++)
-        {
-            const float *p1 = descriptor1[i];
-            float distance_min = 100;
-            int j_min = 0, i_min = 0;
+    auto t_end = std::chrono::high_resolution_clock::now();
+    printf("--> Keypoint Matching & Sorting Time: %.2fms\n", timeDiff(t_detect, t_end));
 
-            for (int j = 0; j < descriptor2.height; j++)
-            {
-                const float *p2 = descriptor2[j];
-                // calculate distance
-                float distance_t = L2Norm(p1, p2, 64);
-                if (distance_t < distance_min)
-                {
-                    distance_min = distance_t;
-                    i_min = i;
-                    j_min = j;
-                }
-            }
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+    printf("--> Features Finding Time: %.2fms\n", elapsed_time_ms);
 
-            matchedPoints->push_back(DMatch(i_min, j_min, distance_min));
-        }
-    }
+    return result;
+}
 
-    template <typename T>
-    cl::Buffer bufferFromImage(const gls::image<T> &source)
-    {
-        int bufferSize = source.stride * source.height * sizeof(float);
-        auto buffer = cl::Buffer(CL_MEM_READ_WRITE, bufferSize);
-        const auto bufferPtr = (float *)cl::enqueueMapBuffer(buffer, true, CL_MAP_WRITE, 0, bufferSize);
-        memcpy(bufferPtr, source.pixels().data(), bufferSize);
-        cl::enqueueUnmapMemObject(buffer, (void *)bufferPtr);
-        return buffer;
-    }
+void clRegisterAndFuse(gls::OpenCLContext* cLContext,
+                       const gls::cl_image_2d<gls::rgba_pixel>& inputImage0,
+                       const gls::cl_image_2d<gls::rgba_pixel>& inputImage1,
+                       gls::cl_image_2d<gls::rgba_pixel>* outputImage,
+                       const gls::Matrix<3, 3>& homography) {
+    // Load the shader source
+    const auto program = cLContext->loadProgram("SURF");
 
-    struct refineMatch
-    {
-        inline bool operator()(const DMatch &mp1, const DMatch &mp2) const
-        {
-            if (mp1.distance < mp2.distance)
-                return true;
-            if (mp1.distance > mp2.distance)
-                return false;
-            // if (mp1.queryIdx < mp2.queryIdx) return true;
-            // if (mp1.queryIdx > mp2.queryIdx) return false;
-            /*if (mp1.octave > mp2.octave) return true;
-            if (mp1.octave < mp2.octave) return false;
-            if (mp1.pt.y < mp2.pt.y) return false;
-            if (mp1.pt.y > mp2.pt.y) return true;*/
-            return mp1.queryIdx < mp2.queryIdx;
-        }
-    };
+    // Bind the kernel parameters
+    auto kernel = cl::KernelFunctor<cl::Image2D,        // inputImage0
+                                    cl::Image2D,        // inputImage1
+                                    cl::Image2D,        // outputImage
+                                    gls::Matrix<3, 3>,  // homography
+                                    cl::Sampler         // linear_sampler
+                                    >(program, "registerAndFuse");
 
-    std::vector<DMatch> SURF_OpenCL::matchKeyPoints(const gls::image<float> &descriptor1,
-                                                    const gls::image<float> &descriptor2)
-    {
-        auto descriptor1Buffer = bufferFromImage(descriptor1);
-        auto descriptor2Buffer = bufferFromImage(descriptor2);
+    const auto linear_sampler =
+        cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
-        auto matchesBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(DMatch) * descriptor1.height);
-
-        // Load the shader source
-        const auto program = _glsContext->loadProgram("SURF");
-
-        // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Buffer, // descriptor1
-                                        int,        // descriptor1_stride
-                                        cl::Buffer, // descriptor2
-                                        int,        // descriptor2_stride
-                                        int,        // descriptor2_height
-                                        cl::Buffer  // matchedPoints
-                                        >(program, "matchKeyPoints");
-
-        int groups = 24;
-        kernel(cl::EnqueueArgs(cl::NDRange(descriptor1.height, groups), cl::NDRange(1, groups)),
-               descriptor1Buffer,
-               descriptor1.stride,
-               descriptor2Buffer,
-               descriptor2.stride,
-               descriptor2.height,
-               matchesBuffer);
-
-        // Collect results
-        const auto matches = (DMatch *)cl::enqueueMapBuffer(matchesBuffer, true, CL_MAP_READ, 0, sizeof(DMatch) * descriptor1.height);
-
-        // Build result vector
-        std::span<DMatch> newElements(matches, descriptor1.height);
-        std::vector<DMatch> matchedPoints(begin(newElements), end(newElements));
-
-        cl::enqueueUnmapMemObject(matchesBuffer, (void *)matches);
-
-        std::sort(matchedPoints.begin(), matchedPoints.end(), refineMatch()); // feature point sorting
-
-        return matchedPoints;
-    }
-
-    std::vector<std::pair<Point2f, Point2f>> SURF::detection(gls::OpenCLContext *cLContext, const gls::image<float> &image1, const gls::image<float> &image2)
-    {
-        auto t_start = std::chrono::high_resolution_clock::now();
-
-        auto surf = SURF::makeInstance(cLContext, image1.width, image1.height, /*max_features=*/1500, /*nOctaves=*/4, /*nOctaveLayers=*/2, /*hessianThreshold=*/0.02);
-
-        auto t_surf = std::chrono::high_resolution_clock::now();
-        printf("--> SURF Creation Time: %.2fms\n", timeDiff(t_start, t_surf));
-
-        auto keypoints1 = std::make_unique<std::vector<KeyPoint>>();
-        auto keypoints2 = std::make_unique<std::vector<KeyPoint>>();
-        gls::image<float>::unique_ptr descriptor1, descriptor2;
-
-        surf->detectAndCompute(image1, keypoints1.get(), &descriptor1);
-        surf->detectAndCompute(image2, keypoints2.get(), &descriptor2);
-
-        auto t_detect = std::chrono::high_resolution_clock::now();
-        printf("--> detectAndCompute Time: %.2fms\n", timeDiff(t_surf, t_detect));
-
-        printf(" ---------- \n Detected feature points: %ld, %ld\n", keypoints1->size(), keypoints2->size());
-
-        // (4) Match feature points
-        std::vector<DMatch> matchedPoints = surf->matchKeyPoints(*descriptor1, *descriptor2);
-
-        auto t_match = std::chrono::high_resolution_clock::now();
-        printf("--> Keypoint Matching: %.2fms\n", timeDiff(t_detect, t_match));
-
-        auto t_sort = std::chrono::high_resolution_clock::now();
-        printf("--> Keypoint Sorting: %.2fms\n", timeDiff(t_match, t_sort));
-
-        // Convert to Point2D format
-        std::vector<std::pair<Point2f, Point2f>> result(matchedPoints.size());
-        for (int i = 0; i < matchedPoints.size(); i++)
-        {
-            result[i] = std::pair{
-                (*keypoints1)[matchedPoints[i].queryIdx].pt,
-                (*keypoints2)[matchedPoints[i].trainIdx].pt};
-        }
-
-        auto t_end = std::chrono::high_resolution_clock::now();
-        printf("--> Keypoint Matching & Sorting Time: %.2fms\n", timeDiff(t_detect, t_end));
-
-        double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-        printf("--> Features Finding Time: %.2fms\n", elapsed_time_ms);
-
-        return result;
-    }
-
-    void clRegisterAndFuse(gls::OpenCLContext *cLContext,
-                           const gls::cl_image_2d<gls::rgba_pixel> &inputImage0,
-                           const gls::cl_image_2d<gls::rgba_pixel> &inputImage1,
-                           gls::cl_image_2d<gls::rgba_pixel> *outputImage,
-                           const gls::Matrix<3, 3> &homography)
-    {
-        // Load the shader source
-        const auto program = cLContext->loadProgram("SURF");
-
-        // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D,       // inputImage0
-                                        cl::Image2D,       // inputImage1
-                                        cl::Image2D,       // outputImage
-                                        gls::Matrix<3, 3>, // homography
-                                        cl::Sampler        // linear_sampler
-                                        >(program, "registerAndFuse");
-
-        const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
-
-        kernel(
+    kernel(
 #if __APPLE__
-            gls::OpenCLContext::buildEnqueueArgs(inputImage0.width, inputImage0.height),
+        gls::OpenCLContext::buildEnqueueArgs(inputImage0.width, inputImage0.height),
 #else
-            cl::EnqueueArgs(cl::NDRange(inputImage0.width, inputImage0.height), cl::NDRange(32, 32)),
+        cl::EnqueueArgs(cl::NDRange(inputImage0.width, inputImage0.height), cl::NDRange(32, 32)),
 #endif
-            inputImage0.getImage2D(), inputImage1.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
-    }
+        inputImage0.getImage2D(), inputImage1.getImage2D(), outputImage->getImage2D(), homography,
+        linear_sampler);
+}
 
-    template <typename T>
-    void clRegisterImage(gls::OpenCLContext *cLContext,
-                         const gls::cl_image_2d<T> &inputImage,
-                         gls::cl_image_2d<T> *outputImage,
-                         const gls::Matrix<3, 3> &homography)
-    {
-        // Load the shader source
-        const auto program = cLContext->loadProgram("SURF");
+template <typename T>
+void clRegisterImage(gls::OpenCLContext* cLContext, const gls::cl_image_2d<T>& inputImage,
+                     gls::cl_image_2d<T>* outputImage, const gls::Matrix<3, 3>& homography) {
+    // Load the shader source
+    const auto program = cLContext->loadProgram("SURF");
 
-        // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D,       // inputImage
-                                        cl::Image2D,       // outputImage
-                                        gls::Matrix<3, 3>, // homography
-                                        cl::Sampler        // linear_sampler
-                                        >(program, "registerImage");
+    // Bind the kernel parameters
+    auto kernel = cl::KernelFunctor<cl::Image2D,        // inputImage
+                                    cl::Image2D,        // outputImage
+                                    gls::Matrix<3, 3>,  // homography
+                                    cl::Sampler         // linear_sampler
+                                    >(program, "registerImage");
 
-        const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
+    const auto linear_sampler =
+        cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
-        kernel(
+    kernel(
 #if __APPLE__
-            gls::OpenCLContext::buildEnqueueArgs(inputImage.width, inputImage.height),
+        gls::OpenCLContext::buildEnqueueArgs(inputImage.width, inputImage.height),
 #else
-            cl::EnqueueArgs(cl::NDRange(inputImage.width, inputImage.height), cl::NDRange(32, 32)),
+        cl::EnqueueArgs(cl::NDRange(inputImage.width, inputImage.height), cl::NDRange(32, 32)),
 #endif
-            inputImage.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
-    }
+        inputImage.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
+}
 
-    template void clRegisterImage(gls::OpenCLContext *cLContext,
-                                  const gls::cl_image_2d<gls::rgba_pixel> &inputImage,
-                                  gls::cl_image_2d<gls::rgba_pixel> *outputImage,
-                                  const gls::Matrix<3, 3> &homography);
+template void clRegisterImage(gls::OpenCLContext* cLContext,
+                              const gls::cl_image_2d<gls::rgba_pixel>& inputImage,
+                              gls::cl_image_2d<gls::rgba_pixel>* outputImage,
+                              const gls::Matrix<3, 3>& homography);
 
-    template void clRegisterImage(gls::OpenCLContext *cLContext,
-                                  const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
-                                  gls::cl_image_2d<gls::rgba_pixel_float> *outputImage,
-                                  const gls::Matrix<3, 3> &homography);
+template void clRegisterImage(gls::OpenCLContext* cLContext,
+                              const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+                              gls::cl_image_2d<gls::rgba_pixel_float>* outputImage,
+                              const gls::Matrix<3, 3>& homography);
 
-} // namespace surf
+}  // namespace gls

--- a/src/SURF.cpp
+++ b/src/SURF.cpp
@@ -31,748 +31,848 @@
 #define USE_OPENCL_INTEGRAL false
 #define USE_INTEGRAL_PYRAMID true
 
-namespace gls {
+namespace gls
+{
 
-static const int   SURF_ORI_SEARCH_INC = 5;
-static const float SURF_ORI_SIGMA      = 2.5f;
-static const float SURF_DESC_SIGMA     = 3.3f;
+    static const int SURF_ORI_SEARCH_INC = 5;
+    static const float SURF_ORI_SIGMA = 2.5f;
+    static const float SURF_DESC_SIGMA = 3.3f;
 
-// Wavelet size at first layer of first octave.
-static const int SURF_HAAR_SIZE0 = 9;
+    // Wavelet size at first layer of first octave.
+    static const int SURF_HAAR_SIZE0 = 9;
 
-// Wavelet size increment between layers. This should be an even number,
-// such that the wavelet sizes in an octave are either all even or all odd.
-// This ensures that when looking for the neighbours of a sample, the layers
-// above and below are aligned correctly.
-static const int SURF_HAAR_SIZE_INC = 6;
+    // Wavelet size increment between layers. This should be an even number,
+    // such that the wavelet sizes in an octave are either all even or all odd.
+    // This ensures that when looking for the neighbours of a sample, the layers
+    // above and below are aligned correctly.
+    static const int SURF_HAAR_SIZE_INC = 6;
 
-template <typename T>
-void integral(const gls::image<float>& img, gls::image<T>* sum) {
-    // Zero the first row and the first column of the sum
-    for (int i = 0; i < sum->width; i++) {
-        (*sum)[0][i] = 0;
-    }
-    for (int j = 1; j < sum->height; j++) {
-        (*sum)[j][0] = 0;
-    }
+    template <typename T>
+    void integral(const gls::image<float> &img, gls::image<T> *sum)
+    {
+        // Zero the first row and the first column of the sum
+        for (int i = 0; i < sum->width; i++)
+        {
+            (*sum)[0][i] = 0;
+        }
+        for (int j = 1; j < sum->height; j++)
+        {
+            (*sum)[j][0] = 0;
+        }
 
-    for (int j = 1; j < sum->height; j++) {
-        for (int i = 1; i < sum->width; i++) {
-            // Use Signed Offset Pixel Representation to improve Integral Image precision
-            // See: Hensley et al.: "Fast Summed-Area Table Generation and its Applications".
-            (*sum)[j][i] = (img[j - 1][i - 1] - 0.5) +
-                           (*sum)[j][i - 1] + (*sum)[j - 1][i] - (*sum)[j - 1][i - 1];
+        for (int j = 1; j < sum->height; j++)
+        {
+            for (int i = 1; i < sum->width; i++)
+            {
+                // Use Signed Offset Pixel Representation to improve Integral Image precision
+                // See: Hensley et al.: "Fast Summed-Area Table Generation and its Applications".
+                (*sum)[j][i] = (img[j - 1][i - 1] - 0.5) +
+                               (*sum)[j][i - 1] + (*sum)[j - 1][i] - (*sum)[j - 1][i - 1];
+            }
         }
     }
-}
 
-struct SurfHF {
-    std::array<gls::point, 4> p;
-    float w;
+    struct SurfHF
+    {
+        std::array<gls::point, 4> p;
+        float w;
 
-    SurfHF() : p({gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}}), w(0) {}
-};
-
-inline std::ostream& operator<<(std::ostream& os, const SurfHF& hf) {
-    os << "SurfHF - " << hf.p[0] << ", " << hf.p[1] << ", " << hf.p[2] << ", " << hf.p[3] << ", " << std::endl;
-    return os;
-}
-
-float integralRectangle(float topRight, float topLeft, float bottomRight, float bottomLeft) {
-    // Use Signed Offset Pixel Representation to improve Integral Image precision, see Integral Image code below
-    return 0.5 + (topRight - topLeft) - (bottomRight - bottomLeft);
-}
-
-template <size_t N>
-static inline float calcHaarPattern(const gls::image<float>& sum, const gls::point& p, const std::array<SurfHF, N>& f) {
-    float d = 0;
-    for (int k = 0; k < N; k++) {
-        const auto& fk = f[k];
-
-        float p0 = sum[p.y + fk.p[0].y][p.x + fk.p[0].x];
-        float p1 = sum[p.y + fk.p[1].y][p.x + fk.p[1].x];
-        float p2 = sum[p.y + fk.p[2].y][p.x + fk.p[2].x];
-        float p3 = sum[p.y + fk.p[3].y][p.x + fk.p[3].x];
-
-        d += fk.w * integralRectangle(p0, p1, p2, p3);
-    }
-    return d;
-}
-
-template <size_t N>
-static void resizeHaarPattern(const int src[N][5], std::array<SurfHF, N>* dst, int oldSize, int newSize) {
-    float ratio = (float) newSize / oldSize;
-    for (int k = 0; k < N; k++) {
-        int dx1 = (int)lrint(ratio * src[k][0]);
-        int dy1 = (int)lrint(ratio * src[k][1]);
-        int dx2 = (int)lrint(ratio * src[k][2]);
-        int dy2 = (int)lrint(ratio * src[k][3]);
-        (*dst)[k].p = {
-            gls::point { dx1, dy1 },
-            gls::point { dx1, dy2 },
-            gls::point { dx2, dy1 },
-            gls::point { dx2, dy2 }
-        };
-        (*dst)[k].w = src[k][4] / ((float)(dx2 - dx1) * (dy2 - dy1));
-    }
-}
-
-static void calcDetAndTrace(const gls::image<float>& sum,
-                            gls::image<float>* det,
-                            gls::image<float>* trace,
-                            int x, int y, int sampleStep,
-                            const std::array<SurfHF, 3>& Dx,
-                            const std::array<SurfHF, 3>& Dy,
-                            const std::array<SurfHF, 4>& Dxy) {
-    const gls::point p = { x * sampleStep, y * sampleStep };
-
-    float dx = calcHaarPattern(sum, p, Dx);
-    float dy = calcHaarPattern(sum, p, Dy);
-    float dxy = calcHaarPattern(sum, p, Dxy);
-
-    (*det)[y][x] = dx * dy - 0.81f * dxy * dxy;
-    (*trace)[y][x] = dx + dy;
-}
-
-/*
- * Maxima location interpolation as described in "Invariant Features from
- * Interest Point Groups" by Matthew Brown and David Lowe. This is performed by
- * fitting a 3D quadratic to a set of neighbouring samples.
- *
- * The gradient vector and Hessian matrix at the initial keypoint location are
- * approximated using central differences. The linear system Ax = b is then
- * solved, where A is the Hessian, b is the negative gradient, and x is the
- * offset of the interpolated maxima coordinates from the initial estimate.
- * This is equivalent to an iteration of Netwon's optimisation algorithm.
- *
- * N9 contains the samples in the 3x3x3 neighbourhood of the maxima
- * dx is the sampling step in x
- * dy is the sampling step in y
- * ds is the sampling step in size
- * point contains the keypoint coordinates and scale to be modified
- *
- * Return value is 1 if interpolation was successful, 0 on failure.
- */
-
-inline float determinant(const gls::Matrix<3, 3>& A) {
-    return A[0][0] * (A[1][1] * A[2][2] - A[1][2] * A[2][1]) -
-           A[0][1] * (A[1][0] * A[2][2] - A[1][2] * A[2][0]) +
-           A[0][2] * (A[1][0] * A[2][1] - A[1][1] * A[2][0]);
-}
-
-inline bool solve3x3(const gls::Matrix<3, 3>& A, const gls::Vector<3>& b, gls::Vector<3>* x) {
-    float det = determinant(A);
-
-    if (det != 0) {
-        return gls::Vector<3> {
-            determinant({b,    A[1], A[2]}),
-            determinant({A[0], b,    A[2]}),
-            determinant({A[0], A[1], b})
-        } / det;
-        return true;
-    }
-    printf("solve3x3: Singular Matrix!\n");
-    return false;
-}
-
-static bool interpolateKeypoint(const std::array<gls::image<float>, 3>& N9, int dx, int dy, int ds, KeyPoint* kpt) {
-    gls::Vector<3> B = {
-        -(N9[1][ 0][ 1] - N9[1][ 0][-1]) / 2, // Negative 1st deriv with respect to x
-        -(N9[1][ 1][ 0] - N9[1][-1][ 0]) / 2, // Negative 1st deriv with respect to y
-        -(N9[2][ 0][ 0] - N9[0][ 0][ 0]) / 2  // Negative 1st deriv with respect to s
+        SurfHF() : p({gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}, gls::point{0, 0}}), w(0) {}
     };
-    gls::Matrix<3, 3> A = {
-        {  N9[1][ 0][-1] - 2 * N9[1][ 0][ 0] + N9[1][ 0][ 1],                           // 2nd deriv x, x
-          (N9[1][ 1][ 1] -     N9[1][ 1][-1] - N9[1][-1][ 1] + N9[1][-1][-1]) / 4,      // 2nd deriv x, y
-          (N9[2][ 0][ 1] -     N9[2][ 0][-1] - N9[0][ 0][ 1] + N9[0][ 0][-1]) / 4 },    // 2nd deriv x, s
-        { (N9[1][ 1][ 1] -     N9[1][ 1][-1] - N9[1][-1][ 1] + N9[1][-1][-1]) / 4,      // 2nd deriv x, y
-           N9[1][-1][ 0] - 2 * N9[1][ 0][ 0] + N9[1][ 1][ 0],                           // 2nd deriv y, y
-          (N9[2][ 1][ 0] -     N9[2][-1][ 0] - N9[0][ 1][ 0] + N9[0][-1][ 0]) / 4 },    // 2nd deriv y, s
-        { (N9[2][ 0][ 1] -     N9[2][ 0][-1] - N9[0][ 0][ 1] + N9[0][ 0][-1]) / 4,      // 2nd deriv x, s
-          (N9[2][ 1][ 0] -     N9[2][-1][ 0] - N9[0][ 1][ 0] + N9[0][-1][ 0]) / 4,      // 2nd deriv y, s
-           N9[0][ 0][ 0] - 2 * N9[1][ 0][ 0] + N9[2][ 0][ 0] }                          // 2nd deriv s, s
+
+    inline std::ostream &operator<<(std::ostream &os, const SurfHF &hf)
+    {
+        os << "SurfHF - " << hf.p[0] << ", " << hf.p[1] << ", " << hf.p[2] << ", " << hf.p[3] << ", " << std::endl;
+        return os;
+    }
+
+    float integralRectangle(float topRight, float topLeft, float bottomRight, float bottomLeft)
+    {
+        // Use Signed Offset Pixel Representation to improve Integral Image precision, see Integral Image code below
+        return 0.5 + (topRight - topLeft) - (bottomRight - bottomLeft);
+    }
+
+    template <size_t N>
+    static inline float calcHaarPattern(const gls::image<float> &sum, const gls::point &p, const std::array<SurfHF, N> &f)
+    {
+        float d = 0;
+        for (int k = 0; k < N; k++)
+        {
+            const auto &fk = f[k];
+
+            float p0 = sum[p.y + fk.p[0].y][p.x + fk.p[0].x];
+            float p1 = sum[p.y + fk.p[1].y][p.x + fk.p[1].x];
+            float p2 = sum[p.y + fk.p[2].y][p.x + fk.p[2].x];
+            float p3 = sum[p.y + fk.p[3].y][p.x + fk.p[3].x];
+
+            d += fk.w * integralRectangle(p0, p1, p2, p3);
+        }
+        return d;
+    }
+
+    template <size_t N>
+    static void resizeHaarPattern(const int src[N][5], std::array<SurfHF, N> *dst, int oldSize, int newSize)
+    {
+        float ratio = (float)newSize / oldSize;
+        for (int k = 0; k < N; k++)
+        {
+            int dx1 = (int)lrint(ratio * src[k][0]);
+            int dy1 = (int)lrint(ratio * src[k][1]);
+            int dx2 = (int)lrint(ratio * src[k][2]);
+            int dy2 = (int)lrint(ratio * src[k][3]);
+            (*dst)[k].p = {
+                gls::point{dx1, dy1},
+                gls::point{dx1, dy2},
+                gls::point{dx2, dy1},
+                gls::point{dx2, dy2}};
+            (*dst)[k].w = src[k][4] / ((float)(dx2 - dx1) * (dy2 - dy1));
+        }
+    }
+
+    static void calcDetAndTrace(const gls::image<float> &sum,
+                                gls::image<float> *det,
+                                gls::image<float> *trace,
+                                int x, int y, int sampleStep,
+                                const std::array<SurfHF, 3> &Dx,
+                                const std::array<SurfHF, 3> &Dy,
+                                const std::array<SurfHF, 4> &Dxy)
+    {
+        const gls::point p = {x * sampleStep, y * sampleStep};
+
+        float dx = calcHaarPattern(sum, p, Dx);
+        float dy = calcHaarPattern(sum, p, Dy);
+        float dxy = calcHaarPattern(sum, p, Dxy);
+
+        (*det)[y][x] = dx * dy - 0.81f * dxy * dxy;
+        (*trace)[y][x] = dx + dy;
+    }
+
+    /*
+     * Maxima location interpolation as described in "Invariant Features from
+     * Interest Point Groups" by Matthew Brown and David Lowe. This is performed by
+     * fitting a 3D quadratic to a set of neighbouring samples.
+     *
+     * The gradient vector and Hessian matrix at the initial keypoint location are
+     * approximated using central differences. The linear system Ax = b is then
+     * solved, where A is the Hessian, b is the negative gradient, and x is the
+     * offset of the interpolated maxima coordinates from the initial estimate.
+     * This is equivalent to an iteration of Netwon's optimisation algorithm.
+     *
+     * N9 contains the samples in the 3x3x3 neighbourhood of the maxima
+     * dx is the sampling step in x
+     * dy is the sampling step in y
+     * ds is the sampling step in size
+     * point contains the keypoint coordinates and scale to be modified
+     *
+     * Return value is 1 if interpolation was successful, 0 on failure.
+     */
+
+    inline float determinant(const gls::Matrix<3, 3> &A)
+    {
+        return A[0][0] * (A[1][1] * A[2][2] - A[1][2] * A[2][1]) -
+               A[0][1] * (A[1][0] * A[2][2] - A[1][2] * A[2][0]) +
+               A[0][2] * (A[1][0] * A[2][1] - A[1][1] * A[2][0]);
+    }
+
+    inline bool solve3x3(const gls::Matrix<3, 3> &A, const gls::Vector<3> &b, gls::Vector<3> *x)
+    {
+        float det = determinant(A);
+
+        if (det != 0)
+        {
+            return gls::Vector<3>{
+                       determinant({b, A[1], A[2]}),
+                       determinant({A[0], b, A[2]}),
+                       determinant({A[0], A[1], b})} /
+                   det;
+            return true;
+        }
+        printf("solve3x3: Singular Matrix!\n");
+        return false;
+    }
+
+    static bool interpolateKeypoint(const std::array<gls::image<float>, 3> &N9, int dx, int dy, int ds, KeyPoint *kpt)
+    {
+        gls::Vector<3> B = {
+            -(N9[1][0][1] - N9[1][0][-1]) / 2, // Negative 1st deriv with respect to x
+            -(N9[1][1][0] - N9[1][-1][0]) / 2, // Negative 1st deriv with respect to y
+            -(N9[2][0][0] - N9[0][0][0]) / 2   // Negative 1st deriv with respect to s
+        };
+        gls::Matrix<3, 3> A = {
+            {N9[1][0][-1] - 2 * N9[1][0][0] + N9[1][0][1],                    // 2nd deriv x, x
+             (N9[1][1][1] - N9[1][1][-1] - N9[1][-1][1] + N9[1][-1][-1]) / 4, // 2nd deriv x, y
+             (N9[2][0][1] - N9[2][0][-1] - N9[0][0][1] + N9[0][0][-1]) / 4},  // 2nd deriv x, s
+            {(N9[1][1][1] - N9[1][1][-1] - N9[1][-1][1] + N9[1][-1][-1]) / 4, // 2nd deriv x, y
+             N9[1][-1][0] - 2 * N9[1][0][0] + N9[1][1][0],                    // 2nd deriv y, y
+             (N9[2][1][0] - N9[2][-1][0] - N9[0][1][0] + N9[0][-1][0]) / 4},  // 2nd deriv y, s
+            {(N9[2][0][1] - N9[2][0][-1] - N9[0][0][1] + N9[0][0][-1]) / 4,   // 2nd deriv x, s
+             (N9[2][1][0] - N9[2][-1][0] - N9[0][1][0] + N9[0][-1][0]) / 4,   // 2nd deriv y, s
+             N9[0][0][0] - 2 * N9[1][0][0] + N9[2][0][0]}                     // 2nd deriv s, s
+        };
+        gls::Vector<3> x;
+        bool ok = solve3x3(A, B, &x);
+        ok = ok && (x[0] != 0 || x[1] != 0 || x[2] != 0) &&
+             std::abs(x[0]) <= 1 && std::abs(x[1]) <= 1 && std::abs(x[2]) <= 1;
+
+        if (ok)
+        {
+            kpt->pt.x += x[0] * dx;
+            kpt->pt.y += x[1] * dy;
+            kpt->size = rint(kpt->size + x[2] * ds);
+        }
+        return ok;
+    }
+
+    struct clSurfHF
+    {
+        cl_int8 p_dx[2];
+        cl_int8 p_dy[2];
+        cl_int8 p_dxy[4];
+
+        clSurfHF(const std::array<SurfHF, 3> &Dx, const std::array<SurfHF, 3> &Dy, const std::array<SurfHF, 4> &Dxy)
+        {
+            /*
+             NOTE: Removed repeating offsets from Dx and Dy, see note in SURF.cl
+             */
+
+            p_dx[0] = {Dx[0].p[0].x, Dx[0].p[0].y, Dx[0].p[1].x, Dx[0].p[1].y, Dx[0].p[2].x, Dx[0].p[2].y, Dx[0].p[3].x, Dx[0].p[3].y};
+            p_dx[1] = {Dx[1].p[2].x, Dx[1].p[2].y, Dx[1].p[3].x, Dx[1].p[3].y, Dx[2].p[2].x, Dx[2].p[2].y, Dx[2].p[3].x, Dx[2].p[3].y};
+
+            p_dy[0] = {Dy[0].p[0].x, Dy[0].p[0].y, Dy[0].p[1].x, Dy[0].p[1].y, Dy[0].p[2].x, Dy[0].p[2].y, Dy[0].p[3].x, Dy[0].p[3].y};
+            p_dy[1] = {Dy[1].p[1].x, Dy[1].p[1].y, Dy[1].p[3].x, Dy[1].p[3].y, Dy[2].p[1].x, Dy[2].p[1].y, Dy[2].p[3].x, Dy[2].p[3].y};
+
+            for (int i = 0; i < 4; i++)
+            {
+                p_dxy[i] = {Dxy[i].p[0].x, Dxy[i].p[0].y, Dxy[i].p[1].x, Dxy[i].p[1].y, Dxy[i].p[2].x, Dxy[i].p[2].y, Dxy[i].p[3].x, Dxy[i].p[3].y};
+            }
+        }
     };
-    gls::Vector<3> x;
-    bool ok = solve3x3(A, B, &x);
-    ok = ok && (x[0] != 0 || x[1] != 0 || x[2] != 0) &&
-         std::abs(x[0]) <= 1 && std::abs(x[1]) <= 1 && std::abs(x[2]) <= 1;
 
-    if (ok) {
-        kpt->pt.x += x[0] * dx;
-        kpt->pt.y += x[1] * dy;
-        kpt->size = rint(kpt->size + x[2] * ds);
-    }
-    return ok;
-}
+    struct DetAndTraceHaarPattern
+    {
+        static const int NX = 3, NY = 3, NXY = 4;
 
-struct clSurfHF {
-    cl_int8 p_dx[2];
-    cl_int8 p_dy[2];
-    cl_int8 p_dxy[4];
+        std::array<SurfHF, NX> Dx;
+        std::array<SurfHF, NY> Dy;
+        std::array<SurfHF, NXY> Dxy;
 
-    clSurfHF(const std::array<SurfHF, 3>& Dx, const std::array<SurfHF, 3>& Dy, const std::array<SurfHF, 4>& Dxy) {
-        /*
-         NOTE: Removed repeating offsets from Dx and Dy, see note in SURF.cl
-         */
+        const gls::rectangle margin_crop;
 
-        p_dx[0] = { Dx[0].p[0].x, Dx[0].p[0].y, Dx[0].p[1].x, Dx[0].p[1].y, Dx[0].p[2].x, Dx[0].p[2].y, Dx[0].p[3].x, Dx[0].p[3].y };
-        p_dx[1] = { Dx[1].p[2].x, Dx[1].p[2].y, Dx[1].p[3].x, Dx[1].p[3].y, Dx[2].p[2].x, Dx[2].p[2].y, Dx[2].p[3].x, Dx[2].p[3].y };
+        DetAndTraceHaarPattern(int sum_width, int sum_height, int size, int sampleStep) : margin_crop((size / 2) / sampleStep, // Ignore pixels where some of the kernel is outside the image
+                                                                                                      (size / 2) / sampleStep,
+                                                                                                      1 + (sum_width - 1 - size) / sampleStep, // The integral image 'sum' is one pixel bigger than the source image
+                                                                                                      1 + (sum_height - 1 - size) / sampleStep)
+        {
+            const int dx_s[NX][5] = {
+                {0, 2, 3, 7, 1},
+                {3, 2, 6, 7, -2},
+                {6, 2, 9, 7, 1}};
+            const int dy_s[NY][5] = {
+                {2, 0, 7, 3, 1},
+                {2, 3, 7, 6, -2},
+                {2, 6, 7, 9, 1}};
+            const int dxy_s[NXY][5] = {
+                {1, 1, 4, 4, 1},
+                {5, 1, 8, 4, -1},
+                {1, 5, 4, 8, -1},
+                {5, 5, 8, 8, 1}};
 
-        p_dy[0] = { Dy[0].p[0].x, Dy[0].p[0].y, Dy[0].p[1].x, Dy[0].p[1].y, Dy[0].p[2].x, Dy[0].p[2].y, Dy[0].p[3].x, Dy[0].p[3].y };
-        p_dy[1] = { Dy[1].p[1].x, Dy[1].p[1].y, Dy[1].p[3].x, Dy[1].p[3].y, Dy[2].p[1].x, Dy[2].p[1].y, Dy[2].p[3].x, Dy[2].p[3].y };
+            assert(size <= (sum_height - 1) || size > (sum_width - 1));
 
-        for (int i = 0; i < 4; i++) {
-            p_dxy[i] = { Dxy[i].p[0].x, Dxy[i].p[0].y, Dxy[i].p[1].x, Dxy[i].p[1].y, Dxy[i].p[2].x, Dxy[i].p[2].y, Dxy[i].p[3].x, Dxy[i].p[3].y };
+            resizeHaarPattern(dx_s, &Dx, 9, size);
+            resizeHaarPattern(dy_s, &Dy, 9, size);
+            resizeHaarPattern(dxy_s, &Dxy, 9, size);
         }
-    }
-};
 
-struct DetAndTraceHaarPattern {
-    static const int NX = 3, NY = 3, NXY = 4;
-
-    std::array<SurfHF, NX> Dx;
-    std::array<SurfHF, NY> Dy;
-    std::array<SurfHF, NXY> Dxy;
-
-    const gls::rectangle margin_crop;
-
-    DetAndTraceHaarPattern(int sum_width, int sum_height, int size, int sampleStep) :
-        margin_crop((size / 2) / sampleStep,                    // Ignore pixels where some of the kernel is outside the image
-                    (size / 2) / sampleStep,
-                    1 + (sum_width - 1 - size) / sampleStep,    // The integral image 'sum' is one pixel bigger than the source image
-                    1 + (sum_height - 1 - size) / sampleStep) {
-        const int dx_s[NX][5] = {
-            {0, 2, 3, 7, 1},
-            {3, 2, 6, 7, -2},
-            {6, 2, 9, 7, 1}
-        };
-        const int dy_s[NY][5] = {
-            {2, 0, 7, 3, 1},
-            {2, 3, 7, 6, -2},
-            {2, 6, 7, 9, 1}
-        };
-        const int dxy_s[NXY][5] = {
-            {1, 1, 4, 4, 1},
-            {5, 1, 8, 4, -1},
-            {1, 5, 4, 8, -1},
-            {5, 5, 8, 8, 1}
-        };
-
-        assert(size <= (sum_height - 1) || size > (sum_width - 1));
-
-        resizeHaarPattern(dx_s, &Dx, 9, size);
-        resizeHaarPattern(dy_s, &Dy, 9, size);
-        resizeHaarPattern(dxy_s, &Dxy, 9, size);
-    }
-
-    // Rescale sampling points to the pyramid level
-    void rescale(int scale) {
-        for (auto& entry : Dx) {
-            for (auto& pi : entry.p) {
-                pi /= scale;
-            }
-        }
-        for (auto& entry : Dy) {
-            for (auto& pi : entry.p) {
-                pi /= scale;
-            }
-        }
-        for (auto& entry : Dxy) {
-            for (auto& pi : entry.p) {
-                pi /= scale;
-            }
-        }
-    }
-
-    // Rescale sampling points to the pyramid level
-    void upscale(int scale) {
-        for (auto& entry : Dx) {
-            for (auto& pi : entry.p) {
-                pi *= scale;
-            }
-        }
-        for (auto& entry : Dy) {
-            for (auto& pi : entry.p) {
-                pi *= scale;
-            }
-        }
-        for (auto& entry : Dxy) {
-            for (auto& pi : entry.p) {
-                pi *= scale;
-            }
-        }
-    }
-};
-
-void calcLayerDetAndTrace(const gls::image<float>& sum, int size, int sampleStep,
-                                gls::image<float>* det, gls::image<float>* trace) {
-    DetAndTraceHaarPattern haarPattern(sum.width, sum.height, size, sampleStep);
-
-    gls::image<float> detCpu = gls::image<float>(det, haarPattern.margin_crop);
-    gls::image<float> traceCpu = gls::image<float>(*trace, haarPattern.margin_crop);
-
-    for (int y = 0; y < haarPattern.margin_crop.height; y++) {
-        for (int x = 0; x < haarPattern.margin_crop.width; x++) {
-            calcDetAndTrace(sum, &detCpu, &traceCpu, x, y, sampleStep, haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
-        }
-    }
-}
-
-void findMaximaInLayer(int width, int height,
-                       const std::array<gls::image<float>*, 3>& dets, const gls::image<float>& trace,
-                       const std::array<int, 3>& sizes, std::vector<KeyPoint>* keypoints, int octave,
-                       float hessianThreshold, int sampleStep, std::mutex& keypointsMutex) {
-    const int size = sizes[1];
-
-    const int layer_height = width / sampleStep;
-    const int layer_width = height / sampleStep;
-
-    // Ignore pixels without a 3x3x3 neighbourhood in the layer above
-    const int margin = (sizes[2] / 2) / sampleStep + 1;
-
-    const gls::image<float>& det0 = *dets[0];
-    const gls::image<float>& det1 = *dets[1];
-    const gls::image<float>& det2 = *dets[2];
-
-    int keyPointMaxima = 0;
-    for (int y = margin; y < layer_height - margin; y++) {
-        for (int x = margin; x < layer_width - margin; x++) {
-            const float val0 = (*dets[1])[y][x];
-
-            if (val0 > hessianThreshold) {
-                /* Coordinates for the start of the wavelet in the sum image. There
-                   is some integer division involved, so don't try to simplify this
-                   (cancel out sampleStep) without checking the result is the same */
-                int sum_y = sampleStep * (y - (size / 2) / sampleStep);
-                int sum_x = sampleStep * (x - (size / 2) / sampleStep);
-
-                /* The 3x3x3 neighbouring samples around the maxima.
-                   The maxima is included at N9[1][0][0] */
-
-                const std::array<gls::image<float>, 3> N9 = {
-                    gls::image<float>(det0, {x, y, 1, 1}),
-                    gls::image<float>(det1, {x, y, 1, 1}),
-                    gls::image<float>(det2, {x, y, 1, 1}),
-                };
-
-                /* Non-maxima suppression. val0 is at N9[1][0][0] */
-                if (val0 > N9[0][-1][-1] && val0 > N9[0][-1][0] && val0 > N9[0][-1][1] &&
-                    val0 > N9[0][ 0][-1] && val0 > N9[0][ 0][0] && val0 > N9[0][ 0][1] &&
-                    val0 > N9[0][ 1][-1] && val0 > N9[0][ 1][0] && val0 > N9[0][ 1][1] &&
-                    val0 > N9[1][-1][-1] && val0 > N9[1][-1][0] && val0 > N9[1][-1][1] &&
-                    val0 > N9[1][ 0][-1]                        && val0 > N9[1][ 0][1] &&
-                    val0 > N9[1][ 1][-1] && val0 > N9[1][ 1][0] && val0 > N9[1][ 1][1] &&
-                    val0 > N9[2][-1][-1] && val0 > N9[2][-1][0] && val0 > N9[2][-1][1] &&
-                    val0 > N9[2][ 0][-1] && val0 > N9[2][ 0][0] && val0 > N9[2][ 0][1] &&
-                    val0 > N9[2][ 1][-1] && val0 > N9[2][ 1][0] && val0 > N9[2][ 1][1])
+        // Rescale sampling points to the pyramid level
+        void rescale(int scale)
+        {
+            for (auto &entry : Dx)
+            {
+                for (auto &pi : entry.p)
                 {
-                    /* Calculate the wavelet center coordinates for the maxima */
-                    float center_y = sum_y + (size - 1) * 0.5f;
-                    float center_x = sum_x + (size - 1) * 0.5f;
-                    KeyPoint kpt = {{center_x, center_y}, (float)sizes[1], -1, val0, octave, trace[y][x] > 0 };
+                    pi /= scale;
+                }
+            }
+            for (auto &entry : Dy)
+            {
+                for (auto &pi : entry.p)
+                {
+                    pi /= scale;
+                }
+            }
+            for (auto &entry : Dxy)
+            {
+                for (auto &pi : entry.p)
+                {
+                    pi /= scale;
+                }
+            }
+        }
 
-                    /* Interpolate maxima location within the 3x3x3 neighbourhood  */
-                    int ds = size - sizes[0];
-                    int interp_ok = interpolateKeypoint(N9, sampleStep, sampleStep, ds, &kpt);
+        // Rescale sampling points to the pyramid level
+        void upscale(int scale)
+        {
+            for (auto &entry : Dx)
+            {
+                for (auto &pi : entry.p)
+                {
+                    pi *= scale;
+                }
+            }
+            for (auto &entry : Dy)
+            {
+                for (auto &pi : entry.p)
+                {
+                    pi *= scale;
+                }
+            }
+            for (auto &entry : Dxy)
+            {
+                for (auto &pi : entry.p)
+                {
+                    pi *= scale;
+                }
+            }
+        }
+    };
 
-                    /* Sometimes the interpolation step gives a negative size etc. */
-                    if (interp_ok) {
-                        std::lock_guard<std::mutex> guard(keypointsMutex);
-                        keypoints->push_back(kpt);
-                        keyPointMaxima++;
+    void calcLayerDetAndTrace(const gls::image<float> &sum, int size, int sampleStep,
+                              gls::image<float> *det, gls::image<float> *trace)
+    {
+        DetAndTraceHaarPattern haarPattern(sum.width, sum.height, size, sampleStep);
+
+        gls::image<float> detCpu = gls::image<float>(det, haarPattern.margin_crop);
+        gls::image<float> traceCpu = gls::image<float>(*trace, haarPattern.margin_crop);
+
+        for (int y = 0; y < haarPattern.margin_crop.height; y++)
+        {
+            for (int x = 0; x < haarPattern.margin_crop.width; x++)
+            {
+                calcDetAndTrace(sum, &detCpu, &traceCpu, x, y, sampleStep, haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
+            }
+        }
+    }
+
+    void findMaximaInLayer(int width, int height,
+                           const std::array<gls::image<float> *, 3> &dets, const gls::image<float> &trace,
+                           const std::array<int, 3> &sizes, std::vector<KeyPoint> *keypoints, int octave,
+                           float hessianThreshold, int sampleStep, std::mutex &keypointsMutex)
+    {
+        const int size = sizes[1];
+
+        const int layer_height = width / sampleStep;
+        const int layer_width = height / sampleStep;
+
+        // Ignore pixels without a 3x3x3 neighbourhood in the layer above
+        const int margin = (sizes[2] / 2) / sampleStep + 1;
+
+        const gls::image<float> &det0 = *dets[0];
+        const gls::image<float> &det1 = *dets[1];
+        const gls::image<float> &det2 = *dets[2];
+
+        int keyPointMaxima = 0;
+        for (int y = margin; y < layer_height - margin; y++)
+        {
+            for (int x = margin; x < layer_width - margin; x++)
+            {
+                const float val0 = (*dets[1])[y][x];
+
+                if (val0 > hessianThreshold)
+                {
+                    /* Coordinates for the start of the wavelet in the sum image. There
+                       is some integer division involved, so don't try to simplify this
+                       (cancel out sampleStep) without checking the result is the same */
+                    int sum_y = sampleStep * (y - (size / 2) / sampleStep);
+                    int sum_x = sampleStep * (x - (size / 2) / sampleStep);
+
+                    /* The 3x3x3 neighbouring samples around the maxima.
+                       The maxima is included at N9[1][0][0] */
+
+                    const std::array<gls::image<float>, 3> N9 = {
+                        gls::image<float>(det0, {x, y, 1, 1}),
+                        gls::image<float>(det1, {x, y, 1, 1}),
+                        gls::image<float>(det2, {x, y, 1, 1}),
+                    };
+
+                    /* Non-maxima suppression. val0 is at N9[1][0][0] */
+                    if (val0 > N9[0][-1][-1] && val0 > N9[0][-1][0] && val0 > N9[0][-1][1] &&
+                        val0 > N9[0][0][-1] && val0 > N9[0][0][0] && val0 > N9[0][0][1] &&
+                        val0 > N9[0][1][-1] && val0 > N9[0][1][0] && val0 > N9[0][1][1] &&
+                        val0 > N9[1][-1][-1] && val0 > N9[1][-1][0] && val0 > N9[1][-1][1] &&
+                        val0 > N9[1][0][-1] && val0 > N9[1][0][1] &&
+                        val0 > N9[1][1][-1] && val0 > N9[1][1][0] && val0 > N9[1][1][1] &&
+                        val0 > N9[2][-1][-1] && val0 > N9[2][-1][0] && val0 > N9[2][-1][1] &&
+                        val0 > N9[2][0][-1] && val0 > N9[2][0][0] && val0 > N9[2][0][1] &&
+                        val0 > N9[2][1][-1] && val0 > N9[2][1][0] && val0 > N9[2][1][1])
+                    {
+                        /* Calculate the wavelet center coordinates for the maxima */
+                        float center_y = sum_y + (size - 1) * 0.5f;
+                        float center_x = sum_x + (size - 1) * 0.5f;
+                        KeyPoint kpt = {{center_x, center_y}, (float)sizes[1], -1, val0, octave, trace[y][x] > 0};
+
+                        /* Interpolate maxima location within the 3x3x3 neighbourhood  */
+                        int ds = size - sizes[0];
+                        int interp_ok = interpolateKeypoint(N9, sampleStep, sampleStep, ds, &kpt);
+
+                        /* Sometimes the interpolation step gives a negative size etc. */
+                        if (interp_ok)
+                        {
+                            std::lock_guard<std::mutex> guard(keypointsMutex);
+                            keypoints->push_back(kpt);
+                            keyPointMaxima++;
+                        }
+                    }
+                }
+            }
+        }
+        std::cout << "keyPointMaxima: " << keyPointMaxima << std::endl;
+    }
+
+    std::vector<float> getGaussianKernel(int n, float sigma)
+    {
+        const int SMALL_GAUSSIAN_SIZE = 7;
+        static const float small_gaussian_tab[][SMALL_GAUSSIAN_SIZE] = {
+            {1.f},
+            {0.25f, 0.5f, 0.25f},
+            {0.0625f, 0.25f, 0.375f, 0.25f, 0.0625f},
+            {0.03125f, 0.109375f, 0.21875f, 0.28125f, 0.21875f, 0.109375f, 0.03125f}};
+
+        const float *fixed_kernel = n % 2 == 1 && n <= SMALL_GAUSSIAN_SIZE && sigma <= 0 ? small_gaussian_tab[n >> 1] : nullptr;
+
+        float sigmaX = sigma > 0 ? sigma : ((n - 1) * 0.5 - 1) * 0.3 + 0.8;
+        float scale2X = -0.5 / (sigmaX * sigmaX);
+        float sum = 0;
+
+        std::vector<float> kernel(n);
+        for (int i = 0; i < n; i++)
+        {
+            float x = i - (n - 1) * 0.5;
+            float t = fixed_kernel ? (float)fixed_kernel[i] : std::exp(scale2X * x * x);
+            kernel[i] = t;
+            sum += kernel[i];
+        }
+
+        sum = 1. / sum;
+        for (auto &v : kernel)
+        {
+            v *= sum;
+        }
+
+        return kernel;
+    }
+
+    void resizeVV(const gls::image<float> &src, gls::image<float> *dst, int interpolation)
+    {
+        // Note that src and dst represent square matrices
+
+        float dsize = (float)src.height / dst->height;
+        if (dst->height && dst->width)
+        {
+            for (int i = 0; i < dst->height; i++)
+            {
+                for (int j = 0; j < dst->width; j++)
+                {
+                    int _i = (int)i * dsize;      // integer part
+                    float _idec = i * dsize - _i; // fractional part
+                    int _j = (int)j * dsize;
+                    float _jdec = j * dsize - _j;
+                    if (_j >= 0 && _j < (src.height - 1) && _i >= 0 && _i < (src.height - 1))
+                    {
+                        // Bilinear interpolation
+                        (*dst)[i][j] = (1 - _idec) * (1 - _jdec) * src[_i][_j] + _idec * (1 - _jdec) * src[_i + 1][_j] +
+                                       _jdec * (1 - _idec) * src[_j][_j + 1] + _idec * _jdec * src[_i + 1][_j + 1];
                     }
                 }
             }
         }
     }
-    std::cout << "keyPointMaxima: " << keyPointMaxima << std::endl;
-}
 
-std::vector<float> getGaussianKernel(int n, float sigma) {
-    const int SMALL_GAUSSIAN_SIZE = 7;
-    static const float small_gaussian_tab[][SMALL_GAUSSIAN_SIZE] = {
-        {1.f},
-        {0.25f, 0.5f, 0.25f},
-        {0.0625f, 0.25f, 0.375f, 0.25f, 0.0625f},
-        {0.03125f, 0.109375f, 0.21875f, 0.28125f, 0.21875f, 0.109375f, 0.03125f}};
-
-    const float* fixed_kernel = n % 2 == 1 && n <= SMALL_GAUSSIAN_SIZE && sigma <= 0 ? small_gaussian_tab[n >> 1] : nullptr;
-
-    float sigmaX = sigma > 0 ? sigma : ((n - 1) * 0.5 - 1) * 0.3 + 0.8;
-    float scale2X = -0.5 / (sigmaX * sigmaX);
-    float sum = 0;
-
-    std::vector<float> kernel(n);
-    for (int i = 0; i < n; i++) {
-        float x = i - (n - 1) * 0.5;
-        float t = fixed_kernel ? (float)fixed_kernel[i] : std::exp(scale2X * x * x);
-        kernel[i] = t;
-        sum += kernel[i];
-    }
-
-    sum = 1. / sum;
-    for (auto& v : kernel) {
-        v *= sum;
-    }
-
-    return kernel;
-}
-
-void resizeVV(const gls::image<float>& src, gls::image<float>* dst, int interpolation) {
-    // Note that src and dst represent square matrices
-
-    float dsize = (float)src.height / dst->height;
-    if (dst->height && dst->width) {
-        for (int i = 0; i < dst->height; i++) {
-            for (int j = 0; j < dst->width; j++) {
-                int _i = (int)i * dsize;       // integer part
-                float _idec = i * dsize - _i;  // fractional part
-                int _j = (int)j * dsize;
-                float _jdec = j * dsize - _j;
-                if (_j >= 0 && _j < (src.height - 1) && _i >= 0 && _i < (src.height - 1)) {
-                    // Bilinear interpolation
-                    (*dst)[i][j] = (1 - _idec) * (1 - _jdec) * src[_i][_j] + _idec * (1 - _jdec) * src[_i + 1][_j] +
-                                   _jdec * (1 - _idec) * src[_j][_j + 1] + _idec * _jdec * src[_i + 1][_j + 1];
-                }
-            }
-        }
-    }
-}
-
-struct SURFInvoker {
-    enum { ORI_RADIUS = 6, ORI_WIN = 60, PATCH_SZ = 20 };
-
-    // Simple bound for number of grid points in circle of radius ORI_RADIUS
-    const int nOriSampleBound = (2 * ORI_RADIUS + 1) * (2 * ORI_RADIUS + 1);
-
-    // Parameters
-    const gls::image<float>& img;
-    const gls::image<float>& sum;
-    std::vector<KeyPoint>* keypoints;
-    gls::image<float>* descriptors;
-
-    // Pre-calculated values
-    int nOriSamples;
-    std::vector<Point2f> apt;
-    std::vector<float> aptw;
-    std::vector<float> DW;
-
-    SURFInvoker(const gls::image<float>& _img,
-                const gls::image<float>& _sum,
-                std::vector<KeyPoint>* _keypoints,
-                gls::image<float>* _descriptors) :
-        img(_img), sum(_sum), keypoints(_keypoints), descriptors(_descriptors) {
-        enum { ORI_RADIUS = 6, ORI_WIN = 60, PATCH_SZ = 20 };
+    struct SURFInvoker
+    {
+        enum
+        {
+            ORI_RADIUS = 6,
+            ORI_WIN = 60,
+            PATCH_SZ = 20
+        };
 
         // Simple bound for number of grid points in circle of radius ORI_RADIUS
         const int nOriSampleBound = (2 * ORI_RADIUS + 1) * (2 * ORI_RADIUS + 1);
 
-        // Allocate arrays
-        apt.resize(nOriSampleBound);
-        aptw.resize(nOriSampleBound);
-        DW.resize(PATCH_SZ * PATCH_SZ);
+        // Parameters
+        const gls::image<float> &img;
+        const gls::image<float> &sum;
+        std::vector<KeyPoint> *keypoints;
+        gls::image<float> *descriptors;
 
-        /* Coordinates and weights of samples used to calculate orientation */
-        const auto G_ori = getGaussianKernel(2 * ORI_RADIUS + 1, SURF_ORI_SIGMA);
-        nOriSamples = 0;
-        for (int i = -ORI_RADIUS; i <= ORI_RADIUS; i++) {
-            for (int j = -ORI_RADIUS; j <= ORI_RADIUS; j++) {
-                if (i * i + j * j <= ORI_RADIUS * ORI_RADIUS) {
-                    apt[nOriSamples] = Point2f(i, j);
-                    aptw[nOriSamples++] = G_ori[i + ORI_RADIUS] * G_ori[j + ORI_RADIUS];
-                }
-            }
-        }
-        assert( nOriSamples <= nOriSampleBound );
+        // Pre-calculated values
+        int nOriSamples;
+        std::vector<Point2f> apt;
+        std::vector<float> aptw;
+        std::vector<float> DW;
 
-        /* Gaussian used to weight descriptor samples */
-        const auto G_desc = getGaussianKernel(PATCH_SZ, SURF_DESC_SIGMA);
-        for (int i = 0; i < PATCH_SZ; i++) {
-            for (int j = 0; j < PATCH_SZ; j++) DW[i * PATCH_SZ + j] = G_desc[i] * G_desc[j];
-        }
-    }
+        SURFInvoker(const gls::image<float> &_img,
+                    const gls::image<float> &_sum,
+                    std::vector<KeyPoint> *_keypoints,
+                    gls::image<float> *_descriptors) : img(_img), sum(_sum), keypoints(_keypoints), descriptors(_descriptors)
+        {
+            enum
+            {
+                ORI_RADIUS = 6,
+                ORI_WIN = 60,
+                PATCH_SZ = 20
+            };
 
-    void computeRange(int k1, int k2) {
-        /* X and Y gradient wavelet data */
-        const int NX = 2, NY = 2;
-        const int dx_s[NX][5] = {
-            {0, 0, 2, 4, -1},
-            {2, 0, 4, 4, 1}
-        };
-        const int dy_s[NY][5] = {
-            {0, 0, 4, 2, 1},
-            {0, 2, 4, 4, -1}
-        };
+            // Simple bound for number of grid points in circle of radius ORI_RADIUS
+            const int nOriSampleBound = (2 * ORI_RADIUS + 1) * (2 * ORI_RADIUS + 1);
 
-        float X[nOriSampleBound], Y[nOriSampleBound], angle[nOriSampleBound];
-        gls::image<float> PATCH(PATCH_SZ + 1, PATCH_SZ + 1);
-        float DX[PATCH_SZ][PATCH_SZ], DY[PATCH_SZ][PATCH_SZ];
+            // Allocate arrays
+            apt.resize(nOriSampleBound);
+            aptw.resize(nOriSampleBound);
+            DW.resize(PATCH_SZ * PATCH_SZ);
 
-        // TODO: should we also add the extended (dsize = 128) case?
-        const int dsize = 64;
-
-        float maxSize = 0;
-        for (int k = k1; k < k2; k++) {
-            maxSize = std::max(maxSize, (*keypoints)[k].size);
-        }
-
-        for (int k = k1; k < k2; k++) {
-            std::array<SurfHF, NX> dx_t;
-            std::array<SurfHF, NY> dy_t;
-            KeyPoint& kp = (*keypoints)[k];
-            float size = kp.size;
-            Point2f center = kp.pt;
-            /* The sampling intervals and wavelet sized for selecting an orientation
-             and building the keypoint descriptor are defined relative to 's' */
-            float s = size * 1.2f / 9.0f;
-            /* To find the dominant orientation, the gradients in x and y are
-             sampled in a circle of radius 6s using wavelets of size 4s.
-             We ensure the gradient wavelet size is even to ensure the
-             wavelet pattern is balanced and symmetric around its center */
-            int grad_wav_size = 2 * (int) lrint(2 * s);
-            if (sum.height < grad_wav_size || sum.width < grad_wav_size) {
-                /* when grad_wav_size is too big,
-                 * the sampling of gradient will be meaningless
-                 * mark keypoint for deletion. */
-                kp.size = -1;
-                continue;
-            }
-
-            float descriptor_dir = 360.f - 90.f;
-            resizeHaarPattern(dx_s, &dx_t, 4, grad_wav_size);
-            resizeHaarPattern(dy_s, &dy_t, 4, grad_wav_size);
-            int nangle = 0;
-            for (int kk = 0; kk < nOriSamples; kk++) {
-                // TODO: if we use round instead of lrint the result is slightly different
-
-                int x = (int) lrint(center.x + apt[kk].x * s - (float)(grad_wav_size - 1) / 2);
-                int y = (int) lrint(center.y + apt[kk].y * s - (float)(grad_wav_size - 1) / 2);
-                if (y < 0 || y >= sum.height - grad_wav_size ||
-                    x < 0 || x >= sum.width - grad_wav_size)
-                    continue;
-                float vx = calcHaarPattern(sum, {x, y}, dx_t);
-                float vy = calcHaarPattern(sum, {x, y}, dy_t);
-                X[nangle] = vx * aptw[kk];
-                Y[nangle] = vy * aptw[kk];
-                nangle++;
-            }
-            if (nangle == 0) {
-                // No gradient could be sampled because the keypoint is too
-                // near too one or more of the sides of the image. As we
-                // therefore cannot find a dominant direction, we skip this
-                // keypoint and mark it for later deletion from the sequence.
-                kp.size = -1;
-                continue;
-            }
-
-            // phase( Mat(1, nangle, CV_32F, X), Mat(1, nangle, CV_32F, Y), Mat(1, nangle, CV_32F, angle), true );
-            for (int i = 0; i < nangle; i++) {
-                float temp = atan2(Y[i], X[i]) * (180 / M_PI);
-                if (temp < 0)
-                    angle[i] = temp + 360;
-                else
-                    angle[i] = temp;
-            }
-
-            float bestx = 0, besty = 0, descriptor_mod = 0;
-            for (float i = 0; i < 360; i += SURF_ORI_SEARCH_INC) {
-                float sumx = 0, sumy = 0, temp_mod;
-                for (int j = 0; j < nangle; j++) {
-                    float d = std::abs(lrint(angle[j]) - i);
-                    if (d < ORI_WIN / 2 || d > 360 - ORI_WIN / 2) {
-                        sumx += X[j];
-                        sumy += Y[j];
-                    }
-                }
-                temp_mod = sumx * sumx + sumy * sumy;
-                if (temp_mod > descriptor_mod) {
-                    descriptor_mod = temp_mod;
-                    bestx = sumx;
-                    besty = sumy;
-                }
-            }
-            descriptor_dir = atan2(-besty, bestx);
-
-            kp.angle = descriptor_dir;
-
-            if (!descriptors)
-                continue;
-
-            /* Extract a window of pixels around the keypoint of size 20s */
-            int win_size = (int)((PATCH_SZ + 1) * s);
-            gls::image<float> mwin(win_size, win_size);
-
-            // !upright
-            descriptor_dir *= (float)(M_PI / 180);
-            float sin_dir = -std::sin(descriptor_dir);
-            float cos_dir =  std::cos(descriptor_dir);
-
-            float win_offset = -(float)(win_size - 1) / 2;
-            float start_x = center.x + win_offset * cos_dir + win_offset * sin_dir;
-            float start_y = center.y - win_offset * sin_dir + win_offset * cos_dir;
-
-            int ncols1 = img.width - 1, nrows1 = img.height - 1;
-            for (int i = 0; i < win_size; i++, start_x += sin_dir, start_y += cos_dir) {
-                float pixel_x = start_x;
-                float pixel_y = start_y;
-                for (int j = 0; j < win_size; j++, pixel_x += cos_dir, pixel_y -= sin_dir) {
-                    int ix = std::floor(pixel_x);
-                    int iy = std::floor(pixel_y);
-
-                    if ((unsigned)ix < (unsigned)ncols1 &&
-                        (unsigned)iy < (unsigned)nrows1) {
-                        float a = pixel_x - ix;
-                        float b = pixel_y - iy;
-
-                        mwin[i][j] = std::round((img[iy][ix] * (1 - a) + img[iy][ix + 1] * a) * (1 - b) +
-                                                (img[iy + 1][ix] * (1 - a) + img[iy + 1][ix + 1] * a) * b);
-                    } else {
-                        int x = std::clamp((int)std::round(pixel_x), 0, ncols1);
-                        int y = std::clamp((int)std::round(pixel_y), 0, nrows1);
-                        mwin[i][j] = img[y][x];
+            /* Coordinates and weights of samples used to calculate orientation */
+            const auto G_ori = getGaussianKernel(2 * ORI_RADIUS + 1, SURF_ORI_SIGMA);
+            nOriSamples = 0;
+            for (int i = -ORI_RADIUS; i <= ORI_RADIUS; i++)
+            {
+                for (int j = -ORI_RADIUS; j <= ORI_RADIUS; j++)
+                {
+                    if (i * i + j * j <= ORI_RADIUS * ORI_RADIUS)
+                    {
+                        apt[nOriSamples] = Point2f(i, j);
+                        aptw[nOriSamples++] = G_ori[i + ORI_RADIUS] * G_ori[j + ORI_RADIUS];
                     }
                 }
             }
+            assert(nOriSamples <= nOriSampleBound);
 
-            // Scale the window to size PATCH_SZ so each pixel's size is s. This
-            // makes calculating the gradients with wavelets of size 2s easy
-            resizeVV(mwin, &PATCH, 0);
-
-            // Calculate gradients in x and y with wavelets of size 2s
+            /* Gaussian used to weight descriptor samples */
+            const auto G_desc = getGaussianKernel(PATCH_SZ, SURF_DESC_SIGMA);
             for (int i = 0; i < PATCH_SZ; i++)
-                for (int j = 0; j < PATCH_SZ; j++) {
-                    float dw = DW[i * PATCH_SZ + j];
-                    float vx = (PATCH[i][j + 1] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i + 1][j]) * dw;
-                    float vy = (PATCH[i + 1][j] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i][j + 1]) * dw;
-                    DX[i][j] = vx;
-                    DY[i][j] = vy;
+            {
+                for (int j = 0; j < PATCH_SZ; j++)
+                    DW[i * PATCH_SZ + j] = G_desc[i] * G_desc[j];
+            }
+        }
+
+        void computeRange(int k1, int k2)
+        {
+            /* X and Y gradient wavelet data */
+            const int NX = 2, NY = 2;
+            const int dx_s[NX][5] = {
+                {0, 0, 2, 4, -1},
+                {2, 0, 4, 4, 1}};
+            const int dy_s[NY][5] = {
+                {0, 0, 4, 2, 1},
+                {0, 2, 4, 4, -1}};
+
+            float X[nOriSampleBound], Y[nOriSampleBound], angle[nOriSampleBound];
+            gls::image<float> PATCH(PATCH_SZ + 1, PATCH_SZ + 1);
+            float DX[PATCH_SZ][PATCH_SZ], DY[PATCH_SZ][PATCH_SZ];
+
+            // TODO: should we also add the extended (dsize = 128) case?
+            const int dsize = 64;
+
+            float maxSize = 0;
+            for (int k = k1; k < k2; k++)
+            {
+                maxSize = std::max(maxSize, (*keypoints)[k].size);
+            }
+
+            for (int k = k1; k < k2; k++)
+            {
+                std::array<SurfHF, NX> dx_t;
+                std::array<SurfHF, NY> dy_t;
+                KeyPoint &kp = (*keypoints)[k];
+                float size = kp.size;
+                Point2f center = kp.pt;
+                /* The sampling intervals and wavelet sized for selecting an orientation
+                 and building the keypoint descriptor are defined relative to 's' */
+                float s = size * 1.2f / 9.0f;
+                /* To find the dominant orientation, the gradients in x and y are
+                 sampled in a circle of radius 6s using wavelets of size 4s.
+                 We ensure the gradient wavelet size is even to ensure the
+                 wavelet pattern is balanced and symmetric around its center */
+                int grad_wav_size = 2 * (int)lrint(2 * s);
+                if (sum.height < grad_wav_size || sum.width < grad_wav_size)
+                {
+                    /* when grad_wav_size is too big,
+                     * the sampling of gradient will be meaningless
+                     * mark keypoint for deletion. */
+                    kp.size = -1;
+                    continue;
                 }
 
-            // Construct the descriptor
-            for (int kk = 0; kk < dsize; kk++) {
-                (*descriptors)[k][kk] = 0;
-            }
-            float square_mag = 0;
+                float descriptor_dir = 360.f - 90.f;
+                resizeHaarPattern(dx_s, &dx_t, 4, grad_wav_size);
+                resizeHaarPattern(dy_s, &dy_t, 4, grad_wav_size);
+                int nangle = 0;
+                for (int kk = 0; kk < nOriSamples; kk++)
+                {
+                    // TODO: if we use round instead of lrint the result is slightly different
 
-            // 64-bin descriptor
-            for (int i = 0; i < 4; i++) {
-                for (int j = 0; j < 4; j++) {
-                    int index = 16 * i + 4 * j;
+                    int x = (int)lrint(center.x + apt[kk].x * s - (float)(grad_wav_size - 1) / 2);
+                    int y = (int)lrint(center.y + apt[kk].y * s - (float)(grad_wav_size - 1) / 2);
+                    if (y < 0 || y >= sum.height - grad_wav_size ||
+                        x < 0 || x >= sum.width - grad_wav_size)
+                        continue;
+                    float vx = calcHaarPattern(sum, {x, y}, dx_t);
+                    float vy = calcHaarPattern(sum, {x, y}, dy_t);
+                    X[nangle] = vx * aptw[kk];
+                    Y[nangle] = vy * aptw[kk];
+                    nangle++;
+                }
+                if (nangle == 0)
+                {
+                    // No gradient could be sampled because the keypoint is too
+                    // near too one or more of the sides of the image. As we
+                    // therefore cannot find a dominant direction, we skip this
+                    // keypoint and mark it for later deletion from the sequence.
+                    kp.size = -1;
+                    continue;
+                }
 
-                    for (int y = i * 5; y < i * 5 + 5; y++) {
-                        for (int x = j * 5; x < j * 5 + 5; x++) {
-                            float tx = DX[y][x], ty = DY[y][x];
-                            (*descriptors)[k][index + 0] += tx;
-                            (*descriptors)[k][index + 1] += ty;
-                            (*descriptors)[k][index + 2] += (float)fabs(tx);
-                            (*descriptors)[k][index + 3] += (float)fabs(ty);
+                // phase( Mat(1, nangle, CV_32F, X), Mat(1, nangle, CV_32F, Y), Mat(1, nangle, CV_32F, angle), true );
+                for (int i = 0; i < nangle; i++)
+                {
+                    float temp = atan2(Y[i], X[i]) * (180 / M_PI);
+                    if (temp < 0)
+                        angle[i] = temp + 360;
+                    else
+                        angle[i] = temp;
+                }
+
+                float bestx = 0, besty = 0, descriptor_mod = 0;
+                for (float i = 0; i < 360; i += SURF_ORI_SEARCH_INC)
+                {
+                    float sumx = 0, sumy = 0, temp_mod;
+                    for (int j = 0; j < nangle; j++)
+                    {
+                        float d = std::abs(lrint(angle[j]) - i);
+                        if (d < ORI_WIN / 2 || d > 360 - ORI_WIN / 2)
+                        {
+                            sumx += X[j];
+                            sumy += Y[j];
                         }
                     }
-                    for (int kk = 0; kk < 4; kk++) {
-                        float v = (*descriptors)[k][index + kk];
-                        square_mag += v * v;
+                    temp_mod = sumx * sumx + sumy * sumy;
+                    if (temp_mod > descriptor_mod)
+                    {
+                        descriptor_mod = temp_mod;
+                        bestx = sumx;
+                        besty = sumy;
                     }
                 }
-            }
+                descriptor_dir = atan2(-besty, bestx);
 
-            // unit vector is essential for contrast invariance
-            float scale = (float)(1. / (std::sqrt(square_mag) + FLT_EPSILON));
-            for (int kk = 0; kk < dsize; kk++) {
-                (*descriptors)[k][kk] *= scale;
+                kp.angle = descriptor_dir;
+
+                if (!descriptors)
+                    continue;
+
+                /* Extract a window of pixels around the keypoint of size 20s */
+                int win_size = (int)((PATCH_SZ + 1) * s);
+                gls::image<float> mwin(win_size, win_size);
+
+                // !upright
+                descriptor_dir *= (float)(M_PI / 180);
+                float sin_dir = -std::sin(descriptor_dir);
+                float cos_dir = std::cos(descriptor_dir);
+
+                float win_offset = -(float)(win_size - 1) / 2;
+                float start_x = center.x + win_offset * cos_dir + win_offset * sin_dir;
+                float start_y = center.y - win_offset * sin_dir + win_offset * cos_dir;
+
+                int ncols1 = img.width - 1, nrows1 = img.height - 1;
+                for (int i = 0; i < win_size; i++, start_x += sin_dir, start_y += cos_dir)
+                {
+                    float pixel_x = start_x;
+                    float pixel_y = start_y;
+                    for (int j = 0; j < win_size; j++, pixel_x += cos_dir, pixel_y -= sin_dir)
+                    {
+                        int ix = std::floor(pixel_x);
+                        int iy = std::floor(pixel_y);
+
+                        if ((unsigned)ix < (unsigned)ncols1 &&
+                            (unsigned)iy < (unsigned)nrows1)
+                        {
+                            float a = pixel_x - ix;
+                            float b = pixel_y - iy;
+
+                            mwin[i][j] = std::round((img[iy][ix] * (1 - a) + img[iy][ix + 1] * a) * (1 - b) +
+                                                    (img[iy + 1][ix] * (1 - a) + img[iy + 1][ix + 1] * a) * b);
+                        }
+                        else
+                        {
+                            int x = std::clamp((int)std::round(pixel_x), 0, ncols1);
+                            int y = std::clamp((int)std::round(pixel_y), 0, nrows1);
+                            mwin[i][j] = img[y][x];
+                        }
+                    }
+                }
+
+                // Scale the window to size PATCH_SZ so each pixel's size is s. This
+                // makes calculating the gradients with wavelets of size 2s easy
+                resizeVV(mwin, &PATCH, 0);
+
+                // Calculate gradients in x and y with wavelets of size 2s
+                for (int i = 0; i < PATCH_SZ; i++)
+                    for (int j = 0; j < PATCH_SZ; j++)
+                    {
+                        float dw = DW[i * PATCH_SZ + j];
+                        float vx = (PATCH[i][j + 1] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i + 1][j]) * dw;
+                        float vy = (PATCH[i + 1][j] - PATCH[i][j] + PATCH[i + 1][j + 1] - PATCH[i][j + 1]) * dw;
+                        DX[i][j] = vx;
+                        DY[i][j] = vy;
+                    }
+
+                // Construct the descriptor
+                for (int kk = 0; kk < dsize; kk++)
+                {
+                    (*descriptors)[k][kk] = 0;
+                }
+                float square_mag = 0;
+
+                // 64-bin descriptor
+                for (int i = 0; i < 4; i++)
+                {
+                    for (int j = 0; j < 4; j++)
+                    {
+                        int index = 16 * i + 4 * j;
+
+                        for (int y = i * 5; y < i * 5 + 5; y++)
+                        {
+                            for (int x = j * 5; x < j * 5 + 5; x++)
+                            {
+                                float tx = DX[y][x], ty = DY[y][x];
+                                (*descriptors)[k][index + 0] += tx;
+                                (*descriptors)[k][index + 1] += ty;
+                                (*descriptors)[k][index + 2] += (float)fabs(tx);
+                                (*descriptors)[k][index + 3] += (float)fabs(ty);
+                            }
+                        }
+                        for (int kk = 0; kk < 4; kk++)
+                        {
+                            float v = (*descriptors)[k][index + kk];
+                            square_mag += v * v;
+                        }
+                    }
+                }
+
+                // unit vector is essential for contrast invariance
+                float scale = (float)(1. / (std::sqrt(square_mag) + FLT_EPSILON));
+                for (int kk = 0; kk < dsize; kk++)
+                {
+                    (*descriptors)[k][kk] *= scale;
+                }
+            }
+        }
+
+        void run()
+        {
+            const int K = (int)keypoints->size();
+
+            if (K > 32)
+            {
+                const int threads = 8;
+                ThreadPool threadPool(threads);
+
+                const int ranges = (int)std::ceil((float)K / threads);
+                for (int rr = 0; rr < ranges; rr++)
+                {
+                    int k1 = ranges * rr;
+                    int k2 = std::min(ranges * (rr + 1), K);
+
+                    threadPool.enqueue([this, k1, k2]()
+                                       { computeRange(k1, k2); });
+                }
+            }
+            else
+            {
+                computeRange(0, K);
+            }
+        }
+    };
+
+    void descriptor(const gls::image<float> &srcImg,
+                    const gls::image<float> &integralSum,
+                    std::vector<KeyPoint> *keypoints,
+                    gls::image<float> *descriptors)
+    {
+        int N = (int)keypoints->size();
+        if (N > 0)
+        {
+            SURFInvoker(srcImg, integralSum, keypoints, descriptors).run();
+        }
+    }
+
+    template <typename T, int N = 4>
+    std::array<typename gls::cl_image_2d<T>::unique_ptr, N> sumImageStack(cl::Context context, int width, int height)
+    {
+        std::array<typename gls::cl_image_2d<T>::unique_ptr, N> result;
+        for (int i = 0; i < N; i++)
+        {
+            int step = 1 << i;
+            result[i] = std::make_unique<gls::cl_image_buffer_2d<T>>(context, 1 + (width - 1) / step, 1 + (height - 1) / step);
+        }
+        return result;
+    }
+
+    void SURFBuild(const std::array<gls::image<float>::unique_ptr, 4> &sum,
+                   const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
+                   const std::vector<gls::image<float>::unique_ptr> &dets,
+                   const std::vector<gls::image<float>::unique_ptr> &traces,
+                   int nOctaves, int nOctaveLayers)
+    {
+        int N = (int)sizes.size();
+        std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
+
+        ThreadPool threadPool(8);
+
+        const int layers = nOctaveLayers + 2;
+
+        assert(nOctaves * layers == N);
+
+        for (int octave = 0; octave < nOctaves; octave++)
+        {
+            for (int layer = 0; layer < layers; layer++)
+            {
+                const int i = octave * layers + layer;
+                /*
+                     RANSAC interior point ratio - number of loops: 121 150 39
+                      Transformation matrix parameter:
+                     0.989685 0.027618 84.000000
+                    -0.030334 0.993164 119.187500
+                    -0.000002 -0.000002 1
+                 */
+                threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, i]()
+                                   { calcLayerDetAndTrace(*sum[0], sizes[i], sampleSteps[i], dets[i].get(), traces[i].get()); });
             }
         }
     }
 
-    void run() {
-        const int K = (int) keypoints->size();
+    void SURFFind(const gls::image<float> &sum,
+                  const std::vector<gls::image<float>::unique_ptr> &dets,
+                  const std::vector<gls::image<float>::unique_ptr> &traces,
+                  const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
+                  const std::vector<int> &middleIndices, std::vector<KeyPoint> *keypoints,
+                  int nOctaveLayers, float hessianThreshold)
+    {
+        std::mutex keypointsMutex;
+        ThreadPool threadPool(8);
 
-        if (K > 32) {
-            const int threads = 8;
-            ThreadPool threadPool(threads);
+        int M = (int)middleIndices.size();
+        std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
+        for (int i = 0; i < M; i++)
+        {
+            const int layer = middleIndices[i];
+            const int octave = i / nOctaveLayers;
 
-            const int ranges = (int) std::ceil((float) K / threads);
-            for (int rr = 0; rr < ranges; rr++) {
-                int k1 = ranges * rr;
-                int k2 = std::min(ranges * (rr + 1), K);
-
-                threadPool.enqueue([this, k1, k2](){
-                    computeRange(k1, k2);
-                });
-            }
-        } else {
-            computeRange(0, K);
-        }
-    }
-};
-
-void descriptor(const gls::image<float>& srcImg,
-                const gls::image<float>& integralSum,
-                std::vector<KeyPoint>* keypoints,
-                gls::image<float>* descriptors) {
-    int N = (int) keypoints->size();
-    if (N > 0) {
-        SURFInvoker(srcImg, integralSum, keypoints, descriptors).run();
-    }
-}
-
-template <typename T, int N = 4>
-std::array<typename gls::cl_image_2d<T>::unique_ptr, N> sumImageStack(cl::Context context, int width, int height) {
-    std::array<typename gls::cl_image_2d<T>::unique_ptr, N> result;
-    for (int i = 0; i < N; i++) {
-        int step = 1 << i;
-        result[i] = std::make_unique<gls::cl_image_buffer_2d<T>>(context, 1 + (width - 1) / step, 1 + (height - 1) / step);
-    }
-    return result;
-}
-
-void SURFBuild(const std::array<gls::image<float>::unique_ptr, 4>& sum,
-               const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
-               const std::vector<gls::image<float>::unique_ptr>& dets,
-               const std::vector<gls::image<float>::unique_ptr>& traces,
-               int nOctaves, int nOctaveLayers) {
-    int N = (int) sizes.size();
-    std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
-
-    ThreadPool threadPool(8);
-
-    const int layers = nOctaveLayers + 2;
-
-    assert(nOctaves * layers == N);
-
-    for (int octave = 0; octave < nOctaves; octave++) {
-        for (int layer = 0; layer < layers; layer++) {
-            const int i = octave * layers + layer;
-            /*
-                 RANSAC interior point ratio - number of loops: 121 150 39
-                  Transformation matrix parameter:
-                 0.989685 0.027618 84.000000
-                -0.030334 0.993164 119.187500
-                -0.000002 -0.000002 1
-             */
-            threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, i](){
-                calcLayerDetAndTrace(*sum[0], sizes[i], sampleSteps[i], dets[i].get(), traces[i].get());
-            });
-        }
-    }
-}
-
-void SURFFind(const gls::image<float>& sum,
-              const std::vector<gls::image<float>::unique_ptr>& dets,
-              const std::vector<gls::image<float>::unique_ptr>& traces,
-              const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
-              const std::vector<int>& middleIndices, std::vector<KeyPoint>* keypoints,
-              int nOctaveLayers, float hessianThreshold) {
-    std::mutex keypointsMutex;
-    ThreadPool threadPool(8);
-
-    int M = (int) middleIndices.size();
-    std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
-    for (int i = 0; i < M; i++) {
-        const int layer = middleIndices[i];
-        const int octave = i / nOctaveLayers;
-
-        threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, &keypoints, &keypointsMutex,
-                             layer, octave, hessianThreshold](){
+            threadPool.enqueue([&sum, &dets, &traces, &sizes, &sampleSteps, &keypoints, &keypointsMutex,
+                                layer, octave, hessianThreshold]()
+                               {
             auto dets0 = dets[layer-1].get();
             auto dets1 = dets[layer].get();
             auto dets2 = dets[layer+1].get();
@@ -781,863 +881,938 @@ void SURFFind(const gls::image<float>& sum,
 
             findMaximaInLayer(sum.width - 1, sum.height - 1, { dets0, dets1, dets2 },
                               *traceImage, { sizes[layer-1], sizes[layer], sizes[layer+1] },
-                              keypoints, octave, hessianThreshold, sampleSteps[layer], keypointsMutex);
-        });
-    }
-}
-
-class SURF_OpenCL : public SURF {
-private:
-    gls::OpenCLContext* _glsContext;
-
-    const int _width;
-    const int _height;
-    const int _max_features;
-    const int _nOctaves;
-    const int _nOctaveLayers;
-    const float _hessianThreshold;
-
-    gls::cl_image_buffer_2d<float>::unique_ptr _integralInputImage = nullptr;
-    cl::Buffer _integralTmpBuffer;
-    cl::Buffer _surfHFDataBuffer;
-    cl::Buffer _keyPointsBuffer;
-
-    std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _dets;
-    std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _traces;
-
-    /* Sampling step along image x and y axes at first octave. This is doubled
-    for each additional octave. WARNING: Increasing this improves speed,
-    however keypoint extraction becomes unreliable. */
-    static const int SAMPLE_STEP0 = 1;
-
-    void calcDetAndTrace(const gls::cl_image_2d<float>& sumImage, gls::cl_image_2d<float>* detImage,
-                      gls::cl_image_2d<float>* traceImage, const int sampleStep,
-                      const DetAndTraceHaarPattern& haarPattern);
-
-    void calcDetAndTrace(const gls::cl_image_2d<float>& sumImage,
-                      const std::array<gls::cl_image_2d<float>*, 4>& detImage,
-                      const std::array<gls::cl_image_2d<float>*, 4>& traceImage, const int sampleStep,
-                      const std::array<DetAndTraceHaarPattern, 4>& haarPattern);
-
-    void findMaximaInLayer(const std::array<const gls::cl_image_2d<float>*, 3>& dets,
-                        const gls::cl_image_2d<float>& traceImage, const std::array<int, 3>& sizes, int octave,
-                        float hessianThreshold, int sampleStep);
-
-    void Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum, const std::vector<int>& sizes,
-            const std::vector<int>& sampleSteps, const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
-            const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces);
-
-    void Find(const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
-           const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces, const std::vector<int>& sizes,
-           const std::vector<int>& sampleSteps, const std::vector<int>& middleIndices,
-           std::vector<KeyPoint>* keypoints, int nOctaveLayers, float hessianThreshold);
-
-    void fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
-                          std::vector<KeyPoint>* keypoints, int nOctaves, int nOctaveLayers, float hessianThreshold);
-
-public:
-    SURF_OpenCL(gls::OpenCLContext * glsContext, int width, int height,
-                int max_features = -1, int nOctaves = 4,
-                int nOctaveLayers = 2, float hessianThreshold = 0.02);
-
-    void integral(const gls::image<float>& img, const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum) override;
-
-    void detect(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& integralSum, std::vector<KeyPoint>* keypoints) override {
-        fastHessianDetector(integralSum, keypoints, _nOctaves, _nOctaveLayers, _hessianThreshold);
-    }
-
-    void detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints,
-                          gls::image<float>::unique_ptr* _descriptors) override {
-        detectAndCompute(img, keypoints, _descriptors, {1, 1});
-    }
-
-    void detectAndCompute(const gls::image<float>& img, std::vector<KeyPoint>* keypoints,
-                          gls::image<float>::unique_ptr* _descriptors, gls::size sections = {1, 1});
-
-
-    std::vector<DMatch> matchKeyPoints(const gls::image<float>& descriptor1, const gls::image<float>& descriptor2)
-     override;
-};
-
-std::unique_ptr<SURF> SURF::makeInstance(gls::OpenCLContext* glsContext, int width, int height, int max_features, int nOctaves, int nOctaveLayers, float hessianThreshold) {
-    return std::make_unique<SURF_OpenCL>(glsContext, width, height, max_features, nOctaves, nOctaveLayers, hessianThreshold);
-}
-
-SURF_OpenCL::SURF_OpenCL(gls::OpenCLContext* glsContext, int width, int height, int max_features, int nOctaves, int nOctaveLayers, float hessianThreshold)
-    : _glsContext(glsContext),
-      _width(width),
-      _height(height),
-      _max_features(max_features),
-      _nOctaves(nOctaves),
-      _nOctaveLayers(nOctaveLayers),
-      _hessianThreshold(hessianThreshold) {
-    int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
-
-    if (_dets.size() != nTotalLayers) {
-        printf("resizing dets and traces vectors to %d\n", nTotalLayers);
-        _dets.resize(nTotalLayers);
-        _traces.resize(nTotalLayers);
-    }
-
-    // Allocate space for each layer
-    int index = 0, step = SAMPLE_STEP0;
-
-    for (int octave = 0; octave < nOctaves; octave++) {
-        for (int layer = 0; layer < nOctaveLayers + 2; layer++) {
-            /* The integral image sum is one pixel bigger than the source image*/
-            if (_dets[index] == nullptr) {
-                _dets[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(), width / step,
-                                                                                height / step);
-                _traces[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(),
-                                                                                  width / step, height / step);
-            }
-            index++;
+                              keypoints, octave, hessianThreshold, sampleSteps[layer], keypointsMutex); });
         }
-        step *= 2;
     }
-}
 
-void SURF_OpenCL::integral(const gls::image<float>& img,
-                           const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum) {
-    static const int tileSize = 8;
+    class SURF_OpenCL : public SURF
+    {
+    private:
+        gls::OpenCLContext *_glsContext;
 
-    gls::size tmpSize(((_height + tileSize - 1) / tileSize) * tileSize, ((_width + tileSize - 1) / tileSize) * tileSize);
-    if (_integralTmpBuffer.get() == 0) {
-        _integralTmpBuffer = cl::Buffer(CL_MEM_READ_WRITE, tmpSize.width * tmpSize.height * sizeof(float));
-    }
-    if (_integralInputImage == nullptr) {
-        _integralInputImage = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(), img.width, img.height);
-    }
-    _integralInputImage->copyPixelsFrom(img);
+        const int _width;
+        const int _height;
+        const int _max_features;
+        const int _nOctaves;
+        const int _nOctaveLayers;
+        const float _hessianThreshold;
 
-    // Load the shader source
-    const auto program = _glsContext->loadProgram("SURF");
+        gls::cl_image_buffer_2d<float>::unique_ptr _integralInputImage = nullptr;
+        cl::Buffer _integralTmpBuffer;
+        cl::Buffer _surfHFDataBuffer;
+        cl::Buffer _keyPointsBuffer;
 
-    // Bind the kernel parameters
-    auto integral_sum_cols = cl::KernelFunctor<cl::Image2D, // src_ptr
-                                               cl::Buffer,  // buf_ptr
-                                               int          // buf_width
-                                               >(program, "integral_sum_cols_image");
+        std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _dets;
+        std::vector<gls::cl_image_buffer_2d<float>::unique_ptr> _traces;
 
-    // Schedule the kernel on the GPU
-    integral_sum_cols(cl::EnqueueArgs(cl::NDRange(_width), cl::NDRange(tileSize)),
-                      _integralInputImage->getImage2D(),
-                      _integralTmpBuffer,
-                      tmpSize.width);
+        /* Sampling step along image x and y axes at first octave. This is doubled
+        for each additional octave. WARNING: Increasing this improves speed,
+        however keypoint extraction becomes unreliable. */
+        static const int SAMPLE_STEP0 = 1;
 
-    // Bind the kernel parameters
-    auto integral_sum_rows = cl::KernelFunctor<cl::Buffer,  // buf_ptr
-                                               int,         // buf_width
-                                               cl::Image2D, // sum0
-                                               cl::Image2D, // sum1
-                                               cl::Image2D, // sum2
-                                               cl::Image2D  // sum3
-                                               >(program, "integral_sum_rows_image");
+        void calcDetAndTrace(const gls::cl_image_2d<float> &sumImage, gls::cl_image_2d<float> *detImage,
+                             gls::cl_image_2d<float> *traceImage, const int sampleStep,
+                             const DetAndTraceHaarPattern &haarPattern);
 
-    // Schedule the kernel on the GPU
-    integral_sum_rows(cl::EnqueueArgs(cl::NDRange(_height), cl::NDRange(tileSize)),
-                      _integralTmpBuffer,
-                      tmpSize.width,
-                      sum[0]->getImage2D(),
-                      sum[1]->getImage2D(),
-                      sum[2]->getImage2D(),
-                      sum[3]->getImage2D());
-}
+        void calcDetAndTrace(const gls::cl_image_2d<float> &sumImage,
+                             const std::array<gls::cl_image_2d<float> *, 4> &detImage,
+                             const std::array<gls::cl_image_2d<float> *, 4> &traceImage, const int sampleStep,
+                             const std::array<DetAndTraceHaarPattern, 4> &haarPattern);
 
-void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float>& sumImage,
-                             gls::cl_image_2d<float>* detImage,
-                             gls::cl_image_2d<float>* traceImage,
-                             const int sampleStep,
-                             const DetAndTraceHaarPattern& haarPattern) {
-    // Load the shader source
-    const auto program = _glsContext->loadProgram("SURF");
+        void findMaximaInLayer(const std::array<const gls::cl_image_2d<float> *, 3> &dets,
+                               const gls::cl_image_2d<float> &traceImage, const std::array<int, 3> &sizes, int octave,
+                               float hessianThreshold, int sampleStep);
 
-    // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // sumImage
-                                    cl::Image2D,  // detImage
-                                    cl::Image2D,  // traceImage
-                                    int,          // sampleStep
-                                    cl_float2,    // w
-                                    cl_int2,      // margin
-                                    cl::Buffer    // surfHFData
-                                    >(program, "calcDetAndTrace");
+        void Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum, const std::vector<int> &sizes,
+                   const std::vector<int> &sampleSteps, const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
+                   const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces);
 
-    const clSurfHF surfHFData(haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
+        void Find(const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
+                  const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces, const std::vector<int> &sizes,
+                  const std::vector<int> &sampleSteps, const std::vector<int> &middleIndices,
+                  std::vector<KeyPoint> *keypoints, int nOctaveLayers, float hessianThreshold);
 
-    if (_surfHFDataBuffer.get() == 0) {
-        _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(clSurfHF));
-    }
-    cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(clSurfHF), &surfHFData);
+        void fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum,
+                                 std::vector<KeyPoint> *keypoints, int nOctaves, int nOctaveLayers, float hessianThreshold);
 
-    const auto& margin_crop = haarPattern.margin_crop;
+    public:
+        SURF_OpenCL(gls::OpenCLContext *glsContext, int width, int height,
+                    int max_features = -1, int nOctaves = 4,
+                    int nOctaveLayers = 2, float hessianThreshold = 0.02);
 
-    // Schedule the kernel on the GPU
-    kernel(
-#if __APPLE__
-           gls::OpenCLContext::buildEnqueueArgs(margin_crop.width, margin_crop.height),
-#else
-           cl::EnqueueArgs(cl::NDRange(margin_crop.width, margin_crop.height), cl::NDRange(32, 32)),
-#endif
-           sumImage.getImage2D(), detImage->getImage2D(), traceImage->getImage2D(),
-           sampleStep, { haarPattern.Dx[0].w, haarPattern.Dxy[0].w }, { margin_crop.x, margin_crop.y }, _surfHFDataBuffer);
-}
+        void integral(const gls::image<float> &img, const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum) override;
 
-void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float>& sumImage,
-                             const std::array<gls::cl_image_2d<float>*, 4>& detImage,
-                             const std::array<gls::cl_image_2d<float>*, 4>& traceImage,
-                             const int sampleStep,
-                             const std::array<DetAndTraceHaarPattern, 4>& haarPattern) {
-    // Load the shader source
-    const auto program = _glsContext->loadProgram("SURF");
+        void detect(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &integralSum, std::vector<KeyPoint> *keypoints) override
+        {
+            fastHessianDetector(integralSum, keypoints, _nOctaves, _nOctaveLayers, _hessianThreshold);
+        }
 
-    // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // sumImage
-                                    cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D,  // detImage
-                                    cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D,  // traceImage
-                                    cl_int,       // sampleStep
-                                    cl_float8,    // w
-                                    cl_int4,      // margin
-                                    cl::Buffer    // surfHFData
-                                    >(program, "calcDetAndTrace4");
+        void detectAndCompute(const gls::image<float> &img, std::vector<KeyPoint> *keypoints,
+                              gls::image<float>::unique_ptr *_descriptors) override
+        {
+            detectAndCompute(img, keypoints, _descriptors, {1, 1});
+        }
 
-    const std::array<clSurfHF, 4> surfHFData = {
-        clSurfHF(haarPattern[0].Dx, haarPattern[0].Dy, haarPattern[0].Dxy),
-        clSurfHF(haarPattern[1].Dx, haarPattern[1].Dy, haarPattern[1].Dxy),
-        clSurfHF(haarPattern[2].Dx, haarPattern[2].Dy, haarPattern[2].Dxy),
-        clSurfHF(haarPattern[3].Dx, haarPattern[3].Dy, haarPattern[3].Dxy)
+        void detectAndCompute(const gls::image<float> &img, std::vector<KeyPoint> *keypoints,
+                              gls::image<float>::unique_ptr *_descriptors, gls::size sections = {1, 1});
+
+        std::vector<DMatch> matchKeyPoints(const gls::image<float> &descriptor1, const gls::image<float> &descriptor2)
+            override;
     };
 
-    if (_surfHFDataBuffer.get() == 0) {
-        _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(surfHFData));
+    std::unique_ptr<SURF> SURF::makeInstance(gls::OpenCLContext *glsContext, int width, int height, int max_features, int nOctaves, int nOctaveLayers, float hessianThreshold)
+    {
+        return std::make_unique<SURF_OpenCL>(glsContext, width, height, max_features, nOctaves, nOctaveLayers, hessianThreshold);
     }
-    cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(surfHFData), &surfHFData);
 
-    kernel(
-#if __APPLE__
-           gls::OpenCLContext::buildEnqueueArgs(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height),
-#else
-           cl::EnqueueArgs(cl::NDRange(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height), cl::NDRange(32, 32)),
-#endif
-           sumImage.getImage2D(),
-           detImage[0]->getImage2D(), detImage[1]->getImage2D(), detImage[2]->getImage2D(), detImage[3]->getImage2D(),
-           traceImage[0]->getImage2D(), traceImage[1]->getImage2D(), traceImage[2]->getImage2D(), traceImage[3]->getImage2D(),
-           sampleStep,
-           {
-               haarPattern[0].Dx[0].w, haarPattern[0].Dxy[0].w,
-               haarPattern[1].Dx[0].w, haarPattern[1].Dxy[0].w,
-               haarPattern[2].Dx[0].w, haarPattern[2].Dxy[0].w,
-               haarPattern[3].Dx[0].w, haarPattern[3].Dxy[0].w
-           },
-           { haarPattern[0].margin_crop.x, haarPattern[1].margin_crop.x, haarPattern[2].margin_crop.x, haarPattern[3].margin_crop.x },
-           _surfHFDataBuffer);
-}
+    SURF_OpenCL::SURF_OpenCL(gls::OpenCLContext *glsContext, int width, int height, int max_features, int nOctaves, int nOctaveLayers, float hessianThreshold)
+        : _glsContext(glsContext),
+          _width(width),
+          _height(height),
+          _max_features(max_features),
+          _nOctaves(nOctaves),
+          _nOctaveLayers(nOctaveLayers),
+          _hessianThreshold(hessianThreshold)
+    {
+        int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
 
-void SURF_OpenCL::Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
-                 const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
-                 const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
-                 const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces) {
-    int N = (int) sizes.size();
-    std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
-
-    const int layers = _nOctaveLayers + 2;
-
-    assert(_nOctaves * layers == N);
-
-    for (int octave = 0; octave < _nOctaves; octave++) {
-#if __ANDROID__
-        const int i = octave * layers;
-
-        std::array<DetAndTraceHaarPattern, 4> haarPatterns = {
-            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]),
-            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i+1], sampleSteps[i+1]),
-            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i+2], sampleSteps[i+2]),
-            DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i+3], sampleSteps[i+3])
-        };
-
-#if USE_INTEGRAL_PYRAMID
-        for (auto& haarPattern : haarPatterns) {
-            // Rescale sampling points to the pyramid level
-            haarPattern.rescale(sampleSteps[i]);
+        if (_dets.size() != nTotalLayers)
+        {
+            printf("resizing dets and traces vectors to %d\n", nTotalLayers);
+            _dets.resize(nTotalLayers);
+            _traces.resize(nTotalLayers);
         }
-        int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2 : sampleSteps[i] == 2 ? 1 : 0;
-        calcDetAndTrace(*sum[idx], { dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get() },
-                          { traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get() },
-                          1 /* sampleSteps[i] */, haarPatterns);
-#else
-//        // Emulate the integral pyramid scaling roundoff
-//        for (auto& haarPattern : haarPatterns) {
-//            haarPattern.rescale(sampleSteps[i]);
-//            haarPattern.upscale(sampleSteps[i]);
-//        }
 
-        calcDetAndTrace(*sum[0], { dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get() },
-                          { traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get() },
-                          sampleSteps[i], haarPatterns);
-#endif
-#else
-        for (int layer = 0; layer < layers; layer++) {
-            const int i = octave * layers + layer;
-            DetAndTraceHaarPattern haarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]);
+        // Allocate space for each layer
+        int index = 0, step = SAMPLE_STEP0;
 
-//            std::cout << "DetAndTraceHaarPattern: " << sum[0]->width << ", " << sum[0]->height << ", " << sizes[i] << ", " << sampleSteps[i] << std::endl;
-
-#if USE_INTEGRAL_PYRAMID
-            // Rescale sampling points to the pyramid level
-            haarPattern.rescale(sampleSteps[i]);
-
-            const int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2 : sampleSteps[i] == 2 ? 1 : 0;
-            calcDetAndTrace(*sum[idx], dets[i].get(), traces[i].get(), 1, haarPattern);
-#else
-//            // Emulate the integral pyramid scaling roundoff
-//            haarPattern.rescale(sampleSteps[i]);
-//            haarPattern.upscale(sampleSteps[i]);
-
-            calcDetAndTrace(*sum[0], dets[i].get(), traces[i].get(), sampleSteps[i], haarPattern);
-#endif
-        }
-#endif
-    }
-}
-
-/*
- * Find the maxima in the determinant of the Hessian in a layer of the
- * scale-space pyramid
- */
-
-typedef struct KeyPointMaxima {
-    static constexpr int MaxCount = 64000;
-    int count;
-    KeyPoint keyPoints[MaxCount];
-} KeyPointMaxima;
-
-void SURF_OpenCL::findMaximaInLayer(const std::array<const gls::cl_image_2d<float>*, 3>& dets,
-                               const gls::cl_image_2d<float>& traceImage,
-                               const std::array<int, 3>& sizes,
-                               int octave, float hessianThreshold, int sampleStep) {
-    // Load the shader source
-    const auto program = _glsContext->loadProgram("SURF");
-
-    // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // detImage0
-                                    cl::Image2D,  // detImage1
-                                    cl::Image2D,  // detImage2
-                                    cl::Image2D,  // traceImage
-                                    cl_int3,      // sizes
-                                    cl::Buffer,   // keypoints
-                                    int,          // margin
-                                    int,          // octave
-                                    float,        // hessianThreshold
-                                    int           // sampleStep
-                                    >(program, "findMaximaInLayer");
-
-    if (_keyPointsBuffer() == 0) {
-        _keyPointsBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(KeyPointMaxima));
-    }
-
-    const int layer_height = _height / sampleStep;
-    const int layer_width = _width / sampleStep;
-
-    // Ignore pixels without a 3x3x3 neighbourhood in the layer above
-    const int margin = (sizes[2] / 2) / sampleStep + 1;
-
-    // Schedule the kernel on the GPU
-    kernel(
-#if __APPLE__
-           gls::OpenCLContext::buildEnqueueArgs(layer_width - 2 * margin, layer_height - 2 * margin),
-#else
-           cl::EnqueueArgs(cl::NDRange(layer_width - 2 * margin, layer_height - 2 * margin), cl::NDRange(32, 32)),
-#endif
-           dets[0]->getImage2D(), dets[1]->getImage2D(), dets[2]->getImage2D(),
-           traceImage.getImage2D(),
-           { sizes[0], sizes[1], sizes[2] }, _keyPointsBuffer,
-           margin, octave, hessianThreshold, sampleStep);
-}
-
-void SURF_OpenCL::Find(const std::vector<gls::cl_image_2d<float>::unique_ptr>& dets,
-                const std::vector<gls::cl_image_2d<float>::unique_ptr>& traces,
-                const std::vector<int>& sizes, const std::vector<int>& sampleSteps,
-                const std::vector<int>& middleIndices, std::vector<KeyPoint>* keypoints,
-                int nOctaveLayers, float hessianThreshold) {
-    int M = (int) middleIndices.size();
-    std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
-    for (int i = 0; i < M; i++) {
-        const int layer = middleIndices[i];
-        const int octave = i / nOctaveLayers;
-
-        const std::array<const gls::cl_image_2d<float>*, 3> detImages = {
-            dets[layer-1].get(),
-            dets[layer].get(),
-            dets[layer+1].get()
-        };
-
-        const auto traceImage = traces[layer].get();
-
-        findMaximaInLayer(detImages, *traceImage,
-                            { sizes[layer-1], sizes[layer], sizes[layer+1] },
-                            octave, hessianThreshold, sampleSteps[layer]);
-    }
-
-    // Collect results
-    const auto keyPointMaxima = (KeyPointMaxima *) cl::enqueueMapBuffer(_keyPointsBuffer, true, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(KeyPointMaxima));
-
-    std::cout << "keyPointMaxima: " << keyPointMaxima->count << std::endl;
-    std::span<KeyPoint> newElements(keyPointMaxima->keyPoints, std::min(keyPointMaxima->count, KeyPointMaxima::MaxCount));
-    keypoints->insert(end(*keypoints), begin(newElements), end(newElements));
-
-    // Reset count
-    keyPointMaxima->count = 0;
-
-    cl::enqueueUnmapMemObject(_keyPointsBuffer, (void*)keyPointMaxima);
-}
-
-struct KeypointGreater {
-    inline bool operator()(const KeyPoint& kp1, const KeyPoint& kp2) const {
-        if (kp1.response > kp2.response) return true;
-        if (kp1.response < kp2.response) return false;
-        if (kp1.size > kp2.size) return true;
-        if (kp1.size < kp2.size) return false;
-        if (kp1.octave > kp2.octave) return true;
-        if (kp1.octave < kp2.octave) return false;
-        if (kp1.pt.y < kp2.pt.y) return false;
-        if (kp1.pt.y > kp2.pt.y) return true;
-        return kp1.pt.x < kp2.pt.x;
-    }
-};
-
-void SURF_OpenCL::fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4>& sum,
-                               std::vector<KeyPoint>* keypoints,
-                               int nOctaves, int nOctaveLayers, float hessianThreshold) {
-    int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
-    int nMiddleLayers = nOctaveLayers * nOctaves;
-
-    std::vector<int> sizes(nTotalLayers);
-    std::vector<int> sampleSteps(nTotalLayers);
-    std::vector<int> middleIndices(nMiddleLayers);
-
-    // Calculate properties of each layer
-    int index = 0, middleIndex = 0, step = SAMPLE_STEP0;
-
-    for (int octave = 0; octave < nOctaves; octave++) {
-        for (int layer = 0; layer < nOctaveLayers + 2; layer++) {
-            sizes[index] = (SURF_HAAR_SIZE0 + SURF_HAAR_SIZE_INC * layer) << octave;
-            sampleSteps[index] = step;
-
-            if (0 < layer && layer <= nOctaveLayers) {
-                middleIndices[middleIndex++] = index;
+        for (int octave = 0; octave < nOctaves; octave++)
+        {
+            for (int layer = 0; layer < nOctaveLayers + 2; layer++)
+            {
+                /* The integral image sum is one pixel bigger than the source image*/
+                if (_dets[index] == nullptr)
+                {
+                    _dets[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(), width / step,
+                                                                                    height / step);
+                    _traces[index] = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(),
+                                                                                      width / step, height / step);
+                }
+                index++;
             }
-            index++;
+            step *= 2;
         }
-        step *= 2;
     }
 
-    auto t_start = std::chrono::high_resolution_clock::now();
+    void SURF_OpenCL::integral(const gls::image<float> &img,
+                               const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum)
+    {
+        static const int tileSize = 8;
 
-    // Calculate hessian determinant and trace samples in each layer
-    Build(sum, sizes, sampleSteps, _dets, _traces);
+        gls::size tmpSize(((_height + tileSize - 1) / tileSize) * tileSize, ((_width + tileSize - 1) / tileSize) * tileSize);
+        if (_integralTmpBuffer.get() == 0)
+        {
+            _integralTmpBuffer = cl::Buffer(CL_MEM_READ_WRITE, tmpSize.width * tmpSize.height * sizeof(float));
+        }
+        if (_integralInputImage == nullptr)
+        {
+            _integralInputImage = std::make_unique<gls::cl_image_buffer_2d<float>>(_glsContext->clContext(), img.width, img.height);
+        }
+        _integralInputImage->copyPixelsFrom(img);
 
-    // Find maxima in the determinant of the hessian
-    Find(_dets, _traces, sizes, sampleSteps, middleIndices, keypoints, nOctaveLayers, hessianThreshold);
+        // Load the shader source
+        const auto program = _glsContext->loadProgram("SURF");
 
-    auto t_end = std::chrono::high_resolution_clock::now();
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
-    printf("Features Finding Time: %.2fms\n", elapsed_time_ms);
+        // Bind the kernel parameters
+        auto integral_sum_cols = cl::KernelFunctor<cl::Image2D, // src_ptr
+                                                   cl::Buffer,  // buf_ptr
+                                                   int          // buf_width
+                                                   >(program, "integral_sum_cols_image");
 
-    sort(keypoints->begin(), keypoints->end(), KeypointGreater());
-}
+        // Schedule the kernel on the GPU
+        integral_sum_cols(cl::EnqueueArgs(cl::NDRange(_width), cl::NDRange(tileSize)),
+                          _integralInputImage->getImage2D(),
+                          _integralTmpBuffer,
+                          tmpSize.width);
 
-static inline float L2Norm(const float* p1, const float* p2, int n) {
-    float sum = 0;
-    for (int i = 0; i < n; i++) {
-        float diff = p1[i] - p2[i];
-        sum += diff * diff;
+        // Bind the kernel parameters
+        auto integral_sum_rows = cl::KernelFunctor<cl::Buffer,  // buf_ptr
+                                                   int,         // buf_width
+                                                   cl::Image2D, // sum0
+                                                   cl::Image2D, // sum1
+                                                   cl::Image2D, // sum2
+                                                   cl::Image2D  // sum3
+                                                   >(program, "integral_sum_rows_image");
+
+        // Schedule the kernel on the GPU
+        integral_sum_rows(cl::EnqueueArgs(cl::NDRange(_height), cl::NDRange(tileSize)),
+                          _integralTmpBuffer,
+                          tmpSize.width,
+                          sum[0]->getImage2D(),
+                          sum[1]->getImage2D(),
+                          sum[2]->getImage2D(),
+                          sum[3]->getImage2D());
     }
-    return sqrtf(sum);
-}
+
+    void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float> &sumImage,
+                                      gls::cl_image_2d<float> *detImage,
+                                      gls::cl_image_2d<float> *traceImage,
+                                      const int sampleStep,
+                                      const DetAndTraceHaarPattern &haarPattern)
+    {
+        // Load the shader source
+        const auto program = _glsContext->loadProgram("SURF");
+
+        // Bind the kernel parameters
+        auto kernel = cl::KernelFunctor<cl::Image2D, // sumImage
+                                        cl::Image2D, // detImage
+                                        cl::Image2D, // traceImage
+                                        int,         // sampleStep
+                                        cl_float2,   // w
+                                        cl_int2,     // margin
+                                        cl::Buffer   // surfHFData
+                                        >(program, "calcDetAndTrace");
+
+        const clSurfHF surfHFData(haarPattern.Dx, haarPattern.Dy, haarPattern.Dxy);
+
+        if (_surfHFDataBuffer.get() == 0)
+        {
+            _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(clSurfHF));
+        }
+        cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(clSurfHF), &surfHFData);
+
+        const auto &margin_crop = haarPattern.margin_crop;
+
+        // Schedule the kernel on the GPU
+        kernel(
+#if __APPLE__
+            gls::OpenCLContext::buildEnqueueArgs(margin_crop.width, margin_crop.height),
+#else
+            cl::EnqueueArgs(cl::NDRange(margin_crop.width, margin_crop.height), cl::NDRange(32, 32)),
+#endif
+            sumImage.getImage2D(), detImage->getImage2D(), traceImage->getImage2D(),
+            sampleStep, {haarPattern.Dx[0].w, haarPattern.Dxy[0].w}, {margin_crop.x, margin_crop.y}, _surfHFDataBuffer);
+    }
+
+    void SURF_OpenCL::calcDetAndTrace(const gls::cl_image_2d<float> &sumImage,
+                                      const std::array<gls::cl_image_2d<float> *, 4> &detImage,
+                                      const std::array<gls::cl_image_2d<float> *, 4> &traceImage,
+                                      const int sampleStep,
+                                      const std::array<DetAndTraceHaarPattern, 4> &haarPattern)
+    {
+        // Load the shader source
+        const auto program = _glsContext->loadProgram("SURF");
+
+        // Bind the kernel parameters
+        auto kernel = cl::KernelFunctor<cl::Image2D,                                        // sumImage
+                                        cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D, // detImage
+                                        cl::Image2D, cl::Image2D, cl::Image2D, cl::Image2D, // traceImage
+                                        cl_int,                                             // sampleStep
+                                        cl_float8,                                          // w
+                                        cl_int4,                                            // margin
+                                        cl::Buffer                                          // surfHFData
+                                        >(program, "calcDetAndTrace4");
+
+        const std::array<clSurfHF, 4> surfHFData = {
+            clSurfHF(haarPattern[0].Dx, haarPattern[0].Dy, haarPattern[0].Dxy),
+            clSurfHF(haarPattern[1].Dx, haarPattern[1].Dy, haarPattern[1].Dxy),
+            clSurfHF(haarPattern[2].Dx, haarPattern[2].Dy, haarPattern[2].Dxy),
+            clSurfHF(haarPattern[3].Dx, haarPattern[3].Dy, haarPattern[3].Dxy)};
+
+        if (_surfHFDataBuffer.get() == 0)
+        {
+            _surfHFDataBuffer = cl::Buffer(CL_MEM_READ_ONLY, sizeof(surfHFData));
+        }
+        cl::enqueueWriteBuffer(_surfHFDataBuffer, false, 0, sizeof(surfHFData), &surfHFData);
+
+        kernel(
+#if __APPLE__
+            gls::OpenCLContext::buildEnqueueArgs(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height),
+#else
+            cl::EnqueueArgs(cl::NDRange(haarPattern[0].margin_crop.width, haarPattern[0].margin_crop.height), cl::NDRange(32, 32)),
+#endif
+            sumImage.getImage2D(),
+            detImage[0]->getImage2D(), detImage[1]->getImage2D(), detImage[2]->getImage2D(), detImage[3]->getImage2D(),
+            traceImage[0]->getImage2D(), traceImage[1]->getImage2D(), traceImage[2]->getImage2D(), traceImage[3]->getImage2D(),
+            sampleStep,
+            {haarPattern[0].Dx[0].w, haarPattern[0].Dxy[0].w,
+             haarPattern[1].Dx[0].w, haarPattern[1].Dxy[0].w,
+             haarPattern[2].Dx[0].w, haarPattern[2].Dxy[0].w,
+             haarPattern[3].Dx[0].w, haarPattern[3].Dxy[0].w},
+            {haarPattern[0].margin_crop.x, haarPattern[1].margin_crop.x, haarPattern[2].margin_crop.x, haarPattern[3].margin_crop.x},
+            _surfHFDataBuffer);
+    }
+
+    void SURF_OpenCL::Build(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum,
+                            const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
+                            const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
+                            const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces)
+    {
+        int N = (int)sizes.size();
+        std::cout << "enqueueing " << N << " calcLayerDetAndTrace" << std::endl;
+
+        const int layers = _nOctaveLayers + 2;
+
+        assert(_nOctaves * layers == N);
+
+        for (int octave = 0; octave < _nOctaves; octave++)
+        {
+#if __ANDROID__
+            const int i = octave * layers;
+
+            std::array<DetAndTraceHaarPattern, 4> haarPatterns = {
+                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]),
+                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 1], sampleSteps[i + 1]),
+                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 2], sampleSteps[i + 2]),
+                DetAndTraceHaarPattern(sum[0]->width, sum[0]->height, sizes[i + 3], sampleSteps[i + 3])};
+
+#if USE_INTEGRAL_PYRAMID
+            for (auto &haarPattern : haarPatterns)
+            {
+                // Rescale sampling points to the pyramid level
+                haarPattern.rescale(sampleSteps[i]);
+            }
+            int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2
+                                            : sampleSteps[i] == 2   ? 1
+                                                                    : 0;
+            calcDetAndTrace(*sum[idx], {dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get()},
+                            {traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get()},
+                            1 /* sampleSteps[i] */, haarPatterns);
+#else
+            //        // Emulate the integral pyramid scaling roundoff
+            //        for (auto& haarPattern : haarPatterns) {
+            //            haarPattern.rescale(sampleSteps[i]);
+            //            haarPattern.upscale(sampleSteps[i]);
+            //        }
+
+            calcDetAndTrace(*sum[0], {dets[i].get(), dets[i + 1].get(), dets[i + 2].get(), dets[i + 3].get()},
+                            {traces[i].get(), traces[i + 1].get(), traces[i + 2].get(), traces[i + 3].get()},
+                            sampleSteps[i], haarPatterns);
+#endif
+#else
+            for (int layer = 0; layer < layers; layer++)
+            {
+                const int i = octave * layers + layer;
+                DetAndTraceHaarPattern haarPattern(sum[0]->width, sum[0]->height, sizes[i], sampleSteps[i]);
+
+                //            std::cout << "DetAndTraceHaarPattern: " << sum[0]->width << ", " << sum[0]->height << ", " << sizes[i] << ", " << sampleSteps[i] << std::endl;
+
+#if USE_INTEGRAL_PYRAMID
+                // Rescale sampling points to the pyramid level
+                haarPattern.rescale(sampleSteps[i]);
+
+                const int idx = sampleSteps[i] == 8 ? 3 : sampleSteps[i] == 4 ? 2
+                                                      : sampleSteps[i] == 2   ? 1
+                                                                              : 0;
+                calcDetAndTrace(*sum[idx], dets[i].get(), traces[i].get(), 1, haarPattern);
+#else
+                //            // Emulate the integral pyramid scaling roundoff
+                //            haarPattern.rescale(sampleSteps[i]);
+                //            haarPattern.upscale(sampleSteps[i]);
+
+                calcDetAndTrace(*sum[0], dets[i].get(), traces[i].get(), sampleSteps[i], haarPattern);
+#endif
+            }
+#endif
+        }
+    }
+
+    /*
+     * Find the maxima in the determinant of the Hessian in a layer of the
+     * scale-space pyramid
+     */
+
+    typedef struct KeyPointMaxima
+    {
+        static constexpr int MaxCount = 64000;
+        int count;
+        KeyPoint keyPoints[MaxCount];
+    } KeyPointMaxima;
+
+    void SURF_OpenCL::findMaximaInLayer(const std::array<const gls::cl_image_2d<float> *, 3> &dets,
+                                        const gls::cl_image_2d<float> &traceImage,
+                                        const std::array<int, 3> &sizes,
+                                        int octave, float hessianThreshold, int sampleStep)
+    {
+        // Load the shader source
+        const auto program = _glsContext->loadProgram("SURF");
+
+        // Bind the kernel parameters
+        auto kernel = cl::KernelFunctor<cl::Image2D, // detImage0
+                                        cl::Image2D, // detImage1
+                                        cl::Image2D, // detImage2
+                                        cl::Image2D, // traceImage
+                                        cl_int3,     // sizes
+                                        cl::Buffer,  // keypoints
+                                        int,         // margin
+                                        int,         // octave
+                                        float,       // hessianThreshold
+                                        int          // sampleStep
+                                        >(program, "findMaximaInLayer");
+
+        if (_keyPointsBuffer() == 0)
+        {
+            _keyPointsBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(KeyPointMaxima));
+        }
+
+        const int layer_height = _height / sampleStep;
+        const int layer_width = _width / sampleStep;
+
+        // Ignore pixels without a 3x3x3 neighbourhood in the layer above
+        const int margin = (sizes[2] / 2) / sampleStep + 1;
+
+        // Schedule the kernel on the GPU
+        kernel(
+#if __APPLE__
+            gls::OpenCLContext::buildEnqueueArgs(layer_width - 2 * margin, layer_height - 2 * margin),
+#else
+            cl::EnqueueArgs(cl::NDRange(layer_width - 2 * margin, layer_height - 2 * margin), cl::NDRange(32, 32)),
+#endif
+            dets[0]->getImage2D(), dets[1]->getImage2D(), dets[2]->getImage2D(),
+            traceImage.getImage2D(),
+            {sizes[0], sizes[1], sizes[2]}, _keyPointsBuffer,
+            margin, octave, hessianThreshold, sampleStep);
+    }
+
+    void SURF_OpenCL::Find(const std::vector<gls::cl_image_2d<float>::unique_ptr> &dets,
+                           const std::vector<gls::cl_image_2d<float>::unique_ptr> &traces,
+                           const std::vector<int> &sizes, const std::vector<int> &sampleSteps,
+                           const std::vector<int> &middleIndices, std::vector<KeyPoint> *keypoints,
+                           int nOctaveLayers, float hessianThreshold)
+    {
+        int M = (int)middleIndices.size();
+        std::cout << "enqueueing " << M << " findMaximaInLayer" << std::endl;
+        for (int i = 0; i < M; i++)
+        {
+            const int layer = middleIndices[i];
+            const int octave = i / nOctaveLayers;
+
+            const std::array<const gls::cl_image_2d<float> *, 3> detImages = {
+                dets[layer - 1].get(),
+                dets[layer].get(),
+                dets[layer + 1].get()};
+
+            const auto traceImage = traces[layer].get();
+
+            findMaximaInLayer(detImages, *traceImage,
+                              {sizes[layer - 1], sizes[layer], sizes[layer + 1]},
+                              octave, hessianThreshold, sampleSteps[layer]);
+        }
+
+        // Collect results
+        const auto keyPointMaxima = (KeyPointMaxima *)cl::enqueueMapBuffer(_keyPointsBuffer, true, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(KeyPointMaxima));
+
+        std::cout << "keyPointMaxima: " << keyPointMaxima->count << std::endl;
+        std::span<KeyPoint> newElements(keyPointMaxima->keyPoints, std::min(keyPointMaxima->count, KeyPointMaxima::MaxCount));
+        keypoints->insert(end(*keypoints), begin(newElements), end(newElements));
+
+        // Reset count
+        keyPointMaxima->count = 0;
+
+        cl::enqueueUnmapMemObject(_keyPointsBuffer, (void *)keyPointMaxima);
+    }
+
+    struct KeypointGreater
+    {
+        inline bool operator()(const KeyPoint &kp1, const KeyPoint &kp2) const
+        {
+            if (kp1.response > kp2.response)
+                return true;
+            if (kp1.response < kp2.response)
+                return false;
+            if (kp1.size > kp2.size)
+                return true;
+            if (kp1.size < kp2.size)
+                return false;
+            if (kp1.octave > kp2.octave)
+                return true;
+            if (kp1.octave < kp2.octave)
+                return false;
+            if (kp1.pt.y < kp2.pt.y)
+                return false;
+            if (kp1.pt.y > kp2.pt.y)
+                return true;
+            return kp1.pt.x < kp2.pt.x;
+        }
+    };
+
+    void SURF_OpenCL::fastHessianDetector(const std::array<gls::cl_image_2d<float>::unique_ptr, 4> &sum,
+                                          std::vector<KeyPoint> *keypoints,
+                                          int nOctaves, int nOctaveLayers, float hessianThreshold)
+    {
+        int nTotalLayers = (nOctaveLayers + 2) * nOctaves;
+        int nMiddleLayers = nOctaveLayers * nOctaves;
+
+        std::vector<int> sizes(nTotalLayers);
+        std::vector<int> sampleSteps(nTotalLayers);
+        std::vector<int> middleIndices(nMiddleLayers);
+
+        // Calculate properties of each layer
+        int index = 0, middleIndex = 0, step = SAMPLE_STEP0;
+
+        for (int octave = 0; octave < nOctaves; octave++)
+        {
+            for (int layer = 0; layer < nOctaveLayers + 2; layer++)
+            {
+                sizes[index] = (SURF_HAAR_SIZE0 + SURF_HAAR_SIZE_INC * layer) << octave;
+                sampleSteps[index] = step;
+
+                if (0 < layer && layer <= nOctaveLayers)
+                {
+                    middleIndices[middleIndex++] = index;
+                }
+                index++;
+            }
+            step *= 2;
+        }
+
+        auto t_start = std::chrono::high_resolution_clock::now();
+
+        // Calculate hessian determinant and trace samples in each layer
+        Build(sum, sizes, sampleSteps, _dets, _traces);
+
+        // Find maxima in the determinant of the hessian
+        Find(_dets, _traces, sizes, sampleSteps, middleIndices, keypoints, nOctaveLayers, hessianThreshold);
+
+        auto t_end = std::chrono::high_resolution_clock::now();
+        double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+        printf("Features Finding Time: %.2fms\n", elapsed_time_ms);
+
+        sort(keypoints->begin(), keypoints->end(), KeypointGreater());
+    }
+
+    static inline float L2Norm(const float *p1, const float *p2, int n)
+    {
+        float sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            float diff = p1[i] - p2[i];
+            sum += diff * diff;
+        }
+        return sqrtf(sum);
+    }
 
 #ifdef __APPLE__
-typedef std::chrono::steady_clock::time_point time_point;
+    typedef std::chrono::steady_clock::time_point time_point;
+#elif __linux__
+    typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point;
 #else
-typedef std::chrono::system_clock::time_point time_point;
+    typedef std::chrono::system_clock::time_point time_point;
 #endif
 
-double timeDiff(time_point t_start, time_point t_end) {
-    return std::chrono::duration<double, std::milli>(t_end-t_start).count();
-}
-
-static bool keypointsAvailable(const std::vector<size_t>& kptIndices,
-                               const std::vector<size_t>& kptSizes) {
-    for (int i = 0; i < kptIndices.size(); i++) {
-        if (kptIndices[i] < kptSizes[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-static int maxKeypointIndex(const std::vector<size_t>& kptIndices,
-                            const std::vector<std::unique_ptr<std::vector<KeyPoint>>>& allKeypoints) {
-    int maxIndex = -1;
-    for (int i = 0; i < kptIndices.size(); i++) {
-        if (kptIndices[i] < allKeypoints[i]->size()) {
-            maxIndex = i;
-        }
-    }
-    for (int i = maxIndex + 1; i < kptIndices.size(); i++) {
-        if (kptIndices[i] < allKeypoints[i]->size() &&
-            KeypointGreater()((*allKeypoints[i])[kptIndices[i]],
-                              (*allKeypoints[maxIndex])[kptIndices[maxIndex]])) {
-            maxIndex = i;
-        }
-    }
-    return maxIndex;
-}
-
-// Merge individually sorted keypoint vectors into a single keypoint vector
-static void mergeKeypoints(const std::vector<std::unique_ptr<std::vector<KeyPoint>>>& allKeypoints,
-                           std::vector<KeyPoint>* keypoints,
-                           const std::vector<gls::image<float>::unique_ptr>& allDescriptors,
-                           gls::image<float>::unique_ptr* descriptors) {
-    // Find out how many keypoints we have
-    int keypointsCount = 0;
-    for (const auto& kps : allKeypoints) {
-        keypointsCount += kps->size();
+    double timeDiff(time_point t_start, time_point t_end)
+    {
+        return std::chrono::duration<double, std::milli>(t_end - t_start).count();
     }
 
-    // Make sure we have corresponding descriptors for all keypoints
-    if (descriptors) {
-        assert(allKeypoints.size() == allDescriptors.size());
-
-        int descriptorsCount = 0;
-        for (const auto& d : allDescriptors) {
-            descriptorsCount += d->height;
-        }
-        assert(keypointsCount == descriptorsCount);
-    }
-
-    // Allocate space for the result
-    keypoints->clear();
-    keypoints->resize(keypointsCount);
-
-    if (descriptors != nullptr) {
-        *descriptors = std::make_unique<gls::image<float>>(64, keypointsCount);
-    }
-
-    std::vector<size_t> kptIndices(allKeypoints.size());
-    std::vector<size_t> kptSizes(allKeypoints.size());
-    for (int i = 0; i < allKeypoints.size(); i++) {
-        kptIndices[i] = 0;
-        kptSizes[i] = allKeypoints[i]->size();
-    }
-
-    int outIndex = 0;
-    while (keypointsAvailable(kptIndices, kptSizes)) {
-        assert(outIndex < keypointsCount);
-
-        // Find max keypoint index
-        int maxIndex = maxKeypointIndex(kptIndices, allKeypoints);
-
-        // Copy keypoint to output
-        (*keypoints)[outIndex] = (*allKeypoints[maxIndex])[kptIndices[maxIndex]];
-
-        // Copy descriptor to output
-        if (descriptors != nullptr) {
-            float *outPtr = (**descriptors)[outIndex];
-            float *descPtr = (*allDescriptors[maxIndex])[(int) kptIndices[maxIndex]];
-
-            memcpy(outPtr, descPtr, 64 * sizeof(float));
-        }
-        kptIndices[maxIndex]++;
-        outIndex++;
-    }
-
-    assert(outIndex == keypointsCount);
-}
-
-void SURF_OpenCL::detectAndCompute(const gls::image<float>& img,
-                                   std::vector<KeyPoint>* keypoints,
-                                   gls::image<float>::unique_ptr* descriptors,
-                                   gls::size sections) {
-    std::vector<gls::rectangle> tiles(sections.width * sections.height);
-
-    const int tile_width = img.width / sections.width;
-    const int tile_height = img.height / sections.height;
-
-    std::cout << "Tile size: " << tile_width << " x " << tile_height << std::endl;
-
-    // TODO: Add a skirt overlap between tiles
-    int y_pos = 0;
-    for (int j = 0; j < sections.height; j++) {
-        int x_pos = 0;
-        for (int i = 0; i < sections.width; i++) {
-            tiles[j * sections.width + i] = gls::rectangle({x_pos, y_pos, tile_width, tile_height});
-            x_pos += tile_width;
-        }
-        y_pos += tile_height;
-    }
-
-    std::vector<gls::image<float>::unique_ptr> allDescriptors;
-    std::vector<std::unique_ptr<std::vector<KeyPoint>>> allKeypoints;
-
-    auto sum = sumImageStack<float>(_glsContext->clContext(), tile_width + 1, tile_height + 1);
-
-    for (const auto& tile : tiles) {
-        const auto tileImage = gls::image<float>(img, tile);
-
-        integral(tileImage, sum);
-
-        auto tileKeypoints = std::make_unique<std::vector<KeyPoint>>();
-
-        fastHessianDetector(sum, tileKeypoints.get(), _nOctaves, _nOctaveLayers, _hessianThreshold);
-
-        // Limit the max number of feature points
-        if (tileKeypoints->size() > _max_features) {
-            printf("detectAndCompute - dropping: %d features out of %d\n", (int) tileKeypoints->size() - _max_features, (int) tileKeypoints->size());
-            tileKeypoints->erase(tileKeypoints->begin() + _max_features, tileKeypoints->end());
-        }
-
-        int N = (int) tileKeypoints->size();
-
-        std::cout << "tileKeypoints: " << N << std::endl;
-
-        auto tileDescriptors = descriptors != nullptr ? std::make_unique<gls::image<float>>(64, N) : nullptr;
-
-        auto t_start_descriptor = std::chrono::high_resolution_clock::now();
-
-        const auto integralSumCpu = sum[0]->mapImage(CL_MAP_READ);
-
-        // we call SURFInvoker in any case, even if we do not need descriptors,
-        // since it computes orientation of each feature.
-        descriptor(tileImage, integralSumCpu, tileKeypoints.get(), descriptors != nullptr ? tileDescriptors.get() : nullptr);
-
-#if DEBUG_RECONSTRUCTED_IMAGE
-        static int count = 0;
-        gls::image<gls::luma_pixel> reconstructed(integralSumCpu.width-1, integralSumCpu.height-1);
-        reconstructed.apply([&integralSumCpu](gls::luma_pixel* p, int x, int y) {
-            float value = integralRectangle(integralSumCpu[y+1][x+1], integralSumCpu[y+1][x], integralSumCpu[y][x+1], integralSumCpu[y][x]);
-            *p = std::clamp((int) (255 * value), 0, 255);
-        });
-        reconstructed.write_png_file("/Users/fabio/reconstructed" + std::to_string(count++) + ".png");
-#endif
-        sum[0]->unmapImage(integralSumCpu);
-
-        // Translate tile keypoints to their full image locations
-        for (auto& kp : *tileKeypoints) {
-            kp.pt += Point2f(tile.x, tile.y);
-        }
-        allKeypoints.push_back(std::move(tileKeypoints));
-
-        if (descriptors != nullptr) {
-            allDescriptors.push_back(std::move(tileDescriptors));
-        }
-
-        auto t_end_descriptor = std::chrono::high_resolution_clock::now();
-        printf("--> descriptor Time: %.2fms\n", timeDiff(t_start_descriptor, t_end_descriptor));
-    }
-
-    mergeKeypoints(allKeypoints, keypoints, allDescriptors, descriptors);
-
-    std::cout << "Collected " << keypoints->size() << " keypoints and " << (**descriptors).height << " descriptors" << std::endl;
-}
-
-void matchKeyPoints(const gls::image<float>& descriptor1,
-                    const gls::image<float>& descriptor2,
-                    std::vector<DMatch>* matchedPoints) {
-    for (int i = 0; i < descriptor1.height; i++) {
-        const float* p1 = descriptor1[i];
-        float distance_min = 100;
-        int j_min = 0, i_min = 0;
-
-        for (int j = 0; j < descriptor2.height; j++) {
-            const float* p2 = descriptor2[j];
-            // calculate distance
-            float distance_t = L2Norm(p1, p2, 64);
-            if (distance_t < distance_min) {
-                distance_min = distance_t;
-                i_min = i;
-                j_min = j;
+    static bool keypointsAvailable(const std::vector<size_t> &kptIndices,
+                                   const std::vector<size_t> &kptSizes)
+    {
+        for (int i = 0; i < kptIndices.size(); i++)
+        {
+            if (kptIndices[i] < kptSizes[i])
+            {
+                return true;
             }
         }
-
-        matchedPoints->push_back(DMatch(i_min, j_min, distance_min));
-    }
-}
-
-template <typename T>
-cl::Buffer bufferFromImage(const gls::image<T>& source) {
-    int bufferSize = source.stride * source.height * sizeof(float);
-    auto buffer = cl::Buffer(CL_MEM_READ_WRITE, bufferSize);
-    const auto bufferPtr = (float *) cl::enqueueMapBuffer(buffer, true, CL_MAP_WRITE, 0, bufferSize);
-    memcpy(bufferPtr, source.pixels().data(), bufferSize);
-    cl::enqueueUnmapMemObject(buffer, (void*)bufferPtr);
-    return buffer;
-}
-
-struct refineMatch {
-    inline bool operator()(const DMatch& mp1, const DMatch& mp2) const {
-        if (mp1.distance < mp2.distance) return true;
-        if (mp1.distance > mp2.distance) return false;
-        // if (mp1.queryIdx < mp2.queryIdx) return true;
-        // if (mp1.queryIdx > mp2.queryIdx) return false;
-        /*if (mp1.octave > mp2.octave) return true;
-        if (mp1.octave < mp2.octave) return false;
-        if (mp1.pt.y < mp2.pt.y) return false;
-        if (mp1.pt.y > mp2.pt.y) return true;*/
-        return mp1.queryIdx < mp2.queryIdx;
-    }
-};
-
-std::vector<DMatch> SURF_OpenCL::matchKeyPoints(const gls::image<float>& descriptor1,
-                                           const gls::image<float>& descriptor2) {
-    auto descriptor1Buffer = bufferFromImage(descriptor1);
-    auto descriptor2Buffer = bufferFromImage(descriptor2);
-
-    auto matchesBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(DMatch) * descriptor1.height);
-
-    // Load the shader source
-    const auto program = _glsContext->loadProgram("SURF");
-
-    // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Buffer,     // descriptor1
-                                    int,            // descriptor1_stride
-                                    cl::Buffer,     // descriptor2
-                                    int,            // descriptor2_stride
-                                    int,            // descriptor2_height
-                                    cl::Buffer      // matchedPoints
-                                    >(program, "matchKeyPoints");
-
-    int groups = 24;
-    kernel(cl::EnqueueArgs(cl::NDRange(descriptor1.height, groups), cl::NDRange(1, groups)),
-           descriptor1Buffer,
-           descriptor1.stride,
-           descriptor2Buffer,
-           descriptor2.stride,
-           descriptor2.height,
-           matchesBuffer);
-
-    // Collect results
-    const auto matches = (DMatch *) cl::enqueueMapBuffer(matchesBuffer, true, CL_MAP_READ, 0, sizeof(DMatch) * descriptor1.height);
-
-    // Build result vector
-    std::span<DMatch> newElements(matches, descriptor1.height);
-    std::vector<DMatch> matchedPoints(begin(newElements), end(newElements));
-
-    cl::enqueueUnmapMemObject(matchesBuffer, (void*)matches);
-
-    std::sort(matchedPoints.begin(), matchedPoints.end(), refineMatch());  // feature point sorting
-
-    return matchedPoints;
-}
-
-std::vector<std::pair<Point2f, Point2f>> SURF::detection(gls::OpenCLContext* cLContext, const gls::image<float>& image1, const gls::image<float>& image2) {
-    auto t_start = std::chrono::high_resolution_clock::now();
-
-    auto surf = SURF::makeInstance(cLContext, image1.width, image1.height, /*max_features=*/ 1500, /*nOctaves=*/ 4, /*nOctaveLayers=*/ 2, /*hessianThreshold=*/ 0.02);
-
-    auto t_surf = std::chrono::high_resolution_clock::now();
-    printf("--> SURF Creation Time: %.2fms\n", timeDiff(t_start, t_surf));
-
-    auto keypoints1 = std::make_unique<std::vector<KeyPoint>>();
-    auto keypoints2 = std::make_unique<std::vector<KeyPoint>>();
-    gls::image<float>::unique_ptr descriptor1, descriptor2;
-
-    surf->detectAndCompute(image1, keypoints1.get(), &descriptor1);
-    surf->detectAndCompute(image2, keypoints2.get(), &descriptor2);
-
-    auto t_detect = std::chrono::high_resolution_clock::now();
-    printf("--> detectAndCompute Time: %.2fms\n", timeDiff(t_surf, t_detect));
-
-    printf(" ---------- \n Detected feature points: %ld, %ld\n", keypoints1->size(), keypoints2->size());
-
-    // (4) Match feature points
-    std::vector<DMatch> matchedPoints = surf->matchKeyPoints(*descriptor1, *descriptor2);
-
-    auto t_match = std::chrono::high_resolution_clock::now();
-    printf("--> Keypoint Matching: %.2fms\n", timeDiff(t_detect, t_match));
-
-    auto t_sort = std::chrono::high_resolution_clock::now();
-    printf("--> Keypoint Sorting: %.2fms\n", timeDiff(t_match, t_sort));
-
-    // Convert to Point2D format
-    std::vector<std::pair<Point2f, Point2f>> result(matchedPoints.size());
-    for (int i = 0; i < matchedPoints.size(); i++) {
-        result[i] = std::pair {
-            (*keypoints1)[matchedPoints[i].queryIdx].pt,
-            (*keypoints2)[matchedPoints[i].trainIdx].pt
-        };
+        return false;
     }
 
-    auto t_end = std::chrono::high_resolution_clock::now();
-    printf("--> Keypoint Matching & Sorting Time: %.2fms\n", timeDiff(t_detect, t_end));
+    static int maxKeypointIndex(const std::vector<size_t> &kptIndices,
+                                const std::vector<std::unique_ptr<std::vector<KeyPoint>>> &allKeypoints)
+    {
+        int maxIndex = -1;
+        for (int i = 0; i < kptIndices.size(); i++)
+        {
+            if (kptIndices[i] < allKeypoints[i]->size())
+            {
+                maxIndex = i;
+            }
+        }
+        for (int i = maxIndex + 1; i < kptIndices.size(); i++)
+        {
+            if (kptIndices[i] < allKeypoints[i]->size() &&
+                KeypointGreater()((*allKeypoints[i])[kptIndices[i]],
+                                  (*allKeypoints[maxIndex])[kptIndices[maxIndex]]))
+            {
+                maxIndex = i;
+            }
+        }
+        return maxIndex;
+    }
 
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
-    printf("--> Features Finding Time: %.2fms\n", elapsed_time_ms);
+    // Merge individually sorted keypoint vectors into a single keypoint vector
+    static void mergeKeypoints(const std::vector<std::unique_ptr<std::vector<KeyPoint>>> &allKeypoints,
+                               std::vector<KeyPoint> *keypoints,
+                               const std::vector<gls::image<float>::unique_ptr> &allDescriptors,
+                               gls::image<float>::unique_ptr *descriptors)
+    {
+        // Find out how many keypoints we have
+        int keypointsCount = 0;
+        for (const auto &kps : allKeypoints)
+        {
+            keypointsCount += kps->size();
+        }
 
-    return result;
-}
+        // Make sure we have corresponding descriptors for all keypoints
+        if (descriptors)
+        {
+            assert(allKeypoints.size() == allDescriptors.size());
 
-void clRegisterAndFuse(gls::OpenCLContext* cLContext,
-                       const gls::cl_image_2d<gls::rgba_pixel>& inputImage0,
-                       const gls::cl_image_2d<gls::rgba_pixel>& inputImage1,
-                       gls::cl_image_2d<gls::rgba_pixel>* outputImage,
-                       const gls::Matrix<3, 3>& homography) {
-    // Load the shader source
-    const auto program = cLContext->loadProgram("SURF");
+            int descriptorsCount = 0;
+            for (const auto &d : allDescriptors)
+            {
+                descriptorsCount += d->height;
+            }
+            assert(keypointsCount == descriptorsCount);
+        }
 
-    // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,        // inputImage0
-                                    cl::Image2D,        // inputImage1
-                                    cl::Image2D,        // outputImage
-                                    gls::Matrix<3, 3>,  // homography
-                                    cl::Sampler         // linear_sampler
-                                    >(program, "registerAndFuse");
+        // Allocate space for the result
+        keypoints->clear();
+        keypoints->resize(keypointsCount);
 
-    const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
+        if (descriptors != nullptr)
+        {
+            *descriptors = std::make_unique<gls::image<float>>(64, keypointsCount);
+        }
 
-    kernel(
-#if __APPLE__
-           gls::OpenCLContext::buildEnqueueArgs(inputImage0.width, inputImage0.height),
-#else
-           cl::EnqueueArgs(cl::NDRange(inputImage0.width, inputImage0.height), cl::NDRange(32, 32)),
+        std::vector<size_t> kptIndices(allKeypoints.size());
+        std::vector<size_t> kptSizes(allKeypoints.size());
+        for (int i = 0; i < allKeypoints.size(); i++)
+        {
+            kptIndices[i] = 0;
+            kptSizes[i] = allKeypoints[i]->size();
+        }
+
+        int outIndex = 0;
+        while (keypointsAvailable(kptIndices, kptSizes))
+        {
+            assert(outIndex < keypointsCount);
+
+            // Find max keypoint index
+            int maxIndex = maxKeypointIndex(kptIndices, allKeypoints);
+
+            // Copy keypoint to output
+            (*keypoints)[outIndex] = (*allKeypoints[maxIndex])[kptIndices[maxIndex]];
+
+            // Copy descriptor to output
+            if (descriptors != nullptr)
+            {
+                float *outPtr = (**descriptors)[outIndex];
+                float *descPtr = (*allDescriptors[maxIndex])[(int)kptIndices[maxIndex]];
+
+                memcpy(outPtr, descPtr, 64 * sizeof(float));
+            }
+            kptIndices[maxIndex]++;
+            outIndex++;
+        }
+
+        assert(outIndex == keypointsCount);
+    }
+
+    void SURF_OpenCL::detectAndCompute(const gls::image<float> &img,
+                                       std::vector<KeyPoint> *keypoints,
+                                       gls::image<float>::unique_ptr *descriptors,
+                                       gls::size sections)
+    {
+        std::vector<gls::rectangle> tiles(sections.width * sections.height);
+
+        const int tile_width = img.width / sections.width;
+        const int tile_height = img.height / sections.height;
+
+        std::cout << "Tile size: " << tile_width << " x " << tile_height << std::endl;
+
+        // TODO: Add a skirt overlap between tiles
+        int y_pos = 0;
+        for (int j = 0; j < sections.height; j++)
+        {
+            int x_pos = 0;
+            for (int i = 0; i < sections.width; i++)
+            {
+                tiles[j * sections.width + i] = gls::rectangle({x_pos, y_pos, tile_width, tile_height});
+                x_pos += tile_width;
+            }
+            y_pos += tile_height;
+        }
+
+        std::vector<gls::image<float>::unique_ptr> allDescriptors;
+        std::vector<std::unique_ptr<std::vector<KeyPoint>>> allKeypoints;
+
+        auto sum = sumImageStack<float>(_glsContext->clContext(), tile_width + 1, tile_height + 1);
+
+        for (const auto &tile : tiles)
+        {
+            const auto tileImage = gls::image<float>(img, tile);
+
+            integral(tileImage, sum);
+
+            auto tileKeypoints = std::make_unique<std::vector<KeyPoint>>();
+
+            fastHessianDetector(sum, tileKeypoints.get(), _nOctaves, _nOctaveLayers, _hessianThreshold);
+
+            // Limit the max number of feature points
+            if (tileKeypoints->size() > _max_features)
+            {
+                printf("detectAndCompute - dropping: %d features out of %d\n", (int)tileKeypoints->size() - _max_features, (int)tileKeypoints->size());
+                tileKeypoints->erase(tileKeypoints->begin() + _max_features, tileKeypoints->end());
+            }
+
+            int N = (int)tileKeypoints->size();
+
+            std::cout << "tileKeypoints: " << N << std::endl;
+
+            auto tileDescriptors = descriptors != nullptr ? std::make_unique<gls::image<float>>(64, N) : nullptr;
+
+            auto t_start_descriptor = std::chrono::high_resolution_clock::now();
+
+            const auto integralSumCpu = sum[0]->mapImage(CL_MAP_READ);
+
+            // we call SURFInvoker in any case, even if we do not need descriptors,
+            // since it computes orientation of each feature.
+            descriptor(tileImage, integralSumCpu, tileKeypoints.get(), descriptors != nullptr ? tileDescriptors.get() : nullptr);
+
+#if DEBUG_RECONSTRUCTED_IMAGE
+            static int count = 0;
+            gls::image<gls::luma_pixel> reconstructed(integralSumCpu.width - 1, integralSumCpu.height - 1);
+            reconstructed.apply([&integralSumCpu](gls::luma_pixel *p, int x, int y)
+                                {
+            float value = integralRectangle(integralSumCpu[y+1][x+1], integralSumCpu[y+1][x], integralSumCpu[y][x+1], integralSumCpu[y][x]);
+            *p = std::clamp((int) (255 * value), 0, 255); });
+            reconstructed.write_png_file("/Users/fabio/reconstructed" + std::to_string(count++) + ".png");
 #endif
-           inputImage0.getImage2D(), inputImage1.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
-}
+            sum[0]->unmapImage(integralSumCpu);
 
-template <typename T>
-void clRegisterImage(gls::OpenCLContext* cLContext,
-                     const gls::cl_image_2d<T>& inputImage,
-                     gls::cl_image_2d<T>* outputImage,
-                     const gls::Matrix<3, 3>& homography) {
-    // Load the shader source
-    const auto program = cLContext->loadProgram("SURF");
+            // Translate tile keypoints to their full image locations
+            for (auto &kp : *tileKeypoints)
+            {
+                kp.pt += Point2f(tile.x, tile.y);
+            }
+            allKeypoints.push_back(std::move(tileKeypoints));
 
-    // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,        // inputImage
-                                    cl::Image2D,        // outputImage
-                                    gls::Matrix<3, 3>,  // homography
-                                    cl::Sampler         // linear_sampler
-                                    >(program, "registerImage");
+            if (descriptors != nullptr)
+            {
+                allDescriptors.push_back(std::move(tileDescriptors));
+            }
 
-    const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
+            auto t_end_descriptor = std::chrono::high_resolution_clock::now();
+            printf("--> descriptor Time: %.2fms\n", timeDiff(t_start_descriptor, t_end_descriptor));
+        }
 
-    kernel(
+        mergeKeypoints(allKeypoints, keypoints, allDescriptors, descriptors);
+
+        std::cout << "Collected " << keypoints->size() << " keypoints and " << (**descriptors).height << " descriptors" << std::endl;
+    }
+
+    void matchKeyPoints(const gls::image<float> &descriptor1,
+                        const gls::image<float> &descriptor2,
+                        std::vector<DMatch> *matchedPoints)
+    {
+        for (int i = 0; i < descriptor1.height; i++)
+        {
+            const float *p1 = descriptor1[i];
+            float distance_min = 100;
+            int j_min = 0, i_min = 0;
+
+            for (int j = 0; j < descriptor2.height; j++)
+            {
+                const float *p2 = descriptor2[j];
+                // calculate distance
+                float distance_t = L2Norm(p1, p2, 64);
+                if (distance_t < distance_min)
+                {
+                    distance_min = distance_t;
+                    i_min = i;
+                    j_min = j;
+                }
+            }
+
+            matchedPoints->push_back(DMatch(i_min, j_min, distance_min));
+        }
+    }
+
+    template <typename T>
+    cl::Buffer bufferFromImage(const gls::image<T> &source)
+    {
+        int bufferSize = source.stride * source.height * sizeof(float);
+        auto buffer = cl::Buffer(CL_MEM_READ_WRITE, bufferSize);
+        const auto bufferPtr = (float *)cl::enqueueMapBuffer(buffer, true, CL_MAP_WRITE, 0, bufferSize);
+        memcpy(bufferPtr, source.pixels().data(), bufferSize);
+        cl::enqueueUnmapMemObject(buffer, (void *)bufferPtr);
+        return buffer;
+    }
+
+    struct refineMatch
+    {
+        inline bool operator()(const DMatch &mp1, const DMatch &mp2) const
+        {
+            if (mp1.distance < mp2.distance)
+                return true;
+            if (mp1.distance > mp2.distance)
+                return false;
+            // if (mp1.queryIdx < mp2.queryIdx) return true;
+            // if (mp1.queryIdx > mp2.queryIdx) return false;
+            /*if (mp1.octave > mp2.octave) return true;
+            if (mp1.octave < mp2.octave) return false;
+            if (mp1.pt.y < mp2.pt.y) return false;
+            if (mp1.pt.y > mp2.pt.y) return true;*/
+            return mp1.queryIdx < mp2.queryIdx;
+        }
+    };
+
+    std::vector<DMatch> SURF_OpenCL::matchKeyPoints(const gls::image<float> &descriptor1,
+                                                    const gls::image<float> &descriptor2)
+    {
+        auto descriptor1Buffer = bufferFromImage(descriptor1);
+        auto descriptor2Buffer = bufferFromImage(descriptor2);
+
+        auto matchesBuffer = cl::Buffer(CL_MEM_READ_WRITE, sizeof(DMatch) * descriptor1.height);
+
+        // Load the shader source
+        const auto program = _glsContext->loadProgram("SURF");
+
+        // Bind the kernel parameters
+        auto kernel = cl::KernelFunctor<cl::Buffer, // descriptor1
+                                        int,        // descriptor1_stride
+                                        cl::Buffer, // descriptor2
+                                        int,        // descriptor2_stride
+                                        int,        // descriptor2_height
+                                        cl::Buffer  // matchedPoints
+                                        >(program, "matchKeyPoints");
+
+        int groups = 24;
+        kernel(cl::EnqueueArgs(cl::NDRange(descriptor1.height, groups), cl::NDRange(1, groups)),
+               descriptor1Buffer,
+               descriptor1.stride,
+               descriptor2Buffer,
+               descriptor2.stride,
+               descriptor2.height,
+               matchesBuffer);
+
+        // Collect results
+        const auto matches = (DMatch *)cl::enqueueMapBuffer(matchesBuffer, true, CL_MAP_READ, 0, sizeof(DMatch) * descriptor1.height);
+
+        // Build result vector
+        std::span<DMatch> newElements(matches, descriptor1.height);
+        std::vector<DMatch> matchedPoints(begin(newElements), end(newElements));
+
+        cl::enqueueUnmapMemObject(matchesBuffer, (void *)matches);
+
+        std::sort(matchedPoints.begin(), matchedPoints.end(), refineMatch()); // feature point sorting
+
+        return matchedPoints;
+    }
+
+    std::vector<std::pair<Point2f, Point2f>> SURF::detection(gls::OpenCLContext *cLContext, const gls::image<float> &image1, const gls::image<float> &image2)
+    {
+        auto t_start = std::chrono::high_resolution_clock::now();
+
+        auto surf = SURF::makeInstance(cLContext, image1.width, image1.height, /*max_features=*/1500, /*nOctaves=*/4, /*nOctaveLayers=*/2, /*hessianThreshold=*/0.02);
+
+        auto t_surf = std::chrono::high_resolution_clock::now();
+        printf("--> SURF Creation Time: %.2fms\n", timeDiff(t_start, t_surf));
+
+        auto keypoints1 = std::make_unique<std::vector<KeyPoint>>();
+        auto keypoints2 = std::make_unique<std::vector<KeyPoint>>();
+        gls::image<float>::unique_ptr descriptor1, descriptor2;
+
+        surf->detectAndCompute(image1, keypoints1.get(), &descriptor1);
+        surf->detectAndCompute(image2, keypoints2.get(), &descriptor2);
+
+        auto t_detect = std::chrono::high_resolution_clock::now();
+        printf("--> detectAndCompute Time: %.2fms\n", timeDiff(t_surf, t_detect));
+
+        printf(" ---------- \n Detected feature points: %ld, %ld\n", keypoints1->size(), keypoints2->size());
+
+        // (4) Match feature points
+        std::vector<DMatch> matchedPoints = surf->matchKeyPoints(*descriptor1, *descriptor2);
+
+        auto t_match = std::chrono::high_resolution_clock::now();
+        printf("--> Keypoint Matching: %.2fms\n", timeDiff(t_detect, t_match));
+
+        auto t_sort = std::chrono::high_resolution_clock::now();
+        printf("--> Keypoint Sorting: %.2fms\n", timeDiff(t_match, t_sort));
+
+        // Convert to Point2D format
+        std::vector<std::pair<Point2f, Point2f>> result(matchedPoints.size());
+        for (int i = 0; i < matchedPoints.size(); i++)
+        {
+            result[i] = std::pair{
+                (*keypoints1)[matchedPoints[i].queryIdx].pt,
+                (*keypoints2)[matchedPoints[i].trainIdx].pt};
+        }
+
+        auto t_end = std::chrono::high_resolution_clock::now();
+        printf("--> Keypoint Matching & Sorting Time: %.2fms\n", timeDiff(t_detect, t_end));
+
+        double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+        printf("--> Features Finding Time: %.2fms\n", elapsed_time_ms);
+
+        return result;
+    }
+
+    void clRegisterAndFuse(gls::OpenCLContext *cLContext,
+                           const gls::cl_image_2d<gls::rgba_pixel> &inputImage0,
+                           const gls::cl_image_2d<gls::rgba_pixel> &inputImage1,
+                           gls::cl_image_2d<gls::rgba_pixel> *outputImage,
+                           const gls::Matrix<3, 3> &homography)
+    {
+        // Load the shader source
+        const auto program = cLContext->loadProgram("SURF");
+
+        // Bind the kernel parameters
+        auto kernel = cl::KernelFunctor<cl::Image2D,       // inputImage0
+                                        cl::Image2D,       // inputImage1
+                                        cl::Image2D,       // outputImage
+                                        gls::Matrix<3, 3>, // homography
+                                        cl::Sampler        // linear_sampler
+                                        >(program, "registerAndFuse");
+
+        const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
+
+        kernel(
 #if __APPLE__
-           gls::OpenCLContext::buildEnqueueArgs(inputImage.width, inputImage.height),
+            gls::OpenCLContext::buildEnqueueArgs(inputImage0.width, inputImage0.height),
 #else
-           cl::EnqueueArgs(cl::NDRange(inputImage.width, inputImage.height), cl::NDRange(32, 32)),
+            cl::EnqueueArgs(cl::NDRange(inputImage0.width, inputImage0.height), cl::NDRange(32, 32)),
 #endif
-           inputImage.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
-}
+            inputImage0.getImage2D(), inputImage1.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
+    }
 
-template
-void clRegisterImage(gls::OpenCLContext* cLContext,
-                     const gls::cl_image_2d<gls::rgba_pixel>& inputImage,
-                     gls::cl_image_2d<gls::rgba_pixel>* outputImage,
-                     const gls::Matrix<3, 3>& homography);
+    template <typename T>
+    void clRegisterImage(gls::OpenCLContext *cLContext,
+                         const gls::cl_image_2d<T> &inputImage,
+                         gls::cl_image_2d<T> *outputImage,
+                         const gls::Matrix<3, 3> &homography)
+    {
+        // Load the shader source
+        const auto program = cLContext->loadProgram("SURF");
 
-template
-void clRegisterImage(gls::OpenCLContext* cLContext,
-                     const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                     gls::cl_image_2d<gls::rgba_pixel_float>* outputImage,
-                     const gls::Matrix<3, 3>& homography);
+        // Bind the kernel parameters
+        auto kernel = cl::KernelFunctor<cl::Image2D,       // inputImage
+                                        cl::Image2D,       // outputImage
+                                        gls::Matrix<3, 3>, // homography
+                                        cl::Sampler        // linear_sampler
+                                        >(program, "registerImage");
+
+        const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
+
+        kernel(
+#if __APPLE__
+            gls::OpenCLContext::buildEnqueueArgs(inputImage.width, inputImage.height),
+#else
+            cl::EnqueueArgs(cl::NDRange(inputImage.width, inputImage.height), cl::NDRange(32, 32)),
+#endif
+            inputImage.getImage2D(), outputImage->getImage2D(), homography, linear_sampler);
+    }
+
+    template void clRegisterImage(gls::OpenCLContext *cLContext,
+                                  const gls::cl_image_2d<gls::rgba_pixel> &inputImage,
+                                  gls::cl_image_2d<gls::rgba_pixel> *outputImage,
+                                  const gls::Matrix<3, 3> &homography);
+
+    template void clRegisterImage(gls::OpenCLContext *cLContext,
+                                  const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                  gls::cl_image_2d<gls::rgba_pixel_float> *outputImage,
+                                  const gls::Matrix<3, 3> &homography);
 
 } // namespace surf

--- a/src/Sonya6400Calibration.cpp
+++ b/src/Sonya6400Calibration.cpp
@@ -22,105 +22,115 @@
 #include "demosaic.hpp"
 
 template <size_t levels = 5>
-class Sonya6400Calibration : public CameraCalibration<levels> {
+class Sonya6400Calibration : public CameraCalibration<levels>
+{
     static const std::array<NoiseModel<levels>, 11> NLFData;
 
 public:
-    NoiseModel<levels> nlfFromIso(int iso) const override {
+    NoiseModel<levels> nlfFromIso(int iso) const override
+    {
         iso = std::clamp(iso, 100, 102400);
-        if (iso >= 100 && iso < 200) {
+        if (iso >= 100 && iso < 200)
+        {
             float a = (iso - 100) / 100;
             return lerp<levels>(NLFData[0], NLFData[1], a);
-        } else if (iso >= 200 && iso < 400) {
+        }
+        else if (iso >= 200 && iso < 400)
+        {
             float a = (iso - 200) / 200;
             return lerp<levels>(NLFData[1], NLFData[2], a);
-        } else if (iso >= 400 && iso < 800) {
+        }
+        else if (iso >= 400 && iso < 800)
+        {
             float a = (iso - 400) / 400;
             return lerp<levels>(NLFData[2], NLFData[3], a);
-        } else if (iso >= 800 && iso < 1600) {
+        }
+        else if (iso >= 800 && iso < 1600)
+        {
             float a = (iso - 800) / 800;
             return lerp<levels>(NLFData[3], NLFData[4], a);
-        } else if (iso >= 1600 && iso < 3200) {
+        }
+        else if (iso >= 1600 && iso < 3200)
+        {
             float a = (iso - 1600) / 1600;
             return lerp<levels>(NLFData[4], NLFData[5], a);
-        } else if (iso >= 3200 && iso < 6400) {
+        }
+        else if (iso >= 3200 && iso < 6400)
+        {
             float a = (iso - 3200) / 3200;
             return lerp<levels>(NLFData[5], NLFData[6], a);
-        } else if (iso >= 6400 && iso < 12800) {
+        }
+        else if (iso >= 6400 && iso < 12800)
+        {
             float a = (iso - 6400) / 6400;
             return lerp<levels>(NLFData[6], NLFData[7], a);
-        } else if (iso >= 12800 && iso < 25600) {
+        }
+        else if (iso >= 12800 && iso < 25600)
+        {
             float a = (iso - 12800) / 12800;
             return lerp<levels>(NLFData[7], NLFData[8], a);
-        } else if (iso >= 25600 && iso < 51200) {
+        }
+        else if (iso >= 25600 && iso < 51200)
+        {
             float a = (iso - 25600) / 25600;
             return lerp<levels>(NLFData[8], NLFData[9], a);
-        } else /* if (iso >= 51200 && iso <= 102400) */ {
+        }
+        else /* if (iso >= 51200 && iso <= 102400) */
+        {
             float a = (iso - 51200) / 51200;
             return lerp<levels>(NLFData[9], NLFData[10], a);
         }
     }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override {
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override
+    {
         const float nlf_alpha = std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
 
-        std::cout << "Sonya6400 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        // std::cout << "Sonya6400 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
 
         float lerp = std::lerp(0.125f, 2.0f, nlf_alpha);
         float lerp_c = 1;
 
-        float lmult[5] = { 0.5, 1, 0.5, 0.25, 0.125 };
-        float cmult[5] = { 1, 0.5, 0.5, 0.5, 0.25 };
+        float lmult[5] = {0.5, 1, 0.5, 0.25, 0.125};
+        float cmult[5] = {1, 0.5, 0.5, 0.5, 0.25};
 
         float chromaBoost = 8;
 
         float gradientBoost = smoothstep(0.3, 0.8, nlf_alpha);
         float gradientThreshold = 1 + 0.5 * smoothstep(0.3, 0.8, nlf_alpha);
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{
-            {
-                .luma = lmult[0] * lerp,
-                .chroma = cmult[0] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = 8 * gradientBoost,
-                .gradientThreshold = gradientThreshold,
-                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)
-            },
-            {
-                .luma = lmult[1] * lerp,
-                .chroma = cmult[1] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1.1
-            },
-            {
-                .luma = lmult[2] * lerp,
-                .chroma = cmult[2] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[3] * lerp,
-                .chroma = cmult[3] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[4] * lerp,
-                .chroma = cmult[4] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            }
-        }};
+        std::array<DenoiseParameters, 5> denoiseParameters = {{{.luma = lmult[0] * lerp,
+                                                                .chroma = cmult[0] * lerp_c,
+                                                                .chromaBoost = chromaBoost,
+                                                                .gradientBoost = 8 * gradientBoost,
+                                                                .gradientThreshold = gradientThreshold,
+                                                                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)},
+                                                               {.luma = lmult[1] * lerp,
+                                                                .chroma = cmult[1] * lerp_c,
+                                                                .chromaBoost = chromaBoost,
+                                                                .gradientBoost = gradientBoost,
+                                                                .sharpening = 1.1},
+                                                               {.luma = lmult[2] * lerp,
+                                                                .chroma = cmult[2] * lerp_c,
+                                                                .chromaBoost = chromaBoost,
+                                                                .gradientBoost = gradientBoost,
+                                                                .sharpening = 1},
+                                                               {.luma = lmult[3] * lerp,
+                                                                .chroma = cmult[3] * lerp_c,
+                                                                .chromaBoost = chromaBoost,
+                                                                .gradientBoost = gradientBoost,
+                                                                .sharpening = 1},
+                                                               {.luma = lmult[4] * lerp,
+                                                                .chroma = cmult[4] * lerp_c,
+                                                                .chromaBoost = chromaBoost,
+                                                                .gradientBoost = gradientBoost,
+                                                                .sharpening = 1}}};
 
-        return { nlf_alpha, denoiseParameters };
+        return {nlf_alpha, denoiseParameters};
     }
 
-
-    DemosaicParameters buildDemosaicParameters() const override {
+    DemosaicParameters buildDemosaicParameters() const override
+    {
         return {
             .rgbConversionParameters = {
                 // .exposureBias = -1.0,
@@ -128,46 +138,42 @@ public:
                 .contrast = 1.05,
                 .saturation = 1.0,
                 .toneCurveSlope = 3.5,
-                .localToneMapping = false
-            },
-            .ltmParameters = {
-                .eps = 0.01,
-                .shadows = 1.0, // 0.8,
-                .highlights = 1.0, // 1.5,
-                .detail = { 1, 1.2, 2.0 }
-            }
-        };
+                .localToneMapping = false},
+            .ltmParameters = {.eps = 0.01,
+                              .shadows = 1.0,    // 0.8,
+                              .highlights = 1.0, // 1.5,
+                              .detail = {1, 1.2, 2.0}}};
     }
 
-    void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const override {
+    void calibrate(RawConverter *rawConverter, const std::filesystem::path &input_dir) const override
+    {
         std::array<CalibrationEntry, 11> calibration_files = {{
-            { 100,    "DSC00185_ISO_100.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 200,    "DSC00188_ISO_200.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 400,    "DSC00192_ISO_400.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 800,    "DSC00195_ISO_800.DNG",    { 2435, 521, 1109, 732 }, false },
-            { 1600,   "DSC00198_ISO_1600.DNG",   { 2435, 521, 1109, 732 }, false },
-            { 3200,   "DSC00201_ISO_3200.DNG",   { 2435, 521, 1109, 732 }, false },
-            { 6400,   "DSC00204_ISO_6400.DNG",   { 2435, 521, 1109, 732 }, false },
-            { 12800,  "DSC00207_ISO_12800.DNG",  { 2435, 521, 1109, 732 }, false },
-            { 25600,  "DSC00210_ISO_25600.DNG",  { 2435, 521, 1109, 732 }, false },
-            { 51200,  "DSC00227_ISO_51200.DNG",  { 2435, 521, 1109, 732 }, false },
-            { 102400, "DSC00230_ISO_102400.DNG", { 2435, 521, 1109, 732 }, false },
+            {100, "DSC00185_ISO_100.DNG", {2435, 521, 1109, 732}, false},
+            {200, "DSC00188_ISO_200.DNG", {2435, 521, 1109, 732}, false},
+            {400, "DSC00192_ISO_400.DNG", {2435, 521, 1109, 732}, false},
+            {800, "DSC00195_ISO_800.DNG", {2435, 521, 1109, 732}, false},
+            {1600, "DSC00198_ISO_1600.DNG", {2435, 521, 1109, 732}, false},
+            {3200, "DSC00201_ISO_3200.DNG", {2435, 521, 1109, 732}, false},
+            {6400, "DSC00204_ISO_6400.DNG", {2435, 521, 1109, 732}, false},
+            {12800, "DSC00207_ISO_12800.DNG", {2435, 521, 1109, 732}, false},
+            {25600, "DSC00210_ISO_25600.DNG", {2435, 521, 1109, 732}, false},
+            {51200, "DSC00227_ISO_51200.DNG", {2435, 521, 1109, 732}, false},
+            {102400, "DSC00230_ISO_102400.DNG", {2435, 521, 1109, 732}, false},
         }};
 
         std::array<NoiseModel<5>, 11> noiseModel;
 
-        for (int i = 0; i < calibration_files.size(); i++) {
-            auto& entry = calibration_files[i];
+        for (int i = 0; i < calibration_files.size(); i++)
+        {
+            auto &entry = calibration_files[i];
             const auto input_path = input_dir / entry.fileName;
 
             DemosaicParameters demosaicParameters = {
                 .rgbConversionParameters = {
-                    .localToneMapping = false
-                }
-            };
+                    .localToneMapping = false}};
 
             const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/ true);
+            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -177,42 +183,47 @@ public:
     }
 };
 
-void calibrateSonya6400(RawConverter* rawConverter, const std::filesystem::path& input_dir) {
+void calibrateSonya6400(RawConverter *rawConverter, const std::filesystem::path &input_dir)
+{
     Sonya6400Calibration calibration;
     calibration.calibrate(rawConverter, input_dir);
 }
 
 template <typename T>
-typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(RawConverter* rawConverter,
-                                                             gls::tiff_metadata* dng_metadata,
-                                                             gls::tiff_metadata* exif_metadata,
-                                                             const gls::image<gls::luma_pixel_16>& inputImage) {
+typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(RawConverter *rawConverter,
+                                                             gls::tiff_metadata *dng_metadata,
+                                                             gls::tiff_metadata *exif_metadata,
+                                                             const gls::image<gls::luma_pixel_16> &inputImage)
+{
     Sonya6400Calibration calibration;
     auto demosaicParameters = calibration.getDemosaicParameters(inputImage, dng_metadata, exif_metadata);
 
-    unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/ false, nullptr, false);
+    unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/false, nullptr, false);
 
-    const auto demosaicedImage = rawConverter->runPipeline(inputImage, demosaicParameters.get(), /*calibrateFromImage=*/ false);
+    const auto demosaicedImage = rawConverter->runPipeline(inputImage, demosaicParameters.get(), /*calibrateFromImage=*/false);
 
-//    gls::cl_image_2d<gls::rgba_pixel_float> unsquishedImage(rawConverter->getContext()->clContext(), demosaicedImage->width, demosaicedImage->height * 1.2);
-//    clRescaleImage(rawConverter->getContext(), *demosaicedImage, &unsquishedImage);
+    //    gls::cl_image_2d<gls::rgba_pixel_float> unsquishedImage(rawConverter->getContext()->clContext(), demosaicedImage->width, demosaicedImage->height * 1.2);
+    //    clRescaleImage(rawConverter->getContext(), *demosaicedImage, &unsquishedImage);
 
     return RawConverter::convertToRGBImage<T>(*demosaicedImage);
 }
 
 template
-typename gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400RawImage<gls::rgb_pixel>(RawConverter* rawConverter,
-                                                                                          gls::tiff_metadata* dng_metadata,
-                                                                                          gls::tiff_metadata* exif_metadata,
-                                                                                          const gls::image<gls::luma_pixel_16>& inputImage);
+    typename gls::image<gls::rgb_pixel>::unique_ptr
+    demosaicSonya6400RawImage<gls::rgb_pixel>(RawConverter *rawConverter,
+                                              gls::tiff_metadata *dng_metadata,
+                                              gls::tiff_metadata *exif_metadata,
+                                              const gls::image<gls::luma_pixel_16> &inputImage);
 
 template
-typename gls::image<gls::rgb_pixel_16>::unique_ptr demosaicSonya6400RawImage<gls::rgb_pixel_16>(RawConverter* rawConverter,
-                                                                                                gls::tiff_metadata* dng_metadata,
-                                                                                                gls::tiff_metadata* exif_metadata,
-                                                                                                const gls::image<gls::luma_pixel_16>& inputImage);
+    typename gls::image<gls::rgb_pixel_16>::unique_ptr
+    demosaicSonya6400RawImage<gls::rgb_pixel_16>(RawConverter *rawConverter,
+                                                 gls::tiff_metadata *dng_metadata,
+                                                 gls::tiff_metadata *exif_metadata,
+                                                 const gls::image<gls::luma_pixel_16> &inputImage);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter *rawConverter, const std::filesystem::path &input_path)
+{
     gls::tiff_metadata dng_metadata, exif_metadata;
     const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
 
@@ -221,7 +232,7 @@ gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter* rawCon
 
 // --- NLFData ---
 
-template<>
+template <>
 const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
     // ISO 100
     {
@@ -232,8 +243,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 7.791e-08, 6.431e-08}, {7.489e-04, 6.842e-06, 6.428e-06}},
             {{1.000e-08, 2.936e-07, 3.165e-07}, {9.712e-04, 4.746e-06, 3.824e-06}},
             {{1.000e-08, 7.608e-07, 7.625e-07}, {1.510e-03, 7.559e-06, 5.740e-06}},
-        }}
-    },
+        }}},
     // ISO 200
     {
         {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.499e-04, 3.647e-04, 3.140e-04, 3.643e-04}},
@@ -243,8 +253,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 7.166e-08, 6.374e-08}, {7.476e-04, 7.374e-06, 7.463e-06}},
             {{1.000e-08, 2.895e-07, 3.087e-07}, {9.677e-04, 4.947e-06, 4.188e-06}},
             {{1.000e-08, 7.605e-07, 7.614e-07}, {1.500e-03, 7.653e-06, 5.846e-06}},
-        }}
-    },
+        }}},
     // ISO 400
     {
         {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.396e-04, 4.238e-04, 3.977e-04, 4.217e-04}},
@@ -254,8 +263,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 6.741e-08, 5.787e-08}, {7.483e-04, 8.636e-06, 9.625e-06}},
             {{1.000e-08, 2.841e-07, 2.978e-07}, {9.675e-04, 5.337e-06, 4.905e-06}},
             {{1.000e-08, 7.600e-07, 7.671e-07}, {1.494e-03, 7.795e-06, 5.757e-06}},
-        }}
-    },
+        }}},
     // ISO 800
     {
         {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.018e-03, 5.322e-04, 5.686e-04, 5.297e-04}},
@@ -265,8 +273,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 7.534e-08, 5.754e-08}, {7.531e-04, 1.069e-05, 1.390e-05}},
             {{1.000e-08, 2.722e-07, 2.967e-07}, {9.571e-04, 6.101e-06, 5.980e-06}},
             {{1.000e-08, 7.695e-07, 7.782e-07}, {1.472e-03, 8.027e-06, 6.125e-06}},
-        }}
-    },
+        }}},
     // ISO 1600
     {
         {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.717e-03, 7.571e-04, 9.241e-04, 7.550e-04}},
@@ -276,8 +283,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 8.995e-08, 7.926e-08}, {7.525e-04, 1.464e-05, 2.207e-05}},
             {{1.000e-08, 2.768e-07, 3.090e-07}, {9.602e-04, 7.266e-06, 8.327e-06}},
             {{1.000e-08, 7.649e-07, 7.682e-07}, {1.473e-03, 8.244e-06, 6.902e-06}},
-        }}
-    },
+        }}},
     // ISO 3200
     {
         {{1.660e-05, 1.000e-08, 1.000e-08, 1.000e-08}, {2.888e-03, 1.320e-03, 1.644e-03, 1.325e-03}},
@@ -287,8 +293,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 1.398e-07, 1.546e-07}, {7.514e-04, 2.278e-05, 3.856e-05}},
             {{1.000e-08, 2.900e-07, 3.274e-07}, {9.181e-04, 9.926e-06, 1.301e-05}},
             {{1.000e-08, 8.220e-07, 8.594e-07}, {1.381e-03, 8.419e-06, 7.551e-06}},
-        }}
-    },
+        }}},
     // ISO 6400
     {
         {{4.137e-05, 1.000e-08, 4.311e-06, 1.000e-08}, {5.539e-03, 2.345e-03, 3.110e-03, 2.352e-03}},
@@ -298,8 +303,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 2.738e-07, 3.553e-07}, {7.587e-04, 3.806e-05, 6.996e-05}},
             {{1.000e-08, 3.175e-07, 3.725e-07}, {8.731e-04, 1.458e-05, 2.216e-05}},
             {{1.000e-08, 9.064e-07, 9.689e-07}, {1.236e-03, 8.252e-06, 8.845e-06}},
-        }}
-    },
+        }}},
     // ISO 12800
     {
         {{6.766e-05, 2.051e-06, 1.645e-05, 2.807e-06}, {1.142e-02, 4.548e-03, 6.092e-03, 4.585e-03}},
@@ -309,8 +313,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 5.859e-07, 7.594e-07}, {7.845e-04, 6.907e-05, 1.366e-04}},
             {{1.000e-08, 3.830e-07, 4.875e-07}, {9.025e-04, 2.413e-05, 4.117e-05}},
             {{1.000e-08, 8.809e-07, 9.512e-07}, {1.303e-03, 1.116e-05, 1.463e-05}},
-        }}
-    },
+        }}},
     // ISO 25600
     {
         {{1.579e-04, 1.000e-08, 1.000e-08, 3.245e-07}, {1.696e-02, 9.136e-03, 1.286e-02, 9.248e-03}},
@@ -320,8 +323,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 1.072e-06, 1.201e-06}, {8.396e-04, 1.341e-04, 2.781e-04}},
             {{1.000e-08, 5.847e-07, 7.495e-07}, {8.875e-04, 4.236e-05, 7.692e-05}},
             {{1.000e-08, 9.475e-07, 1.120e-06}, {1.221e-03, 1.611e-05, 2.217e-05}},
-        }}
-    },
+        }}},
     // ISO 51200
     {
         {{2.426e-04, 1.000e-08, 1.693e-06, 1.000e-08}, {1.800e-02, 1.339e-02, 1.708e-02, 1.357e-02}},
@@ -331,8 +333,7 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 2.492e-06, 2.101e-06}, {1.032e-03, 2.499e-04, 5.670e-04}},
             {{1.000e-08, 7.571e-07, 1.032e-06}, {9.193e-04, 8.701e-05, 1.658e-04}},
             {{1.000e-08, 1.040e-06, 1.307e-06}, {1.208e-03, 2.773e-05, 4.544e-05}},
-        }}
-    },
+        }}},
     // ISO 102400
     {
         {{2.763e-04, 1.000e-08, 5.632e-05, 1.000e-08}, {2.324e-02, 2.530e-02, 2.491e-02, 2.492e-02}},
@@ -342,6 +343,5 @@ const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
             {{1.000e-08, 2.768e-06, 2.035e-06}, {1.652e-03, 5.720e-04, 1.284e-03}},
             {{1.000e-08, 6.270e-07, 8.442e-07}, {1.133e-03, 1.931e-04, 3.861e-04}},
             {{1.000e-08, 1.104e-06, 1.611e-06}, {1.372e-03, 5.371e-05, 1.010e-04}},
-        }}
-    },
+        }}},
 }};

--- a/src/Sonya6400Calibration.cpp
+++ b/src/Sonya6400Calibration.cpp
@@ -13,80 +13,61 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CameraCalibration.hpp"
-
 #include <array>
 #include <cmath>
 #include <filesystem>
 
+#include "CameraCalibration.hpp"
 #include "demosaic.hpp"
 
 template <size_t levels = 5>
-class Sonya6400Calibration : public CameraCalibration<levels>
-{
+class Sonya6400Calibration : public CameraCalibration<levels> {
     static const std::array<NoiseModel<levels>, 11> NLFData;
 
-public:
-    NoiseModel<levels> nlfFromIso(int iso) const override
-    {
+   public:
+    NoiseModel<levels> nlfFromIso(int iso) const override {
         iso = std::clamp(iso, 100, 102400);
-        if (iso >= 100 && iso < 200)
-        {
+        if (iso >= 100 && iso < 200) {
             float a = (iso - 100) / 100;
             return lerp<levels>(NLFData[0], NLFData[1], a);
-        }
-        else if (iso >= 200 && iso < 400)
-        {
+        } else if (iso >= 200 && iso < 400) {
             float a = (iso - 200) / 200;
             return lerp<levels>(NLFData[1], NLFData[2], a);
-        }
-        else if (iso >= 400 && iso < 800)
-        {
+        } else if (iso >= 400 && iso < 800) {
             float a = (iso - 400) / 400;
             return lerp<levels>(NLFData[2], NLFData[3], a);
-        }
-        else if (iso >= 800 && iso < 1600)
-        {
+        } else if (iso >= 800 && iso < 1600) {
             float a = (iso - 800) / 800;
             return lerp<levels>(NLFData[3], NLFData[4], a);
-        }
-        else if (iso >= 1600 && iso < 3200)
-        {
+        } else if (iso >= 1600 && iso < 3200) {
             float a = (iso - 1600) / 1600;
             return lerp<levels>(NLFData[4], NLFData[5], a);
-        }
-        else if (iso >= 3200 && iso < 6400)
-        {
+        } else if (iso >= 3200 && iso < 6400) {
             float a = (iso - 3200) / 3200;
             return lerp<levels>(NLFData[5], NLFData[6], a);
-        }
-        else if (iso >= 6400 && iso < 12800)
-        {
+        } else if (iso >= 6400 && iso < 12800) {
             float a = (iso - 6400) / 6400;
             return lerp<levels>(NLFData[6], NLFData[7], a);
-        }
-        else if (iso >= 12800 && iso < 25600)
-        {
+        } else if (iso >= 12800 && iso < 25600) {
             float a = (iso - 12800) / 12800;
             return lerp<levels>(NLFData[7], NLFData[8], a);
-        }
-        else if (iso >= 25600 && iso < 51200)
-        {
+        } else if (iso >= 25600 && iso < 51200) {
             float a = (iso - 25600) / 25600;
             return lerp<levels>(NLFData[8], NLFData[9], a);
-        }
-        else /* if (iso >= 51200 && iso <= 102400) */
+        } else /* if (iso >= 51200 && iso <= 102400) */
         {
             float a = (iso - 51200) / 51200;
             return lerp<levels>(NLFData[9], NLFData[10], a);
         }
     }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override
-    {
-        const float nlf_alpha = std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const override {
+        const float nlf_alpha =
+            std::clamp((log2(iso) - log2(100)) / (log2(102400) - log2(100)), 0.0, 1.0);
 
-        // std::cout << "Sonya6400 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        // std::cout << "Sonya6400 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+        // << std::endl;
 
         float lerp = std::lerp(0.125f, 2.0f, nlf_alpha);
         float lerp_c = 1;
@@ -99,54 +80,53 @@ public:
         float gradientBoost = smoothstep(0.3, 0.8, nlf_alpha);
         float gradientThreshold = 1 + 0.5 * smoothstep(0.3, 0.8, nlf_alpha);
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{{.luma = lmult[0] * lerp,
-                                                                .chroma = cmult[0] * lerp_c,
-                                                                .chromaBoost = chromaBoost,
-                                                                .gradientBoost = 8 * gradientBoost,
-                                                                .gradientThreshold = gradientThreshold,
-                                                                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)},
-                                                               {.luma = lmult[1] * lerp,
-                                                                .chroma = cmult[1] * lerp_c,
-                                                                .chromaBoost = chromaBoost,
-                                                                .gradientBoost = gradientBoost,
-                                                                .sharpening = 1.1},
-                                                               {.luma = lmult[2] * lerp,
-                                                                .chroma = cmult[2] * lerp_c,
-                                                                .chromaBoost = chromaBoost,
-                                                                .gradientBoost = gradientBoost,
-                                                                .sharpening = 1},
-                                                               {.luma = lmult[3] * lerp,
-                                                                .chroma = cmult[3] * lerp_c,
-                                                                .chromaBoost = chromaBoost,
-                                                                .gradientBoost = gradientBoost,
-                                                                .sharpening = 1},
-                                                               {.luma = lmult[4] * lerp,
-                                                                .chroma = cmult[4] * lerp_c,
-                                                                .chromaBoost = chromaBoost,
-                                                                .gradientBoost = gradientBoost,
-                                                                .sharpening = 1}}};
+        std::array<DenoiseParameters, 5> denoiseParameters = {
+            {{.luma = lmult[0] * lerp,
+              .chroma = cmult[0] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = 8 * gradientBoost,
+              .gradientThreshold = gradientThreshold,
+              .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)},
+             {.luma = lmult[1] * lerp,
+              .chroma = cmult[1] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1.1},
+             {.luma = lmult[2] * lerp,
+              .chroma = cmult[2] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[3] * lerp,
+              .chroma = cmult[3] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[4] * lerp,
+              .chroma = cmult[4] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1}}};
 
         return {nlf_alpha, denoiseParameters};
     }
 
-    DemosaicParameters buildDemosaicParameters() const override
-    {
-        return {
-            .rgbConversionParameters = {
-                // .exposureBias = -1.0,
-                // .blacks = 0.1,
-                .contrast = 1.05,
-                .saturation = 1.0,
-                .toneCurveSlope = 3.5,
-                .localToneMapping = false},
-            .ltmParameters = {.eps = 0.01,
-                              .shadows = 1.0,    // 0.8,
-                              .highlights = 1.0, // 1.5,
-                              .detail = {1, 1.2, 2.0}}};
+    DemosaicParameters buildDemosaicParameters() const override {
+        return {.rgbConversionParameters =
+                    {// .exposureBias = -1.0,
+                     // .blacks = 0.1,
+                     .contrast = 1.05,
+                     .saturation = 1.0,
+                     .toneCurveSlope = 3.5,
+                     .localToneMapping = false},
+                .ltmParameters = {.eps = 0.01,
+                                  .shadows = 1.0,     // 0.8,
+                                  .highlights = 1.0,  // 1.5,
+                                  .detail = {1, 1.2, 2.0}}};
     }
 
-    void calibrate(RawConverter *rawConverter, const std::filesystem::path &input_dir) const override
-    {
+    void calibrate(RawConverter* rawConverter,
+                   const std::filesystem::path& input_dir) const override {
         std::array<CalibrationEntry, 11> calibration_files = {{
             {100, "DSC00185_ISO_100.DNG", {2435, 521, 1109, 732}, false},
             {200, "DSC00188_ISO_200.DNG", {2435, 521, 1109, 732}, false},
@@ -163,17 +143,18 @@ public:
 
         std::array<NoiseModel<5>, 11> noiseModel;
 
-        for (int i = 0; i < calibration_files.size(); i++)
-        {
-            auto &entry = calibration_files[i];
+        for (int i = 0; i < calibration_files.size(); i++) {
+            auto& entry = calibration_files[i];
             const auto input_path = input_dir / entry.fileName;
 
             DemosaicParameters demosaicParameters = {
-                .rgbConversionParameters = {
-                    .localToneMapping = false}};
+                .rgbConversionParameters = {.localToneMapping = false}};
 
-            const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/true);
+            const auto rgb_image = CameraCalibration<5>::calibrate(
+                rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
+            rgb_image->write_png_file(
+                (input_path.parent_path() / input_path.stem()).string() + "_cal.png",
+                /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -183,49 +164,48 @@ public:
     }
 };
 
-void calibrateSonya6400(RawConverter *rawConverter, const std::filesystem::path &input_dir)
-{
+void calibrateSonya6400(RawConverter* rawConverter, const std::filesystem::path& input_dir) {
     Sonya6400Calibration calibration;
     calibration.calibrate(rawConverter, input_dir);
 }
 
 template <typename T>
-typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(RawConverter *rawConverter,
-                                                             gls::tiff_metadata *dng_metadata,
-                                                             gls::tiff_metadata *exif_metadata,
-                                                             const gls::image<gls::luma_pixel_16> &inputImage)
-{
+typename gls::image<T>::unique_ptr demosaicSonya6400RawImage(
+    RawConverter* rawConverter, gls::tiff_metadata* dng_metadata, gls::tiff_metadata* exif_metadata,
+    const gls::image<gls::luma_pixel_16>& inputImage) {
     Sonya6400Calibration calibration;
-    auto demosaicParameters = calibration.getDemosaicParameters(inputImage, dng_metadata, exif_metadata);
+    auto demosaicParameters =
+        calibration.getDemosaicParameters(inputImage, dng_metadata, exif_metadata);
 
-    unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(), /*auto_white_balance=*/false, nullptr, false);
+    unpackDNGMetadata(inputImage, dng_metadata, demosaicParameters.get(),
+                      /*auto_white_balance=*/false, nullptr, false);
 
-    const auto demosaicedImage = rawConverter->runPipeline(inputImage, demosaicParameters.get(), /*calibrateFromImage=*/false);
+    const auto demosaicedImage = rawConverter->runPipeline(inputImage, demosaicParameters.get(),
+                                                           /*calibrateFromImage=*/false);
 
-    //    gls::cl_image_2d<gls::rgba_pixel_float> unsquishedImage(rawConverter->getContext()->clContext(), demosaicedImage->width, demosaicedImage->height * 1.2);
-    //    clRescaleImage(rawConverter->getContext(), *demosaicedImage, &unsquishedImage);
+    //    gls::cl_image_2d<gls::rgba_pixel_float>
+    //    unsquishedImage(rawConverter->getContext()->clContext(), demosaicedImage->width,
+    //    demosaicedImage->height * 1.2); clRescaleImage(rawConverter->getContext(),
+    //    *demosaicedImage, &unsquishedImage);
 
     return RawConverter::convertToRGBImage<T>(*demosaicedImage);
 }
 
-template
-    typename gls::image<gls::rgb_pixel>::unique_ptr
-    demosaicSonya6400RawImage<gls::rgb_pixel>(RawConverter *rawConverter,
-                                              gls::tiff_metadata *dng_metadata,
-                                              gls::tiff_metadata *exif_metadata,
-                                              const gls::image<gls::luma_pixel_16> &inputImage);
+template typename gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400RawImage<gls::rgb_pixel>(
+    RawConverter* rawConverter, gls::tiff_metadata* dng_metadata, gls::tiff_metadata* exif_metadata,
+    const gls::image<gls::luma_pixel_16>& inputImage);
 
-template
-    typename gls::image<gls::rgb_pixel_16>::unique_ptr
-    demosaicSonya6400RawImage<gls::rgb_pixel_16>(RawConverter *rawConverter,
-                                                 gls::tiff_metadata *dng_metadata,
-                                                 gls::tiff_metadata *exif_metadata,
-                                                 const gls::image<gls::luma_pixel_16> &inputImage);
+template typename gls::image<gls::rgb_pixel_16>::unique_ptr
+demosaicSonya6400RawImage<gls::rgb_pixel_16>(RawConverter* rawConverter,
+                                             gls::tiff_metadata* dng_metadata,
+                                             gls::tiff_metadata* exif_metadata,
+                                             const gls::image<gls::luma_pixel_16>& inputImage);
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter *rawConverter, const std::filesystem::path &input_path)
-{
+gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(
+    RawConverter* rawConverter, const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
     return demosaicSonya6400RawImage(rawConverter, &dng_metadata, &exif_metadata, *inputImage);
 }
@@ -235,113 +215,102 @@ gls::image<gls::rgb_pixel>::unique_ptr demosaicSonya6400DNG(RawConverter *rawCon
 template <>
 const std::array<NoiseModel<5>, 11> Sonya6400Calibration<5>::NLFData = {{
     // ISO 100
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {3.681e-04, 3.448e-04, 2.846e-04, 3.447e-04}},
-        {{
-            {{1.000e-08, 1.000e-08, 1.026e-08}, {3.686e-04, 7.427e-06, 8.743e-06}},
-            {{1.000e-08, 1.000e-08, 1.000e-08}, {5.010e-04, 8.027e-06, 7.757e-06}},
-            {{1.000e-08, 7.791e-08, 6.431e-08}, {7.489e-04, 6.842e-06, 6.428e-06}},
-            {{1.000e-08, 2.936e-07, 3.165e-07}, {9.712e-04, 4.746e-06, 3.824e-06}},
-            {{1.000e-08, 7.608e-07, 7.625e-07}, {1.510e-03, 7.559e-06, 5.740e-06}},
-        }}},
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {3.681e-04, 3.448e-04, 2.846e-04, 3.447e-04}},
+     {{
+         {{1.000e-08, 1.000e-08, 1.026e-08}, {3.686e-04, 7.427e-06, 8.743e-06}},
+         {{1.000e-08, 1.000e-08, 1.000e-08}, {5.010e-04, 8.027e-06, 7.757e-06}},
+         {{1.000e-08, 7.791e-08, 6.431e-08}, {7.489e-04, 6.842e-06, 6.428e-06}},
+         {{1.000e-08, 2.936e-07, 3.165e-07}, {9.712e-04, 4.746e-06, 3.824e-06}},
+         {{1.000e-08, 7.608e-07, 7.625e-07}, {1.510e-03, 7.559e-06, 5.740e-06}},
+     }}},
     // ISO 200
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.499e-04, 3.647e-04, 3.140e-04, 3.643e-04}},
-        {{
-            {{1.000e-08, 1.000e-08, 3.841e-08}, {3.891e-04, 9.280e-06, 1.321e-05}},
-            {{1.000e-08, 1.000e-08, 2.128e-08}, {5.035e-04, 9.215e-06, 1.053e-05}},
-            {{1.000e-08, 7.166e-08, 6.374e-08}, {7.476e-04, 7.374e-06, 7.463e-06}},
-            {{1.000e-08, 2.895e-07, 3.087e-07}, {9.677e-04, 4.947e-06, 4.188e-06}},
-            {{1.000e-08, 7.605e-07, 7.614e-07}, {1.500e-03, 7.653e-06, 5.846e-06}},
-        }}},
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {4.499e-04, 3.647e-04, 3.140e-04, 3.643e-04}},
+     {{
+         {{1.000e-08, 1.000e-08, 3.841e-08}, {3.891e-04, 9.280e-06, 1.321e-05}},
+         {{1.000e-08, 1.000e-08, 2.128e-08}, {5.035e-04, 9.215e-06, 1.053e-05}},
+         {{1.000e-08, 7.166e-08, 6.374e-08}, {7.476e-04, 7.374e-06, 7.463e-06}},
+         {{1.000e-08, 2.895e-07, 3.087e-07}, {9.677e-04, 4.947e-06, 4.188e-06}},
+         {{1.000e-08, 7.605e-07, 7.614e-07}, {1.500e-03, 7.653e-06, 5.846e-06}},
+     }}},
     // ISO 400
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.396e-04, 4.238e-04, 3.977e-04, 4.217e-04}},
-        {{
-            {{1.000e-08, 1.000e-08, 7.723e-08}, {4.263e-04, 1.306e-05, 2.182e-05}},
-            {{1.000e-08, 1.000e-08, 1.239e-08}, {5.113e-04, 1.186e-05, 1.652e-05}},
-            {{1.000e-08, 6.741e-08, 5.787e-08}, {7.483e-04, 8.636e-06, 9.625e-06}},
-            {{1.000e-08, 2.841e-07, 2.978e-07}, {9.675e-04, 5.337e-06, 4.905e-06}},
-            {{1.000e-08, 7.600e-07, 7.671e-07}, {1.494e-03, 7.795e-06, 5.757e-06}},
-        }}},
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {6.396e-04, 4.238e-04, 3.977e-04, 4.217e-04}},
+     {{
+         {{1.000e-08, 1.000e-08, 7.723e-08}, {4.263e-04, 1.306e-05, 2.182e-05}},
+         {{1.000e-08, 1.000e-08, 1.239e-08}, {5.113e-04, 1.186e-05, 1.652e-05}},
+         {{1.000e-08, 6.741e-08, 5.787e-08}, {7.483e-04, 8.636e-06, 9.625e-06}},
+         {{1.000e-08, 2.841e-07, 2.978e-07}, {9.675e-04, 5.337e-06, 4.905e-06}},
+         {{1.000e-08, 7.600e-07, 7.671e-07}, {1.494e-03, 7.795e-06, 5.757e-06}},
+     }}},
     // ISO 800
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.018e-03, 5.322e-04, 5.686e-04, 5.297e-04}},
-        {{
-            {{1.000e-08, 6.604e-08, 2.035e-07}, {4.924e-04, 2.036e-05, 3.801e-05}},
-            {{1.000e-08, 1.000e-08, 3.925e-08}, {5.207e-04, 1.685e-05, 2.784e-05}},
-            {{1.000e-08, 7.534e-08, 5.754e-08}, {7.531e-04, 1.069e-05, 1.390e-05}},
-            {{1.000e-08, 2.722e-07, 2.967e-07}, {9.571e-04, 6.101e-06, 5.980e-06}},
-            {{1.000e-08, 7.695e-07, 7.782e-07}, {1.472e-03, 8.027e-06, 6.125e-06}},
-        }}},
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.018e-03, 5.322e-04, 5.686e-04, 5.297e-04}},
+     {{
+         {{1.000e-08, 6.604e-08, 2.035e-07}, {4.924e-04, 2.036e-05, 3.801e-05}},
+         {{1.000e-08, 1.000e-08, 3.925e-08}, {5.207e-04, 1.685e-05, 2.784e-05}},
+         {{1.000e-08, 7.534e-08, 5.754e-08}, {7.531e-04, 1.069e-05, 1.390e-05}},
+         {{1.000e-08, 2.722e-07, 2.967e-07}, {9.571e-04, 6.101e-06, 5.980e-06}},
+         {{1.000e-08, 7.695e-07, 7.782e-07}, {1.472e-03, 8.027e-06, 6.125e-06}},
+     }}},
     // ISO 1600
-    {
-        {{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.717e-03, 7.571e-04, 9.241e-04, 7.550e-04}},
-        {{
-            {{1.000e-08, 1.857e-07, 3.453e-07}, {6.393e-04, 3.485e-05, 7.274e-05}},
-            {{1.000e-08, 8.949e-08, 1.677e-07}, {5.405e-04, 2.620e-05, 4.922e-05}},
-            {{1.000e-08, 8.995e-08, 7.926e-08}, {7.525e-04, 1.464e-05, 2.207e-05}},
-            {{1.000e-08, 2.768e-07, 3.090e-07}, {9.602e-04, 7.266e-06, 8.327e-06}},
-            {{1.000e-08, 7.649e-07, 7.682e-07}, {1.473e-03, 8.244e-06, 6.902e-06}},
-        }}},
+    {{{1.000e-08, 1.000e-08, 1.000e-08, 1.000e-08}, {1.717e-03, 7.571e-04, 9.241e-04, 7.550e-04}},
+     {{
+         {{1.000e-08, 1.857e-07, 3.453e-07}, {6.393e-04, 3.485e-05, 7.274e-05}},
+         {{1.000e-08, 8.949e-08, 1.677e-07}, {5.405e-04, 2.620e-05, 4.922e-05}},
+         {{1.000e-08, 8.995e-08, 7.926e-08}, {7.525e-04, 1.464e-05, 2.207e-05}},
+         {{1.000e-08, 2.768e-07, 3.090e-07}, {9.602e-04, 7.266e-06, 8.327e-06}},
+         {{1.000e-08, 7.649e-07, 7.682e-07}, {1.473e-03, 8.244e-06, 6.902e-06}},
+     }}},
     // ISO 3200
-    {
-        {{1.660e-05, 1.000e-08, 1.000e-08, 1.000e-08}, {2.888e-03, 1.320e-03, 1.644e-03, 1.325e-03}},
-        {{
-            {{1.000e-08, 5.176e-07, 7.774e-07}, {9.818e-04, 6.376e-05, 1.439e-04}},
-            {{1.000e-08, 2.866e-07, 4.436e-07}, {5.614e-04, 4.559e-05, 9.371e-05}},
-            {{1.000e-08, 1.398e-07, 1.546e-07}, {7.514e-04, 2.278e-05, 3.856e-05}},
-            {{1.000e-08, 2.900e-07, 3.274e-07}, {9.181e-04, 9.926e-06, 1.301e-05}},
-            {{1.000e-08, 8.220e-07, 8.594e-07}, {1.381e-03, 8.419e-06, 7.551e-06}},
-        }}},
+    {{{1.660e-05, 1.000e-08, 1.000e-08, 1.000e-08}, {2.888e-03, 1.320e-03, 1.644e-03, 1.325e-03}},
+     {{
+         {{1.000e-08, 5.176e-07, 7.774e-07}, {9.818e-04, 6.376e-05, 1.439e-04}},
+         {{1.000e-08, 2.866e-07, 4.436e-07}, {5.614e-04, 4.559e-05, 9.371e-05}},
+         {{1.000e-08, 1.398e-07, 1.546e-07}, {7.514e-04, 2.278e-05, 3.856e-05}},
+         {{1.000e-08, 2.900e-07, 3.274e-07}, {9.181e-04, 9.926e-06, 1.301e-05}},
+         {{1.000e-08, 8.220e-07, 8.594e-07}, {1.381e-03, 8.419e-06, 7.551e-06}},
+     }}},
     // ISO 6400
-    {
-        {{4.137e-05, 1.000e-08, 4.311e-06, 1.000e-08}, {5.539e-03, 2.345e-03, 3.110e-03, 2.352e-03}},
-        {{
-            {{1.634e-06, 1.265e-06, 1.432e-06}, {1.585e-03, 1.157e-04, 2.866e-04}},
-            {{1.000e-08, 6.595e-07, 9.218e-07}, {6.463e-04, 8.421e-05, 1.826e-04}},
-            {{1.000e-08, 2.738e-07, 3.553e-07}, {7.587e-04, 3.806e-05, 6.996e-05}},
-            {{1.000e-08, 3.175e-07, 3.725e-07}, {8.731e-04, 1.458e-05, 2.216e-05}},
-            {{1.000e-08, 9.064e-07, 9.689e-07}, {1.236e-03, 8.252e-06, 8.845e-06}},
-        }}},
+    {{{4.137e-05, 1.000e-08, 4.311e-06, 1.000e-08}, {5.539e-03, 2.345e-03, 3.110e-03, 2.352e-03}},
+     {{
+         {{1.634e-06, 1.265e-06, 1.432e-06}, {1.585e-03, 1.157e-04, 2.866e-04}},
+         {{1.000e-08, 6.595e-07, 9.218e-07}, {6.463e-04, 8.421e-05, 1.826e-04}},
+         {{1.000e-08, 2.738e-07, 3.553e-07}, {7.587e-04, 3.806e-05, 6.996e-05}},
+         {{1.000e-08, 3.175e-07, 3.725e-07}, {8.731e-04, 1.458e-05, 2.216e-05}},
+         {{1.000e-08, 9.064e-07, 9.689e-07}, {1.236e-03, 8.252e-06, 8.845e-06}},
+     }}},
     // ISO 12800
-    {
-        {{6.766e-05, 2.051e-06, 1.645e-05, 2.807e-06}, {1.142e-02, 4.548e-03, 6.092e-03, 4.585e-03}},
-        {{
-            {{2.206e-05, 3.045e-06, 3.033e-06}, {2.528e-03, 2.095e-04, 5.749e-04}},
-            {{1.000e-08, 1.672e-06, 1.998e-06}, {8.673e-04, 1.579e-04, 3.680e-04}},
-            {{1.000e-08, 5.859e-07, 7.594e-07}, {7.845e-04, 6.907e-05, 1.366e-04}},
-            {{1.000e-08, 3.830e-07, 4.875e-07}, {9.025e-04, 2.413e-05, 4.117e-05}},
-            {{1.000e-08, 8.809e-07, 9.512e-07}, {1.303e-03, 1.116e-05, 1.463e-05}},
-        }}},
+    {{{6.766e-05, 2.051e-06, 1.645e-05, 2.807e-06}, {1.142e-02, 4.548e-03, 6.092e-03, 4.585e-03}},
+     {{
+         {{2.206e-05, 3.045e-06, 3.033e-06}, {2.528e-03, 2.095e-04, 5.749e-04}},
+         {{1.000e-08, 1.672e-06, 1.998e-06}, {8.673e-04, 1.579e-04, 3.680e-04}},
+         {{1.000e-08, 5.859e-07, 7.594e-07}, {7.845e-04, 6.907e-05, 1.366e-04}},
+         {{1.000e-08, 3.830e-07, 4.875e-07}, {9.025e-04, 2.413e-05, 4.117e-05}},
+         {{1.000e-08, 8.809e-07, 9.512e-07}, {1.303e-03, 1.116e-05, 1.463e-05}},
+     }}},
     // ISO 25600
-    {
-        {{1.579e-04, 1.000e-08, 1.000e-08, 3.245e-07}, {1.696e-02, 9.136e-03, 1.286e-02, 9.248e-03}},
-        {{
-            {{7.544e-05, 7.086e-06, 3.769e-06}, {4.212e-03, 3.907e-04, 1.213e-03}},
-            {{1.000e-08, 3.283e-06, 3.365e-06}, {1.327e-03, 3.095e-04, 7.497e-04}},
-            {{1.000e-08, 1.072e-06, 1.201e-06}, {8.396e-04, 1.341e-04, 2.781e-04}},
-            {{1.000e-08, 5.847e-07, 7.495e-07}, {8.875e-04, 4.236e-05, 7.692e-05}},
-            {{1.000e-08, 9.475e-07, 1.120e-06}, {1.221e-03, 1.611e-05, 2.217e-05}},
-        }}},
+    {{{1.579e-04, 1.000e-08, 1.000e-08, 3.245e-07}, {1.696e-02, 9.136e-03, 1.286e-02, 9.248e-03}},
+     {{
+         {{7.544e-05, 7.086e-06, 3.769e-06}, {4.212e-03, 3.907e-04, 1.213e-03}},
+         {{1.000e-08, 3.283e-06, 3.365e-06}, {1.327e-03, 3.095e-04, 7.497e-04}},
+         {{1.000e-08, 1.072e-06, 1.201e-06}, {8.396e-04, 1.341e-04, 2.781e-04}},
+         {{1.000e-08, 5.847e-07, 7.495e-07}, {8.875e-04, 4.236e-05, 7.692e-05}},
+         {{1.000e-08, 9.475e-07, 1.120e-06}, {1.221e-03, 1.611e-05, 2.217e-05}},
+     }}},
     // ISO 51200
-    {
-        {{2.426e-04, 1.000e-08, 1.693e-06, 1.000e-08}, {1.800e-02, 1.339e-02, 1.708e-02, 1.357e-02}},
-        {{
-            {{1.611e-04, 1.476e-05, 1.097e-05}, {4.615e-03, 5.094e-04, 1.937e-03}},
-            {{7.772e-06, 6.942e-06, 8.358e-06}, {1.925e-03, 5.114e-04, 1.327e-03}},
-            {{1.000e-08, 2.492e-06, 2.101e-06}, {1.032e-03, 2.499e-04, 5.670e-04}},
-            {{1.000e-08, 7.571e-07, 1.032e-06}, {9.193e-04, 8.701e-05, 1.658e-04}},
-            {{1.000e-08, 1.040e-06, 1.307e-06}, {1.208e-03, 2.773e-05, 4.544e-05}},
-        }}},
+    {{{2.426e-04, 1.000e-08, 1.693e-06, 1.000e-08}, {1.800e-02, 1.339e-02, 1.708e-02, 1.357e-02}},
+     {{
+         {{1.611e-04, 1.476e-05, 1.097e-05}, {4.615e-03, 5.094e-04, 1.937e-03}},
+         {{7.772e-06, 6.942e-06, 8.358e-06}, {1.925e-03, 5.114e-04, 1.327e-03}},
+         {{1.000e-08, 2.492e-06, 2.101e-06}, {1.032e-03, 2.499e-04, 5.670e-04}},
+         {{1.000e-08, 7.571e-07, 1.032e-06}, {9.193e-04, 8.701e-05, 1.658e-04}},
+         {{1.000e-08, 1.040e-06, 1.307e-06}, {1.208e-03, 2.773e-05, 4.544e-05}},
+     }}},
     // ISO 102400
-    {
-        {{2.763e-04, 1.000e-08, 5.632e-05, 1.000e-08}, {2.324e-02, 2.530e-02, 2.491e-02, 2.492e-02}},
-        {{
-            {{3.416e-04, 6.339e-05, 5.365e-05}, {6.797e-03, 2.545e-04, 3.741e-03}},
-            {{3.558e-05, 1.744e-05, 2.873e-05}, {3.637e-03, 1.092e-03, 2.794e-03}},
-            {{1.000e-08, 2.768e-06, 2.035e-06}, {1.652e-03, 5.720e-04, 1.284e-03}},
-            {{1.000e-08, 6.270e-07, 8.442e-07}, {1.133e-03, 1.931e-04, 3.861e-04}},
-            {{1.000e-08, 1.104e-06, 1.611e-06}, {1.372e-03, 5.371e-05, 1.010e-04}},
-        }}},
+    {{{2.763e-04, 1.000e-08, 5.632e-05, 1.000e-08}, {2.324e-02, 2.530e-02, 2.491e-02, 2.492e-02}},
+     {{
+         {{3.416e-04, 6.339e-05, 5.365e-05}, {6.797e-03, 2.545e-04, 3.741e-03}},
+         {{3.558e-05, 1.744e-05, 2.873e-05}, {3.637e-03, 1.092e-03, 2.794e-03}},
+         {{1.000e-08, 2.768e-06, 2.035e-06}, {1.652e-03, 5.720e-04, 1.284e-03}},
+         {{1.000e-08, 6.270e-07, 8.442e-07}, {1.133e-03, 1.931e-04, 3.861e-04}},
+         {{1.000e-08, 1.104e-06, 1.611e-06}, {1.372e-03, 5.371e-05, 1.010e-04}},
+     }}},
 }};

--- a/src/demosaic.cpp
+++ b/src/demosaic.cpp
@@ -18,18 +18,17 @@
 #include <iomanip>
 
 #include "demosaic_cl.hpp"
-
 #include "raw_converter.hpp"
 
 // #include "guided_filter.hpp"
 
 #include "gls_logging.h"
 
-static const char *TAG = "CLImage Pipeline";
+static const char* TAG = "CLImage Pipeline";
 
-gls::image<gls::rgb_pixel>::unique_ptr runPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                   DemosaicParameters *demosaicParameters, bool calibrateFromImage)
-{
+gls::image<gls::rgb_pixel>::unique_ptr runPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
+                                                   DemosaicParameters* demosaicParameters,
+                                                   bool calibrateFromImage) {
     gls::OpenCLContext glsContext("");
 
     auto rawConverter = std::make_unique<RawConverter>(&glsContext);
@@ -43,14 +42,15 @@ gls::image<gls::rgb_pixel>::unique_ptr runPipeline(const gls::image<gls::luma_pi
     auto t_end = std::chrono::high_resolution_clock::now();
     double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms
+                  << "ms for image of size: " << rawImage.width << " x " << rawImage.height
+                  << std::endl;
 
     return rgbImage;
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr runFastPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                       const DemosaicParameters &demosaicParameters)
-{
+gls::image<gls::rgb_pixel>::unique_ptr runFastPipeline(
+    const gls::image<gls::luma_pixel_16>& rawImage, const DemosaicParameters& demosaicParameters) {
     gls::OpenCLContext glsContext("");
 
     auto rawConverter = std::make_unique<RawConverter>(&glsContext);
@@ -64,7 +64,8 @@ gls::image<gls::rgb_pixel>::unique_ptr runFastPipeline(const gls::image<gls::lum
     auto t_end = std::chrono::high_resolution_clock::now();
     double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    // LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    // LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image
+    // of size: " << rawImage.width << " x " << rawImage.height << std::endl;
 
     return rgbImage;
 }

--- a/src/demosaic.cpp
+++ b/src/demosaic.cpp
@@ -25,10 +25,11 @@
 
 #include "gls_logging.h"
 
-static const char* TAG = "CLImage Pipeline";
+static const char *TAG = "CLImage Pipeline";
 
-gls::image<gls::rgb_pixel>::unique_ptr runPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                   DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
+gls::image<gls::rgb_pixel>::unique_ptr runPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                   DemosaicParameters *demosaicParameters, bool calibrateFromImage)
+{
     gls::OpenCLContext glsContext("");
 
     auto rawConverter = std::make_unique<RawConverter>(&glsContext);
@@ -40,15 +41,16 @@ gls::image<gls::rgb_pixel>::unique_ptr runPipeline(const gls::image<gls::luma_pi
     auto rgbImage = RawConverter::convertToRGBImage(*clsRGBImage);
 
     auto t_end = std::chrono::high_resolution_clock::now();
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
 
     return rgbImage;
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr runFastPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                       const DemosaicParameters& demosaicParameters) {
+gls::image<gls::rgb_pixel>::unique_ptr runFastPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                       const DemosaicParameters &demosaicParameters)
+{
     gls::OpenCLContext glsContext("");
 
     auto rawConverter = std::make_unique<RawConverter>(&glsContext);
@@ -60,9 +62,9 @@ gls::image<gls::rgb_pixel>::unique_ptr runFastPipeline(const gls::image<gls::lum
     auto rgbImage = RawConverter::convertToRGBImage(*clsRGBImage);
 
     auto t_end = std::chrono::high_resolution_clock::now();
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    // LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
 
     return rgbImage;
 }

--- a/src/demosaic_cl.cpp
+++ b/src/demosaic_cl.cpp
@@ -28,35 +28,37 @@
  NOTE: This code can throw exceptions, to facilitate debugging no exception handler is provided, so things can crash in place.
  */
 
-void scaleRawData(gls::OpenCLContext* glsContext,
-                 const gls::cl_image_2d<gls::luma_pixel_16>& rawImage,
-                 gls::cl_image_2d<gls::luma_pixel_float>* scaledRawImage,
-                 BayerPattern bayerPattern, gls::Vector<4> scaleMul, float blackLevel) {
+void scaleRawData(gls::OpenCLContext *glsContext,
+                  const gls::cl_image_2d<gls::luma_pixel_16> &rawImage,
+                  gls::cl_image_2d<gls::luma_pixel_float> *scaledRawImage,
+                  BayerPattern bayerPattern, gls::Vector<4> scaleMul, float blackLevel)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D,  // scaledRawImage
-                                    int,          // bayerPattern
-                                    cl_float4,    // scaleMul
-                                    float         // blackLevel
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // scaledRawImage
+                                    int,         // bayerPattern
+                                    cl_float4,   // scaleMul
+                                    float        // blackLevel
                                     >(program, "scaleRawData");
 
     // Work on one Quad (2x2) at a time
-    kernel(gls::OpenCLContext::buildEnqueueArgs(scaledRawImage->width/2, scaledRawImage->height/2),
+    kernel(gls::OpenCLContext::buildEnqueueArgs(scaledRawImage->width / 2, scaledRawImage->height / 2),
            rawImage.getImage2D(), scaledRawImage->getImage2D(), bayerPattern, {scaleMul[0], scaleMul[1], scaleMul[2], scaleMul[3]}, blackLevel);
 }
 
-void rawImageGradient(gls::OpenCLContext* glsContext,
-                      const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                      gls::cl_image_2d<gls::luma_alpha_pixel_float>* gradientImage) {
+void rawImageGradient(gls::OpenCLContext *glsContext,
+                      const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                      gls::cl_image_2d<gls::luma_alpha_pixel_float> *gradientImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D   // gradientImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D  // gradientImage
                                     >(program, "rawImageGradient");
 
     // Schedule the kernel on the GPU
@@ -64,15 +66,16 @@ void rawImageGradient(gls::OpenCLContext* glsContext,
            rawImage.getImage2D(), gradientImage->getImage2D());
 }
 
-void rawImageSobel(gls::OpenCLContext* glsContext,
-                   const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                   gls::cl_image_2d<gls::rgba_pixel_float>* gradientImage) {
+void rawImageSobel(gls::OpenCLContext *glsContext,
+                   const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                   gls::cl_image_2d<gls::rgba_pixel_float> *gradientImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D   // gradientImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D  // gradientImage
                                     >(program, "rawImageSobel");
 
     // Schedule the kernel on the GPU
@@ -80,118 +83,123 @@ void rawImageSobel(gls::OpenCLContext* glsContext,
            rawImage.getImage2D(), gradientImage->getImage2D());
 }
 
-void interpolateGreen(gls::OpenCLContext* glsContext,
-                      const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                      const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                      gls::cl_image_2d<gls::luma_pixel_float>* greenImage,
-                      BayerPattern bayerPattern, gls::Vector<2> greenVariance) {
+void interpolateGreen(gls::OpenCLContext *glsContext,
+                      const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                      const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                      gls::cl_image_2d<gls::luma_pixel_float> *greenImage,
+                      BayerPattern bayerPattern, gls::Vector<2> greenVariance)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D,  // gradientImage
-                                    cl::Image2D,  // greenImage
-                                    int,          // bayerPattern
-                                    cl_float2     // greenVariance
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // gradientImage
+                                    cl::Image2D, // greenImage
+                                    int,         // bayerPattern
+                                    cl_float2    // greenVariance
                                     >(program, "interpolateGreen");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(greenImage->width, greenImage->height),
-           rawImage.getImage2D(), gradientImage.getImage2D(), greenImage->getImage2D(), bayerPattern, { greenVariance[0], greenVariance[1] });
+           rawImage.getImage2D(), gradientImage.getImage2D(), greenImage->getImage2D(), bayerPattern, {greenVariance[0], greenVariance[1]});
 }
 
-void interpolateRedBlue(gls::OpenCLContext* glsContext,
-                        const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                        const gls::cl_image_2d<gls::luma_pixel_float>& greenImage,
-                        const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                        gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-                        BayerPattern bayerPattern, gls::Vector<2> redVariance, gls::Vector<2> blueVariance) {
+void interpolateRedBlue(gls::OpenCLContext *glsContext,
+                        const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                        const gls::cl_image_2d<gls::luma_pixel_float> &greenImage,
+                        const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                        gls::cl_image_2d<gls::rgba_pixel_float> *rgbImage,
+                        BayerPattern bayerPattern, gls::Vector<2> redVariance, gls::Vector<2> blueVariance)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D,  // greenImage
-                                    cl::Image2D,  // gradientImage
-                                    cl::Image2D,  // rgbImage
-                                    int,          // bayerPattern
-                                    cl_float2,    // redVariance
-                                    cl_float2     // blueVariance
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // greenImage
+                                    cl::Image2D, // gradientImage
+                                    cl::Image2D, // rgbImage
+                                    int,         // bayerPattern
+                                    cl_float2,   // redVariance
+                                    cl_float2    // blueVariance
                                     >(program, "interpolateRedBlue");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(rgbImage->width / 2, rgbImage->height / 2),
            rawImage.getImage2D(), greenImage.getImage2D(), gradientImage.getImage2D(),
            rgbImage->getImage2D(), bayerPattern,
-           { redVariance[0], redVariance[1] }, { blueVariance[0], blueVariance[1] });
+           {redVariance[0], redVariance[1]}, {blueVariance[0], blueVariance[1]});
 }
 
-void interpolateRedBlueAtGreen(gls::OpenCLContext* glsContext,
-                               const gls::cl_image_2d<gls::rgba_pixel_float>& rgbImageIn,
-                               const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                               gls::cl_image_2d<gls::rgba_pixel_float>* rgbImageOut,
-                               BayerPattern bayerPattern, gls::Vector<2> redVariance, gls::Vector<2> blueVariance) {
+void interpolateRedBlueAtGreen(gls::OpenCLContext *glsContext,
+                               const gls::cl_image_2d<gls::rgba_pixel_float> &rgbImageIn,
+                               const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                               gls::cl_image_2d<gls::rgba_pixel_float> *rgbImageOut,
+                               BayerPattern bayerPattern, gls::Vector<2> redVariance, gls::Vector<2> blueVariance)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rgbImageIn
-                                    cl::Image2D,  // gradientImage
-                                    cl::Image2D,  // rgbImageOut
-                                    int,          // bayerPattern
-                                    cl_float2,    // redVariance
-                                    cl_float2     // blueVariance
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rgbImageIn
+                                    cl::Image2D, // gradientImage
+                                    cl::Image2D, // rgbImageOut
+                                    int,         // bayerPattern
+                                    cl_float2,   // redVariance
+                                    cl_float2    // blueVariance
                                     >(program, "interpolateRedBlueAtGreen");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(rgbImageOut->width / 2, rgbImageOut->height / 2),
            rgbImageIn.getImage2D(), gradientImage.getImage2D(),
            rgbImageOut->getImage2D(), bayerPattern,
-           { redVariance[0], redVariance[1] }, { blueVariance[0], blueVariance[1] });
+           {redVariance[0], redVariance[1]}, {blueVariance[0], blueVariance[1]});
 }
 
-void malvar(gls::OpenCLContext* glsContext,
-            const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-            const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-            gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
+void malvar(gls::OpenCLContext *glsContext,
+            const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+            const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+            gls::cl_image_2d<gls::rgba_pixel_float> *rgbImage,
             BayerPattern bayerPattern, gls::Vector<2> redVariance,
-            gls::Vector<2> greenVariance, gls::Vector<2> blueVariance) {
+            gls::Vector<2> greenVariance, gls::Vector<2> blueVariance)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D,  // gradientImage
-                                    cl::Image2D,  // rgbImage
-                                    int,          // bayerPattern
-                                    cl_float2,    // redVariance
-                                    cl_float2,    // greenVariance
-                                    cl_float2     // blueVariance
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // gradientImage
+                                    cl::Image2D, // rgbImage
+                                    int,         // bayerPattern
+                                    cl_float2,   // redVariance
+                                    cl_float2,   // greenVariance
+                                    cl_float2    // blueVariance
                                     >(program, "malvar");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(rgbImage->width, rgbImage->height),
            rawImage.getImage2D(), gradientImage.getImage2D(), rgbImage->getImage2D(),
            bayerPattern,
-           { redVariance[0], redVariance[1] },
-           { greenVariance[0], greenVariance[1] },
-           { blueVariance[0], blueVariance[1] });
+           {redVariance[0], redVariance[1]},
+           {greenVariance[0], greenVariance[1]},
+           {blueVariance[0], blueVariance[1]});
 }
 
-void fasteDebayer(gls::OpenCLContext* glsContext,
-                  const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                  gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-                  BayerPattern bayerPattern) {
+void fasteDebayer(gls::OpenCLContext *glsContext,
+                  const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                  gls::cl_image_2d<gls::rgba_pixel_float> *rgbImage,
+                  BayerPattern bayerPattern)
+{
     assert(rawImage.width == 2 * rgbImage->width && rawImage.height == 2 * rgbImage->height);
 
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D,  // rgbImage
-                                    int           // bayerPattern
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // rgbImage
+                                    int          // bayerPattern
                                     >(program, "fastDebayer");
 
     // Schedule the kernel on the GPU
@@ -199,11 +207,12 @@ void fasteDebayer(gls::OpenCLContext* glsContext,
            rawImage.getImage2D(), rgbImage->getImage2D(), bayerPattern);
 }
 
-void rawNoiseStatistics(gls::OpenCLContext* glsContext,
-                        const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
+void rawNoiseStatistics(gls::OpenCLContext *glsContext,
+                        const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
                         BayerPattern bayerPattern,
-                        gls::cl_image_2d<gls::rgba_pixel_float>* meanImage,
-                        gls::cl_image_2d<gls::rgba_pixel_float>* varImage) {
+                        gls::cl_image_2d<gls::rgba_pixel_float> *meanImage,
+                        gls::cl_image_2d<gls::rgba_pixel_float> *varImage)
+{
     assert(rawImage.width == 2 * meanImage->width && rawImage.height == 2 * meanImage->height);
     assert(varImage->width == meanImage->width && varImage->height == meanImage->height);
 
@@ -211,10 +220,10 @@ void rawNoiseStatistics(gls::OpenCLContext* glsContext,
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    int,          // bayerPattern
-                                    cl::Image2D,  // meanImage
-                                    cl::Image2D   // varImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    int,         // bayerPattern
+                                    cl::Image2D, // meanImage
+                                    cl::Image2D  // varImage
                                     >(program, "rawNoiseStatistics");
 
     // Schedule the kernel on the GPU
@@ -223,15 +232,16 @@ void rawNoiseStatistics(gls::OpenCLContext* glsContext,
 }
 
 template <typename T1, typename T2>
-void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
-                 const gls::cl_image_2d<T1>& inputImage,
-                 gls::cl_image_2d<T2>* outputImage) {
+void applyKernel(gls::OpenCLContext *glsContext, const std::string &kernelName,
+                 const gls::cl_image_2d<T1> &inputImage,
+                 gls::cl_image_2d<T2> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D  // outputImage
                                     >(program, kernelName);
 
     // Schedule the kernel on the GPU
@@ -239,112 +249,106 @@ void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
            inputImage.getImage2D(), outputImage->getImage2D());
 }
 
-template
-void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
-                 const gls::cl_image_2d<gls::luma_pixel_float>& inputImage,
-                 gls::cl_image_2d<gls::luma_pixel_float>* outputImage);
+template void applyKernel(gls::OpenCLContext *glsContext, const std::string &kernelName,
+                          const gls::cl_image_2d<gls::luma_pixel_float> &inputImage,
+                          gls::cl_image_2d<gls::luma_pixel_float> *outputImage);
 
-template
-void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
-                 const gls::cl_image_2d<gls::luma_alpha_pixel_float>& inputImage,
-                 gls::cl_image_2d<gls::luma_alpha_pixel_float>* outputImage);
+template void applyKernel(gls::OpenCLContext *glsContext, const std::string &kernelName,
+                          const gls::cl_image_2d<gls::luma_alpha_pixel_float> &inputImage,
+                          gls::cl_image_2d<gls::luma_alpha_pixel_float> *outputImage);
 
-template
-void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
-                 const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                 gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+template void applyKernel(gls::OpenCLContext *glsContext, const std::string &kernelName,
+                          const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                          gls::cl_image_2d<gls::rgba_pixel_float> *outputImage);
 
-template
-void applyKernel(gls::OpenCLContext* glsContext, const std::string& kernelName,
-                 const gls::cl_image_2d<gls::luma_pixel_float>& inputImage,
-                 gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+template void applyKernel(gls::OpenCLContext *glsContext, const std::string &kernelName,
+                          const gls::cl_image_2d<gls::luma_pixel_float> &inputImage,
+                          gls::cl_image_2d<gls::rgba_pixel_float> *outputImage);
 
 template <typename T>
-void resampleImage(gls::OpenCLContext* glsContext, const std::string& kernelName, const gls::cl_image_2d<T>& inputImage,
-                   gls::cl_image_2d<T>* outputImage) {
+void resampleImage(gls::OpenCLContext *glsContext, const std::string &kernelName, const gls::cl_image_2d<T> &inputImage,
+                   gls::cl_image_2d<T> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl::Image2D,  // outputImage
-                                    cl::Sampler
-                                    >(program, kernelName);
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D, // outputImage
+                                    cl::Sampler>(program, kernelName);
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
            inputImage.getImage2D(), outputImage->getImage2D(), linear_sampler);
 }
 
-template
-void resampleImage(gls::OpenCLContext* glsContext, const std::string& kernelName, const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                   gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+template void resampleImage(gls::OpenCLContext *glsContext, const std::string &kernelName, const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                            gls::cl_image_2d<gls::rgba_pixel_float> *outputImage);
 
-template
-void resampleImage(gls::OpenCLContext* glsContext, const std::string& kernelName, const gls::cl_image_2d<gls::luma_alpha_pixel_float>& inputImage,
-                   gls::cl_image_2d<gls::luma_alpha_pixel_float>* outputImage);
+template void resampleImage(gls::OpenCLContext *glsContext, const std::string &kernelName, const gls::cl_image_2d<gls::luma_alpha_pixel_float> &inputImage,
+                            gls::cl_image_2d<gls::luma_alpha_pixel_float> *outputImage);
 
 template <typename T>
-void subtractNoiseImage(gls::OpenCLContext* glsContext,
-                        const gls::cl_image_2d<T>& inputImage,
-                        const gls::cl_image_2d<T>& inputImage1,
-                        const gls::cl_image_2d<T>& inputImageDenoised1,
-                        const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                        float luma_weight, float sharpening, const gls::Vector<2>& nlf, gls::cl_image_2d<T>* outputImage) {
+void subtractNoiseImage(gls::OpenCLContext *glsContext,
+                        const gls::cl_image_2d<T> &inputImage,
+                        const gls::cl_image_2d<T> &inputImage1,
+                        const gls::cl_image_2d<T> &inputImageDenoised1,
+                        const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                        float luma_weight, float sharpening, const gls::Vector<2> &nlf, gls::cl_image_2d<T> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl::Image2D,  // inputImage1
-                                    cl::Image2D,  // inputImageDenoised1
-                                    cl::Image2D,  // gradientImage
-                                    float,        // luma_weight
-                                    float,        // sharpening
-                                    cl_float2,    // nlf
-                                    cl::Image2D,  // outputImage
-                                    cl::Sampler   // linear_sampler
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D, // inputImage1
+                                    cl::Image2D, // inputImageDenoised1
+                                    cl::Image2D, // gradientImage
+                                    float,       // luma_weight
+                                    float,       // sharpening
+                                    cl_float2,   // nlf
+                                    cl::Image2D, // outputImage
+                                    cl::Sampler  // linear_sampler
                                     >(program, "subtractNoiseImage");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
            inputImage.getImage2D(), inputImage1.getImage2D(),
            inputImageDenoised1.getImage2D(), gradientImage.getImage2D(),
-           luma_weight, sharpening, { nlf[0], nlf[1] }, outputImage->getImage2D(), linear_sampler);
+           luma_weight, sharpening, {nlf[0], nlf[1]}, outputImage->getImage2D(), linear_sampler);
 }
 
-template
-void subtractNoiseImage(gls::OpenCLContext* glsContext,
-                        const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                        const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage1,
-                        const gls::cl_image_2d<gls::rgba_pixel_float>& inputImageDenoised1,
-                        const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                        float luma_weight, float sharpening, const gls::Vector<2>& nlf,
-                        gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+template void subtractNoiseImage(gls::OpenCLContext *glsContext,
+                                 const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                 const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage1,
+                                 const gls::cl_image_2d<gls::rgba_pixel_float> &inputImageDenoised1,
+                                 const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                                 float luma_weight, float sharpening, const gls::Vector<2> &nlf,
+                                 gls::cl_image_2d<gls::rgba_pixel_float> *outputImage);
 
-void transformImage(gls::OpenCLContext* glsContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float>& linearImage,
-                    gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-                    const gls::Matrix<3, 3>& transform) {
+void transformImage(gls::OpenCLContext *glsContext,
+                    const gls::cl_image_2d<gls::rgba_pixel_float> &linearImage,
+                    gls::cl_image_2d<gls::rgba_pixel_float> *rgbImage,
+                    const gls::Matrix<3, 3> &transform)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
-    struct Matrix3x3 {
+    struct Matrix3x3
+    {
         cl_float3 m[3];
-    } clTransform = {{
-        { transform[0][0], transform[0][1], transform[0][2] },
-        { transform[1][0], transform[1][1], transform[1][2] },
-        { transform[2][0], transform[2][1], transform[2][2] }
-    }};
+    } clTransform = {{{transform[0][0], transform[0][1], transform[0][2]},
+                      {transform[1][0], transform[1][1], transform[1][2]},
+                      {transform[2][0], transform[2][1], transform[2][2]}}};
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // linearImage
-                                    cl::Image2D,  // rgbImage
-                                    Matrix3x3     // transform
+    auto kernel = cl::KernelFunctor<cl::Image2D, // linearImage
+                                    cl::Image2D, // rgbImage
+                                    Matrix3x3    // transform
                                     >(program, "transformImage");
 
     // Schedule the kernel on the GPU
@@ -352,30 +356,30 @@ void transformImage(gls::OpenCLContext* glsContext,
            linearImage.getImage2D(), rgbImage->getImage2D(), clTransform);
 }
 
-void convertTosRGB(gls::OpenCLContext* glsContext,
-                  const gls::cl_image_2d<gls::rgba_pixel_float>& linearImage,
-                  const gls::cl_image_2d<gls::luma_pixel_float>& ltmMaskImage,
-                  gls::cl_image_2d<gls::rgba_pixel_float>* rgbImage,
-                  const DemosaicParameters& demosaicParameters) {
+void convertTosRGB(gls::OpenCLContext *glsContext,
+                   const gls::cl_image_2d<gls::rgba_pixel_float> &linearImage,
+                   const gls::cl_image_2d<gls::luma_pixel_float> &ltmMaskImage,
+                   gls::cl_image_2d<gls::rgba_pixel_float> *rgbImage,
+                   const DemosaicParameters &demosaicParameters)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
-    const auto& transform = demosaicParameters.rgb_cam;
+    const auto &transform = demosaicParameters.rgb_cam;
 
-    struct Matrix3x3 {
+    struct Matrix3x3
+    {
         cl_float3 m[3];
-    } clTransform = {{
-        { transform[0][0], transform[0][1], transform[0][2] },
-        { transform[1][0], transform[1][1], transform[1][2] },
-        { transform[2][0], transform[2][1], transform[2][2] }
-    }};
+    } clTransform = {{{transform[0][0], transform[0][1], transform[0][2]},
+                      {transform[1][0], transform[1][1], transform[1][2]},
+                      {transform[2][0], transform[2][1], transform[2][2]}}};
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // linearImage
-                                    cl::Image2D,  // ltmMaskImage
-                                    cl::Image2D,  // rgbImage
-                                    Matrix3x3,    // transform
-                                    RGBConversionParameters    // demosaicParameters
+    auto kernel = cl::KernelFunctor<cl::Image2D,            // linearImage
+                                    cl::Image2D,            // ltmMaskImage
+                                    cl::Image2D,            // rgbImage
+                                    Matrix3x3,              // transform
+                                    RGBConversionParameters // demosaicParameters
                                     >(program, "convertTosRGB");
 
     // Schedule the kernel on the GPU
@@ -383,42 +387,44 @@ void convertTosRGB(gls::OpenCLContext* glsContext,
            linearImage.getImage2D(), ltmMaskImage.getImage2D(), rgbImage->getImage2D(), clTransform, demosaicParameters.rgbConversionParameters);
 }
 
-void convertToGrayscale(gls::OpenCLContext* glsContext,
-                        const gls::cl_image_2d<gls::rgba_pixel_float>& linearImage,
-                        gls::cl_image_2d<float>* grayscaleImage,
-                        const DemosaicParameters& demosaicParameters) {
+void convertToGrayscale(gls::OpenCLContext *glsContext,
+                        const gls::cl_image_2d<gls::rgba_pixel_float> &linearImage,
+                        gls::cl_image_2d<float> *grayscaleImage,
+                        const DemosaicParameters &demosaicParameters)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
-    const auto& transform = demosaicParameters.rgb_cam;
+    const auto &transform = demosaicParameters.rgb_cam;
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // linearImage
-                                    cl::Image2D,  // grayscaleImage
-                                    cl_float3     // transform
+    auto kernel = cl::KernelFunctor<cl::Image2D, // linearImage
+                                    cl::Image2D, // grayscaleImage
+                                    cl_float3    // transform
                                     >(program, "convertToGrayscale");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(grayscaleImage->width, grayscaleImage->height),
-           linearImage.getImage2D(), grayscaleImage->getImage2D(), { transform[0][0], transform[0][1], transform[0][2] });
+           linearImage.getImage2D(), grayscaleImage->getImage2D(), {transform[0][0], transform[0][1], transform[0][2]});
 }
 
-void despeckleImage(gls::OpenCLContext* glsContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                    const gls::Vector<3>& var_a, const gls::Vector<3>& var_b,
-                    gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+void despeckleImage(gls::OpenCLContext *glsContext,
+                    const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                    const gls::Vector<3> &var_a, const gls::Vector<3> &var_b,
+                    gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl_float3,    // var_a
-                                    cl_float3,    // var_b
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl_float3,   // var_a
+                                    cl_float3,   // var_b
+                                    cl::Image2D  // outputImage
                                     >(program, "despeckleLumaMedianChromaImage");
 
-    cl_float3 cl_var_a = { var_a[0], var_a[1], var_a[2] };
-    cl_float3 cl_var_b = { var_b[0], var_b[1], var_b[2] };
+    cl_float3 cl_var_a = {var_a[0], var_a[1], var_a[2]};
+    cl_float3 cl_var_b = {var_b[0], var_b[1], var_b[2]};
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
@@ -428,54 +434,56 @@ void despeckleImage(gls::OpenCLContext* glsContext,
 // --- Multiscale Noise Reduction ---
 // https://www.cns.nyu.edu/pub/lcv/rajashekar08a.pdf
 
-void denoiseImage(gls::OpenCLContext* glsContext,
-                  const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                  const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                  const gls::Vector<3>& var_a, const gls::Vector<3>& var_b,
+void denoiseImage(gls::OpenCLContext *glsContext,
+                  const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                  const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                  const gls::Vector<3> &var_a, const gls::Vector<3> &var_b,
                   const gls::Vector<3> thresholdMultipliers,
                   float chromaBoost, float gradientBoost, float gradientThreshold,
-                  gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+                  gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl::Image2D,  // gradientImage
-                                    cl_float3,    // var_a
-                                    cl_float3,    // var_b
-                                    cl_float3,    // thresholdMultipliers
-                                    float,        // chromaBoost
-                                    float,        // gradientBoost
-                                    float,        // gradientThreshold
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D, // gradientImage
+                                    cl_float3,   // var_a
+                                    cl_float3,   // var_b
+                                    cl_float3,   // thresholdMultipliers
+                                    float,       // chromaBoost
+                                    float,       // gradientBoost
+                                    float,       // gradientThreshold
+                                    cl::Image2D  // outputImage
                                     >(program, "denoiseImage");
 
-    cl_float3 cl_var_a = { var_a[0], var_a[1], var_a[2] };
-    cl_float3 cl_var_b = { var_b[0], var_b[1], var_b[2] };
+    cl_float3 cl_var_a = {var_a[0], var_a[1], var_a[2]};
+    cl_float3 cl_var_b = {var_b[0], var_b[1], var_b[2]};
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
            inputImage.getImage2D(), gradientImage.getImage2D(),
-           cl_var_a, cl_var_b, { thresholdMultipliers[0], thresholdMultipliers[1], thresholdMultipliers[2] },
+           cl_var_a, cl_var_b, {thresholdMultipliers[0], thresholdMultipliers[1], thresholdMultipliers[2]},
            chromaBoost, gradientBoost, gradientThreshold, outputImage->getImage2D());
 }
 
-void denoiseImageGuided(gls::OpenCLContext* glsContext,
-                        const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                        const gls::Vector<3>& var_a, const gls::Vector<3>& var_b,
-                        gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+void denoiseImageGuided(gls::OpenCLContext *glsContext,
+                        const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                        const gls::Vector<3> &var_a, const gls::Vector<3> &var_b,
+                        gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl_float3,    // var_a
-                                    cl_float3,    // ver_b
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl_float3,   // var_a
+                                    cl_float3,   // ver_b
+                                    cl::Image2D  // outputImage
                                     >(program, "denoiseImageGuided");
 
-    cl_float3 cl_var_a = { var_a[0], var_a[1], var_a[2] };
-    cl_float3 cl_var_b = { var_b[0], var_b[1], var_b[2] };
+    cl_float3 cl_var_a = {var_a[0], var_a[1], var_a[2]};
+    cl_float3 cl_var_b = {var_b[0], var_b[1], var_b[2]};
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
@@ -483,16 +491,18 @@ void denoiseImageGuided(gls::OpenCLContext* glsContext,
 }
 
 // Arrays order is LF, MF, HF
-void localToneMappingMask(gls::OpenCLContext* glsContext,
-                          const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                          const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage,
-                          const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abImage,
-                          const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float>*, 3>& abMeanImage,
-                          const LTMParameters& ltmParameters,
-                          const gls::Matrix<3, 3>& ycbcr_srgb,
-                          const gls::Vector<2>& nlf,
-                          gls::cl_image_2d<gls::luma_pixel_float>* outputImage) {
-    for (int i = 0; i < 3; i++) {
+void localToneMappingMask(gls::OpenCLContext *glsContext,
+                          const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                          const std::array<const gls::cl_image_2d<gls::rgba_pixel_float> *, 3> &guideImage,
+                          const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float> *, 3> &abImage,
+                          const std::array<const gls::cl_image_2d<gls::luma_alpha_pixel_float> *, 3> &abMeanImage,
+                          const LTMParameters &ltmParameters,
+                          const gls::Matrix<3, 3> &ycbcr_srgb,
+                          const gls::Vector<2> &nlf,
+                          gls::cl_image_2d<gls::luma_pixel_float> *outputImage)
+{
+    for (int i = 0; i < 3; i++)
+    {
         assert(guideImage[i]->width == abImage[i]->width && guideImage[i]->height == abImage[i]->height);
         assert(guideImage[i]->width == abMeanImage[i]->width && guideImage[i]->height == abMeanImage[i]->height);
     }
@@ -500,43 +510,45 @@ void localToneMappingMask(gls::OpenCLContext* glsContext,
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
-    struct Matrix3x3 {
+    struct Matrix3x3
+    {
         cl_float3 m[3];
-    } cl_ycbcr_srgb = {{
-        { ycbcr_srgb[0][0], ycbcr_srgb[0][1], ycbcr_srgb[0][2] },
-        { ycbcr_srgb[1][0], ycbcr_srgb[1][1], ycbcr_srgb[1][2] },
-        { ycbcr_srgb[2][0], ycbcr_srgb[2][1], ycbcr_srgb[2][2] }
-    }};
+    } cl_ycbcr_srgb = {{{ycbcr_srgb[0][0], ycbcr_srgb[0][1], ycbcr_srgb[0][2]},
+                        {ycbcr_srgb[1][0], ycbcr_srgb[1][1], ycbcr_srgb[1][2]},
+                        {ycbcr_srgb[2][0], ycbcr_srgb[2][1], ycbcr_srgb[2][2]}}};
 
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
     // Bind the kernel parameters
-    auto gfKernel = cl::KernelFunctor<cl::Image2D,  // guideImage
-                                      cl::Image2D,  // abImage
-                                      float,        // eps
-                                      cl::Sampler   // linear_sampler
+    auto gfKernel = cl::KernelFunctor<cl::Image2D, // guideImage
+                                      cl::Image2D, // abImage
+                                      float,       // eps
+                                      cl::Sampler  // linear_sampler
                                       >(program, "GuidedFilterABImage");
 
-    auto gfMeanKernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                          cl::Image2D,  // outputImage
-                                          cl::Sampler   // linear_sampler
+    auto gfMeanKernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                          cl::Image2D, // outputImage
+                                          cl::Sampler  // linear_sampler
                                           >(program, "BoxFilterGFImage");
 
-    auto ltmKernel = cl::KernelFunctor<cl::Image2D,     // inputImage
-                                       cl::Image2D,     // lfAbImage
-                                       cl::Image2D,     // mfAbImage
-                                       cl::Image2D,     // hfAbImage
-                                       cl::Image2D,     // ltmMaskImage
-                                       LTMParameters,   // ltmParameters
-                                       Matrix3x3,       // ycbcr_srgb
-                                       cl_float2,       // nlf
-                                       cl::Sampler      // linear_sampler
+    auto ltmKernel = cl::KernelFunctor<cl::Image2D,   // inputImage
+                                       cl::Image2D,   // lfAbImage
+                                       cl::Image2D,   // mfAbImage
+                                       cl::Image2D,   // hfAbImage
+                                       cl::Image2D,   // ltmMaskImage
+                                       LTMParameters, // ltmParameters
+                                       Matrix3x3,     // ycbcr_srgb
+                                       cl_float2,     // nlf
+                                       cl::Sampler    // linear_sampler
                                        >(program, "localToneMappingMaskImage");
 
-    try {
+    try
+    {
         // Schedule the kernel on the GPU
-        for (int i = 0; i < 3; i++) {
-            if (i == 0 || ltmParameters.detail[i] != 1) {
+        for (int i = 0; i < 3; i++)
+        {
+            if (i == 0 || ltmParameters.detail[i] != 1)
+            {
                 gfKernel(gls::OpenCLContext::buildEnqueueArgs(guideImage[i]->width, guideImage[i]->height),
                          guideImage[i]->getImage2D(), abImage[i]->getImage2D(), ltmParameters.eps, linear_sampler);
 
@@ -547,26 +559,29 @@ void localToneMappingMask(gls::OpenCLContext* glsContext,
 
         ltmKernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
                   inputImage.getImage2D(), abMeanImage[0]->getImage2D(), abMeanImage[1]->getImage2D(), abMeanImage[2]->getImage2D(), outputImage->getImage2D(),
-                  ltmParameters, cl_ycbcr_srgb, { nlf[0], nlf[1] }, linear_sampler);
-    } catch (cl::Error& e) {
+                  ltmParameters, cl_ycbcr_srgb, {nlf[0], nlf[1]}, linear_sampler);
+    }
+    catch (cl::Error &e)
+    {
         std::cout << "Error: " << e.what() << " - " << gls::clStatusToString(e.err()) << std::endl;
         throw std::logic_error("This is bad");
     }
 }
 
-void bayerToRawRGBA(gls::OpenCLContext* glsContext,
-                    const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                    gls::cl_image_2d<gls::rgba_pixel_float>* rgbaImage,
-                    BayerPattern bayerPattern) {
+void bayerToRawRGBA(gls::OpenCLContext *glsContext,
+                    const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                    gls::cl_image_2d<gls::rgba_pixel_float> *rgbaImage,
+                    BayerPattern bayerPattern)
+{
     assert(rawImage.width == 2 * rgbaImage->width && rawImage.height == 2 * rgbaImage->height);
 
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rawImage
-                                    cl::Image2D,  // rgbaImage
-                                    int           // bayerPattern
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // rgbaImage
+                                    int          // bayerPattern
                                     >(program, "bayerToRawRGBA");
 
     // Schedule the kernel on the GPU
@@ -574,19 +589,20 @@ void bayerToRawRGBA(gls::OpenCLContext* glsContext,
            rawImage.getImage2D(), rgbaImage->getImage2D(), bayerPattern);
 }
 
-void rawRGBAToBayer(gls::OpenCLContext* glsContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float>& rgbaImage,
-                    gls::cl_image_2d<gls::luma_pixel_float>* rawImage,
-                    BayerPattern bayerPattern) {
+void rawRGBAToBayer(gls::OpenCLContext *glsContext,
+                    const gls::cl_image_2d<gls::rgba_pixel_float> &rgbaImage,
+                    gls::cl_image_2d<gls::luma_pixel_float> *rawImage,
+                    BayerPattern bayerPattern)
+{
     assert(rawImage->width == 2 * rgbaImage.width && rawImage->height == 2 * rgbaImage.height);
 
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // rgbaImage
-                                    cl::Image2D,  // rawImage
-                                    int           // bayerPattern
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rgbaImage
+                                    cl::Image2D, // rawImage
+                                    int          // bayerPattern
                                     >(program, "rawRGBAToBayer");
 
     // Schedule the kernel on the GPU
@@ -594,78 +610,85 @@ void rawRGBAToBayer(gls::OpenCLContext* glsContext,
            rgbaImage.getImage2D(), rawImage->getImage2D(), bayerPattern);
 }
 
-void denoiseRawRGBAImage(gls::OpenCLContext* glsContext,
-                         const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+void denoiseRawRGBAImage(gls::OpenCLContext *glsContext,
+                         const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
                          const gls::Vector<4> rawVariance,
-                         gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+                         gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl_float4,    // rawVariance
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl_float4,   // rawVariance
+                                    cl::Image2D  // outputImage
                                     >(program, "denoiseRawRGBAImage");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
-           inputImage.getImage2D(), { rawVariance[0], rawVariance[1], rawVariance[2], rawVariance[3] }, outputImage->getImage2D());
+           inputImage.getImage2D(), {rawVariance[0], rawVariance[1], rawVariance[2], rawVariance[3]}, outputImage->getImage2D());
 }
 
-void despeckleRawRGBAImage(gls::OpenCLContext* glsContext,
-                           const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+void despeckleRawRGBAImage(gls::OpenCLContext *glsContext,
+                           const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
                            const gls::Vector<4> rawVariance,
-                           gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+                           gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl_float4,    // rawVariance
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl_float4,   // rawVariance
+                                    cl::Image2D  // outputImage
                                     >(program, "despeckleRawRGBAImage");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
-           inputImage.getImage2D(), { rawVariance[0], rawVariance[1], rawVariance[2], rawVariance[3] }, outputImage->getImage2D());
+           inputImage.getImage2D(), {rawVariance[0], rawVariance[1], rawVariance[2], rawVariance[3]}, outputImage->getImage2D());
 }
 
-std::vector<std::array<float, 3>> gaussianKernelBilinearWeights(float radius) {
-    int kernelSize = (int) (ceil(2 * radius));
-    if ((kernelSize % 2) == 0) {
+std::vector<std::array<float, 3>> gaussianKernelBilinearWeights(float radius)
+{
+    int kernelSize = (int)(ceil(2 * radius));
+    if ((kernelSize % 2) == 0)
+    {
         kernelSize++;
     }
 
-    std::vector<float> weights(kernelSize*kernelSize);
-    for (int y = -kernelSize / 2, i = 0; y <= kernelSize / 2; y++) {
-        for (int x = -kernelSize / 2; x <= kernelSize / 2; x++, i++) {
+    std::vector<float> weights(kernelSize * kernelSize);
+    for (int y = -kernelSize / 2, i = 0; y <= kernelSize / 2; y++)
+    {
+        for (int x = -kernelSize / 2; x <= kernelSize / 2; x++, i++)
+        {
             weights[i] = exp(-((float)(x * x + y * y) / (2 * radius * radius)));
         }
     }
-    std::cout << "Gaussian Kernel weights (" << weights.size() << "): " << std::endl;
-    for (const auto& w : weights) {
-        std::cout << std::setprecision(4) << std::scientific << w << ", ";
-    }
-    std::cout << std::endl;
+    // std::cout << "Gaussian Kernel weights (" << weights.size() << "): " << std::endl;
+    // for (const auto& w : weights) {
+    // std::cout << std::setprecision(4) << std::scientific << w << ", ";
+    // }
+    // std::cout << std::endl;
 
     const int outWidth = kernelSize / 2 + 1;
     const int weightsCount = outWidth * outWidth;
     std::vector<std::array<float, 3>> weightsOut(weightsCount);
     KernelOptimizeBilinear2d(kernelSize, weights, &weightsOut);
 
-    std::cout << "Bilinear Gaussian Kernel weights and offsets (" << weightsOut.size() << "): " << std::endl;
-    for (const auto& [w, x, y] : weightsOut) {
-        std::cout << w << " @ (" << x << " : " << y << "), " << std::endl;
-    }
+    // std::cout << "Bilinear Gaussian Kernel weights and offsets (" << weightsOut.size() << "): " << std::endl;
+    // for (const auto& [w, x, y] : weightsOut) {
+    // std::cout << w << " @ (" << x << " : " << y << "), " << std::endl;
+    // }
 
     return weightsOut;
 }
 
-void gaussianBlurSobelImage(gls::OpenCLContext* glsContext,
-                            const gls::cl_image_2d<gls::luma_pixel_float>& rawImage,
-                            const gls::cl_image_2d<gls::rgba_pixel_float>& sobelImage,
+void gaussianBlurSobelImage(gls::OpenCLContext *glsContext,
+                            const gls::cl_image_2d<gls::luma_pixel_float> &rawImage,
+                            const gls::cl_image_2d<gls::rgba_pixel_float> &sobelImage,
                             std::array<float, 2> rawNoiseModel, float radius1, float radius2,
-                            gls::cl_image_2d<gls::luma_alpha_pixel_float>* outputImage) {
+                            gls::cl_image_2d<gls::luma_alpha_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
@@ -678,45 +701,49 @@ void gaussianBlurSobelImage(gls::OpenCLContext* glsContext,
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,    // rawImage
-                                    cl::Image2D,    // sobelImage
-                                    int,            // samples1
-                                    cl::Buffer,     // weights1
-                                    int,            // samples2
-                                    cl::Buffer,     // weights2
-                                    cl_float2,      // rawVariance
-                                    cl::Image2D,    // outputImage
-                                    cl::Sampler     // linear_sampler
+    auto kernel = cl::KernelFunctor<cl::Image2D, // rawImage
+                                    cl::Image2D, // sobelImage
+                                    int,         // samples1
+                                    cl::Buffer,  // weights1
+                                    int,         // samples2
+                                    cl::Buffer,  // weights2
+                                    cl_float2,   // rawVariance
+                                    cl::Image2D, // outputImage
+                                    cl::Sampler  // linear_sampler
                                     >(program, "sampledConvolutionSobel");
 
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
            rawImage.getImage2D(), sobelImage.getImage2D(),
-           (int) weightsOut1.size(), weightsBuffer1,
-           (int) weightsOut2.size(), weightsBuffer2,
-           cl_float2 { rawNoiseModel[0], rawNoiseModel[1] },
+           (int)weightsOut1.size(), weightsBuffer1,
+           (int)weightsOut2.size(), weightsBuffer2,
+           cl_float2{rawNoiseModel[0], rawNoiseModel[1]},
            outputImage->getImage2D(), linear_sampler);
 }
 
-void gaussianBlurImage(gls::OpenCLContext* glsContext,
-                       const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+void gaussianBlurImage(gls::OpenCLContext *glsContext,
+                       const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
                        float radius,
-                       gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+                       gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     const bool ordinary_gaussian = false;
-    if (ordinary_gaussian) {
+    if (ordinary_gaussian)
+    {
         // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                        float,        // radius
-                                        cl::Image2D   // outputImage
+        auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                        float,       // radius
+                                        cl::Image2D  // outputImage
                                         >(program, "gaussianBlurImage");
 
         // Schedule the kernel on the GPU
         kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
                inputImage.getImage2D(), radius, outputImage->getImage2D());
-    } else {
+    }
+    else
+    {
         auto weightsOut = gaussianKernelBilinearWeights(radius);
 
         cl::Buffer weightsBuffer(weightsOut.begin(), weightsOut.end(), /* readOnly */ true, /* useHostPtr */ false);
@@ -724,33 +751,34 @@ void gaussianBlurImage(gls::OpenCLContext* glsContext,
         const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
         // Bind the kernel parameters
-        auto kernel = cl::KernelFunctor<cl::Image2D,    // inputImage
-                                        int,            // samples
-                                        cl::Buffer,     // weights
-                                        cl::Image2D,    // outputImage
-                                        cl::Sampler     // linear_sampler
+        auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                        int,         // samples
+                                        cl::Buffer,  // weights
+                                        cl::Image2D, // outputImage
+                                        cl::Sampler  // linear_sampler
                                         >(program, "sampledConvolutionImage");
 
         // Schedule the kernel on the GPU
         kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
-               inputImage.getImage2D(), (int) weightsOut.size(), weightsBuffer, outputImage->getImage2D(), linear_sampler);
+               inputImage.getImage2D(), (int)weightsOut.size(), weightsBuffer, outputImage->getImage2D(), linear_sampler);
     }
 }
 
-void blueNoiseImage(gls::OpenCLContext* glsContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                    const gls::cl_image_2d<gls::luma_pixel_16>& blueNoiseImage,
+void blueNoiseImage(gls::OpenCLContext *glsContext,
+                    const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                    const gls::cl_image_2d<gls::luma_pixel_16> &blueNoiseImage,
                     gls::Vector<2> lumaVariance,
-                    gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+                    gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl::Image2D,  // blueNoiseImage
-                                    cl_float2,    // lumaVariance
-                                    cl::Image2D,  // outputImage
-                                    cl::Sampler   // linear_sampler
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D, // blueNoiseImage
+                                    cl_float2,   // lumaVariance
+                                    cl::Image2D, // outputImage
+                                    cl::Sampler  // linear_sampler
                                     >(program, "blueNoiseImage");
 
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_REPEAT, CL_FILTER_LINEAR);
@@ -758,22 +786,22 @@ void blueNoiseImage(gls::OpenCLContext* glsContext,
     // Schedule the kernel on the GPU
     kernel(gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
            inputImage.getImage2D(), blueNoiseImage.getImage2D(),
-           { lumaVariance[0], lumaVariance[1] },
+           {lumaVariance[0], lumaVariance[1]},
            outputImage->getImage2D(), linear_sampler);
 }
 
-
-void blendHighlightsImage(gls::OpenCLContext* glsContext,
-                          const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+void blendHighlightsImage(gls::OpenCLContext *glsContext,
+                          const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
                           float clip,
-                          gls::cl_image_2d<gls::rgba_pixel_float>* outputImage) {
+                          gls::cl_image_2d<gls::rgba_pixel_float> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    float,        // clip
-                                    cl::Image2D   // outputImage
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    float,       // clip
+                                    cl::Image2D  // outputImage
                                     >(program, "blendHighlightsImage");
 
     // Schedule the kernel on the GPU
@@ -781,7 +809,8 @@ void blendHighlightsImage(gls::OpenCLContext* glsContext,
            inputImage.getImage2D(), clip, outputImage->getImage2D());
 }
 
-YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls::rgba_pixel_float>& image, float exposure_multiplier) {
+YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext *glsContext, const gls::cl_image_2d<gls::rgba_pixel_float> &image, float exposure_multiplier)
+{
     gls::cl_image_2d<gls::rgba_pixel_float> noiseStats(glsContext->clContext(), image.width, image.height);
     applyKernel(glsContext, "noiseStatistics", image, &noiseStats);
     const auto noiseStatsCpu = noiseStats.mapImage();
@@ -800,7 +829,8 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
     gls::DVector<3> s_xy = gls::DVector<3>::zeros();
 
     double N = 0;
-    noiseStatsCpu.apply([&](const gls::rgba_pixel_float& ns, int x, int y) {
+    noiseStatsCpu.apply([&](const gls::rgba_pixel_float &ns, int x, int y)
+                        {
         double m = ns[0];
         gls::DVector<3> v = { ns[1], ns[2], ns[3] };
 
@@ -810,8 +840,7 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
             s_xx += m * m;
             s_xy += m * v;
             N++;
-        }
-    });
+        } });
 
     // Linear regression on pixel statistics to extract a linear noise model: nlf = A + B * Y
     auto nlfB = max((N * s_xy - s_x * s_y) / (N * s_xx - s_x * s_x), 1e-8);
@@ -819,7 +848,8 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
 
     // Estimate regression mean square error
     gls::DVector<3> err2 = gls::DVector<3>::zeros();
-    noiseStatsCpu.apply([&](const gls::rgba_pixel_float& ns, int x, int y) {
+    noiseStatsCpu.apply([&](const gls::rgba_pixel_float &ns, int x, int y)
+                        {
         double m = ns[0];
         gls::DVector<3> v = { ns[1], ns[2], ns[3] };
 
@@ -827,12 +857,11 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
             auto nlfP = nlfA + nlfB * m;
             auto diff = nlfP - v;
             err2 += diff * diff;
-        }
-    });
+        } });
     err2 /= N;
 
-//    std::cout << "1) Pyramid NLF A: " << std::setprecision(4) << std::scientific << nlfA << ", B: " << nlfB << ", MSE: " << sqrt(err2)
-//              << " on " << std::setprecision(1) << std::fixed << 100 * N / (image.width * image.height) << "% pixels"<< std::endl;
+    //    std::cout << "1) Pyramid NLF A: " << std::setprecision(4) << std::scientific << nlfA << ", B: " << nlfB << ", MSE: " << sqrt(err2)
+    //              << " on " << std::setprecision(1) << std::fixed << 100 * N / (image.width * image.height) << "% pixels"<< std::endl;
 
     // Redo the statistics collection limiting the sample to pixels that fit well the linear model
     s_x = 0;
@@ -842,7 +871,8 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
     N = 0;
     gls::DVector<3> newErr2 = gls::DVector<3>::zeros();
     int discarded = 0;
-    noiseStatsCpu.apply([&](const gls::rgba_pixel_float& ns, int x, int y) {
+    noiseStatsCpu.apply([&](const gls::rgba_pixel_float &ns, int x, int y)
+                        {
         double m = ns[0];
         gls::DVector<3> v = { ns[1], ns[2], ns[3] };
 
@@ -861,8 +891,7 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
             } else {
                 discarded++;
             }
-        }
-    });
+        } });
     newErr2 /= N;
 
     // Estimate the new regression parameters
@@ -881,63 +910,74 @@ YCbCrNLF MeasureYCbCrNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<
     nlfA *= varianceExposureAdjustment;
     nlfB *= varianceExposureAdjustment;
 
-    return std::pair (
-        gls::Vector<3> { (float) nlfA[0], (float) nlfA[1], (float) nlfA[2] }, // A values
-        gls::Vector<3> { (float) nlfB[0], (float) nlfB[1], (float) nlfB[2] }  // B values
+    return std::pair(
+        gls::Vector<3>{(float)nlfA[0], (float)nlfA[1], (float)nlfA[2]}, // A values
+        gls::Vector<3>{(float)nlfB[0], (float)nlfB[1], (float)nlfB[2]}  // B values
     );
 }
 
 template <typename T>
-struct sample {
+struct sample
+{
     const T mean;
     const T var;
 };
 
 template <typename T>
-struct line_model {
+struct line_model
+{
     T a;
     T b;
 };
 
 template <typename T>
-struct ImageVectorPairAdapter {
-    ImageVectorPairAdapter(const gls::image<T>& mean,
-                           const gls::image<T>& var) : _mean(mean), _var(var) {
+struct ImageVectorPairAdapter
+{
+    ImageVectorPairAdapter(const gls::image<T> &mean,
+                           const gls::image<T> &var) : _mean(mean), _var(var)
+    {
         assert(mean.pixels().size() == var.pixels().size());
     }
 
-    const gls::image<T>& _mean;
-    const gls::image<T>& _var;
+    const gls::image<T> &_mean;
+    const gls::image<T> &_var;
 
-    const sample<T> operator[] (size_t index) const {
-        return sample<T> { _mean.pixels()[index], _var.pixels()[index] };
+    const sample<T> operator[](size_t index) const
+    {
+        return sample<T>{_mean.pixels()[index], _var.pixels()[index]};
     }
 
-    size_t size() const {
+    size_t size() const
+    {
         return _mean.pixels().size();
     }
 };
 
 typedef ImageVectorPairAdapter<gls::rgba_pixel_float> RGBAImageVectorPairAdapter;
 
-gls::Vector<4> toVector(const gls::rgba_pixel_float& p) {
-    return gls::Vector<4> { p[0], p[1], p[2], p[3] };
+gls::Vector<4> toVector(const gls::rgba_pixel_float &p)
+{
+    return gls::Vector<4>{p[0], p[1], p[2], p[3]};
 }
 
-gls::Vector<3> toVector(const gls::rgb_pixel_float& p) {
-    return gls::Vector<3> { p[0], p[1], p[2] };
+gls::Vector<3> toVector(const gls::rgb_pixel_float &p)
+{
+    return gls::Vector<3>{p[0], p[1], p[2]};
 }
 
-class RGBALineEstimator : virtual public RTL::Estimator<line_model<gls::Vector<4>>, sample<gls::rgba_pixel_float>, RGBAImageVectorPairAdapter > {
-   public:
-    virtual line_model<gls::Vector<4>> ComputeModel(const RGBAImageVectorPairAdapter& data, const std::set<int>& samples) {
+class RGBALineEstimator : virtual public RTL::Estimator<line_model<gls::Vector<4>>, sample<gls::rgba_pixel_float>, RGBAImageVectorPairAdapter>
+{
+public:
+    virtual line_model<gls::Vector<4>> ComputeModel(const RGBAImageVectorPairAdapter &data, const std::set<int> &samples)
+    {
         gls::Vector<4> s_x = gls::Vector<4>::zeros();
         gls::Vector<4> s_y = gls::Vector<4>::zeros();
         gls::Vector<4> s_xx = gls::Vector<4>::zeros();
         gls::Vector<4> s_xy = gls::Vector<4>::zeros();
         float N = 0;
 
-        for (auto itr = samples.begin(); itr != samples.end(); itr++) {
+        for (auto itr = samples.begin(); itr != samples.end(); itr++)
+        {
             const sample<gls::rgba_pixel_float> p = data[*itr];
 
             gls::Vector<4> m = toVector(p.mean);
@@ -953,17 +993,19 @@ class RGBALineEstimator : virtual public RTL::Estimator<line_model<gls::Vector<4
         auto nlfB = (N * s_xy - s_x * s_y) / (N * s_xx - s_x * s_x);
         auto nlfA = (s_y - nlfB * s_x) / N;
 
-        return line_model<gls::Vector<4>> { nlfA, nlfB };
+        return line_model<gls::Vector<4>>{nlfA, nlfB};
     }
 
-    virtual float ComputeError(const line_model<gls::Vector<4>>& model, const sample<gls::rgba_pixel_float>& sample) {
+    virtual float ComputeError(const line_model<gls::Vector<4>> &model, const sample<gls::rgba_pixel_float> &sample)
+    {
         const auto diff = toVector(sample.var) - (model.a + model.b * toVector(sample.mean));
 
         return sqrt(dot(diff, diff));
     }
 };
 
-RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls::luma_pixel_float>& rawImage, float exposure_multiplier, BayerPattern bayerPattern) {
+RawNLF MeasureRawNLF(gls::OpenCLContext *glsContext, const gls::cl_image_2d<gls::luma_pixel_float> &rawImage, float exposure_multiplier, BayerPattern bayerPattern)
+{
     gls::cl_image_2d<gls::rgba_pixel_float> meanImage(glsContext->clContext(), rawImage.width / 2, rawImage.height / 2);
     gls::cl_image_2d<gls::rgba_pixel_float> varImage(glsContext->clContext(), rawImage.width / 2, rawImage.height / 2);
 
@@ -973,7 +1015,8 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
     const auto varImageCpu = varImage.mapImage();
 
     const bool use_ransac = false;
-    if (use_ransac) {
+    if (use_ransac)
+    {
         RGBALineEstimator estimator;
         RTL::RANSAC<line_model<gls::Vector<4>>, sample<gls::rgba_pixel_float>, RGBAImageVectorPairAdapter> ransac(&estimator);
         ransac.SetParamThreshold(1e-6);
@@ -982,16 +1025,16 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
         const auto imageVectorPairAdapter = RGBAImageVectorPairAdapter(meanImageCpu, varImageCpu);
 
         line_model<gls::Vector<4>> model;
-        float loss = ransac.FindBest(model, imageVectorPairAdapter, (int) imageVectorPairAdapter.size(), 2);
+        float loss = ransac.FindBest(model, imageVectorPairAdapter, (int)imageVectorPairAdapter.size(), 2);
 
         model.a = max(model.a, 1e-8f);
         model.b = max(model.b, 1e-8f);
 
         std::cout << "Estimated line model a: " << std::setprecision(4) << std::scientific << model.a << ", b: " << model.b << " with loss " << loss << std::endl;
 
-        return std::pair (
-            gls::Vector<4> { (float) model.a[0], (float) model.a[1], (float) model.a[2], (float) model.a[3] }, // A values
-            gls::Vector<4> { (float) model.b[0], (float) model.b[1], (float) model.b[2], (float) model.b[3] }  // B values
+        return std::pair(
+            gls::Vector<4>{(float)model.a[0], (float)model.a[1], (float)model.a[2], (float)model.a[3]}, // A values
+            gls::Vector<4>{(float)model.b[0], (float)model.b[1], (float)model.b[2], (float)model.b[3]}  // B values
         );
     }
 
@@ -1009,7 +1052,8 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
     gls::DVector<4> s_xy = gls::DVector<4>::zeros();
 
     double N = 0;
-    meanImageCpu.apply([&](const gls::rgba_pixel_float& mm, int x, int y) {
+    meanImageCpu.apply([&](const gls::rgba_pixel_float &mm, int x, int y)
+                       {
         const gls::rgba_pixel_float& vv = varImageCpu[y][x];
         gls::DVector<4> m = { mm[0], mm[1], mm[2], mm[3] };
         gls::DVector<4> v = { vv[0], vv[1], vv[2], vv[3] };
@@ -1020,8 +1064,7 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
             s_xx += m * m;
             s_xy += m * v;
             N++;
-        }
-    });
+        } });
 
     // Linear regression on pixel statistics to extract a linear noise model: nlf = A + B * Y
     auto nlfB = max((N * s_xy - s_x * s_y) / (N * s_xx - s_x * s_x), 1e-8);
@@ -1029,7 +1072,8 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
 
     // Estimate regression mean square error
     gls::DVector<4> err2 = gls::DVector<4>::zeros();
-    meanImageCpu.apply([&](const gls::rgba_pixel_float& mm, int x, int y) {
+    meanImageCpu.apply([&](const gls::rgba_pixel_float &mm, int x, int y)
+                       {
         const gls::rgba_pixel_float& vv = varImageCpu[y][x];
         gls::DVector<4> m = { mm[0], mm[1], mm[2], mm[3] };
         gls::DVector<4> v = { vv[0], vv[1], vv[2], vv[3] };
@@ -1038,12 +1082,11 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
             auto nlfP = nlfA + nlfB * m;
             auto diff = nlfP - v;
             err2 += diff * diff;
-        }
-    });
+        } });
     err2 /= N;
 
-//    std::cout << "RAW NLF A: " << std::setprecision(4) << std::scientific << nlfA << ", B: " << nlfB << ", MSE: " << sqrt(err2)
-//              << " on " << std::setprecision(1) << std::fixed << 100 * N / (rawImage.width * rawImage.height) << "% pixels"<< std::endl;
+    //    std::cout << "RAW NLF A: " << std::setprecision(4) << std::scientific << nlfA << ", B: " << nlfB << ", MSE: " << sqrt(err2)
+    //              << " on " << std::setprecision(1) << std::fixed << 100 * N / (rawImage.width * rawImage.height) << "% pixels"<< std::endl;
 
     // Redo the statistics collection limiting the sample to pixels that fit well the linear model
     s_x = gls::DVector<4>::zeros();
@@ -1052,7 +1095,8 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
     s_xy = gls::DVector<4>::zeros();
     N = 0;
     gls::DVector<4> newErr2 = gls::DVector<4>::zeros();
-    meanImageCpu.apply([&](const gls::rgba_pixel_float& mm, int x, int y) {
+    meanImageCpu.apply([&](const gls::rgba_pixel_float &mm, int x, int y)
+                       {
         const gls::rgba_pixel_float& vv = varImageCpu[y][x];
         gls::DVector<4> m = { mm[0], mm[1], mm[2], mm[3] };
         gls::DVector<4> v = { vv[0], vv[1], vv[2], vv[3] };
@@ -1070,8 +1114,7 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
                 N++;
                 newErr2 += diffSquare;
             }
-        }
-    });
+        } });
     newErr2 /= N;
 
     // Estimate the new regression parameters
@@ -1081,7 +1124,7 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
     assert(all(newErr2 < err2));
 
     std::cout << "RAW NLF A: " << std::setprecision(4) << std::scientific << nlfA << ", B: " << nlfB << ", MSE: " << sqrt(newErr2)
-              << " on " << std::setprecision(1) << std::fixed << 100 * N / (rawImage.width * rawImage.height) << "% pixels"<< std::endl;
+              << " on " << std::setprecision(1) << std::fixed << 100 * N / (rawImage.width * rawImage.height) << "% pixels" << std::endl;
 
     meanImage.unmapImage(meanImageCpu);
     varImage.unmapImage(varImageCpu);
@@ -1091,38 +1134,39 @@ RawNLF MeasureRawNLF(gls::OpenCLContext* glsContext, const gls::cl_image_2d<gls:
     nlfA *= varianceExposureAdjustment;
     nlfB *= varianceExposureAdjustment;
 
-    return std::pair (
-        gls::Vector<4> { (float) nlfA[0], (float) nlfA[1], (float) nlfA[2], (float) nlfA[3] }, // A values
-        gls::Vector<4> { (float) nlfB[0], (float) nlfB[1], (float) nlfB[2], (float) nlfB[3] }  // B values
+    return std::pair(
+        gls::Vector<4>{(float)nlfA[0], (float)nlfA[1], (float)nlfA[2], (float)nlfA[3]}, // A values
+        gls::Vector<4>{(float)nlfB[0], (float)nlfB[1], (float)nlfB[2], (float)nlfB[3]}  // B values
     );
 }
 
-void clFuseFrames(gls::OpenCLContext* glsContext,
-                  const gls::cl_image_2d<gls::rgba_pixel_float>& referenceImage,
-                  const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                  const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                  const gls::cl_image_2d<gls::rgba_pixel_float>& previousFusedImage,
-                  const gls::Matrix<3, 3>& homography,
-                  const gls::Vector<3>& var_a, const gls::Vector<3>& var_b, int fusedFrames,
-                  gls::cl_image_2d<gls::rgba_pixel_float>* newFusedImage) {
+void clFuseFrames(gls::OpenCLContext *glsContext,
+                  const gls::cl_image_2d<gls::rgba_pixel_float> &referenceImage,
+                  const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                  const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                  const gls::cl_image_2d<gls::rgba_pixel_float> &previousFusedImage,
+                  const gls::Matrix<3, 3> &homography,
+                  const gls::Vector<3> &var_a, const gls::Vector<3> &var_b, int fusedFrames,
+                  gls::cl_image_2d<gls::rgba_pixel_float> *newFusedImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,        // referenceImage
-                                    cl::Image2D,        // gradientImage
-                                    cl::Image2D,        // inputImage
-                                    cl::Image2D,        // inputFusedImage
-                                    gls::Matrix<3, 3>,  // homography
-                                    cl::Sampler,        // linear_sampler
-                                    cl_float3,          // var_a
-                                    cl_float3,          // var_b
-                                    int,                // fusedFrames
-                                    cl::Image2D         // outputFusedImage
+    auto kernel = cl::KernelFunctor<cl::Image2D,       // referenceImage
+                                    cl::Image2D,       // gradientImage
+                                    cl::Image2D,       // inputImage
+                                    cl::Image2D,       // inputFusedImage
+                                    gls::Matrix<3, 3>, // homography
+                                    cl::Sampler,       // linear_sampler
+                                    cl_float3,         // var_a
+                                    cl_float3,         // var_b
+                                    int,               // fusedFrames
+                                    cl::Image2D        // outputFusedImage
                                     >(program, "fuseFrames");
 
-    cl_float3 cl_var_a = { var_a[0], var_a[1], var_a[2] };
-    cl_float3 cl_var_b = { var_b[0], var_b[1], var_b[2] };
+    cl_float3 cl_var_a = {var_a[0], var_a[1], var_a[2]};
+    cl_float3 cl_var_b = {var_b[0], var_b[1], var_b[2]};
 
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
@@ -1139,22 +1183,23 @@ void clFuseFrames(gls::OpenCLContext* glsContext,
 }
 
 template <typename T>
-void subtractNoiseFusedImage(gls::OpenCLContext* glsContext,
-                             const gls::cl_image_2d<T>& inputImage,
-                             const gls::cl_image_2d<T>& inputImage1,
-                             const gls::cl_image_2d<T>& inputImageDenoised1,
-                             gls::cl_image_2d<T>* outputImage) {
+void subtractNoiseFusedImage(gls::OpenCLContext *glsContext,
+                             const gls::cl_image_2d<T> &inputImage,
+                             const gls::cl_image_2d<T> &inputImage1,
+                             const gls::cl_image_2d<T> &inputImageDenoised1,
+                             gls::cl_image_2d<T> *outputImage)
+{
     // Load the shader source
     const auto program = glsContext->loadProgram("demosaic");
 
     const auto linear_sampler = cl::Sampler(glsContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,  // inputImage
-                                    cl::Image2D,  // inputImage1
-                                    cl::Image2D,  // inputImageDenoised1
-                                    cl::Image2D,  // outputImage
-                                    cl::Sampler   // linear_sampler
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D, // inputImage1
+                                    cl::Image2D, // inputImageDenoised1
+                                    cl::Image2D, // outputImage
+                                    cl::Sampler  // linear_sampler
                                     >(program, "subtractNoiseFusedImage");
 
     // Schedule the kernel on the GPU
@@ -1163,43 +1208,41 @@ void subtractNoiseFusedImage(gls::OpenCLContext* glsContext,
            outputImage->getImage2D(), linear_sampler);
 }
 
-template
-void subtractNoiseFusedImage(gls::OpenCLContext* glsContext,
-                             const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                             const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage1,
-                             const gls::cl_image_2d<gls::rgba_pixel_float>& inputImageDenoised1,
-                             gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+template void subtractNoiseFusedImage(gls::OpenCLContext *glsContext,
+                                      const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                      const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage1,
+                                      const gls::cl_image_2d<gls::rgba_pixel_float> &inputImageDenoised1,
+                                      gls::cl_image_2d<gls::rgba_pixel_float> *outputImage);
 
 template <typename T>
-void clRescaleImage(gls::OpenCLContext* cLContext,
-                    const gls::cl_image_2d<T>& inputImage,
-                    gls::cl_image_2d<T>* outputImage) {
+void clRescaleImage(gls::OpenCLContext *cLContext,
+                    const gls::cl_image_2d<T> &inputImage,
+                    gls::cl_image_2d<T> *outputImage)
+{
     // Load the shader source
     const auto program = cLContext->loadProgram("demosaic");
 
     // Bind the kernel parameters
-    auto kernel = cl::KernelFunctor<cl::Image2D,        // inputImage
-                                    cl::Image2D,        // outputImage
-                                    cl::Sampler         // linear_sampler
+    auto kernel = cl::KernelFunctor<cl::Image2D, // inputImage
+                                    cl::Image2D, // outputImage
+                                    cl::Sampler  // linear_sampler
                                     >(program, "rescaleImage");
 
     const auto linear_sampler = cl::Sampler(cLContext->clContext(), true, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_LINEAR);
 
     kernel(
 #if __APPLE__
-           gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
+        gls::OpenCLContext::buildEnqueueArgs(outputImage->width, outputImage->height),
 #else
-           cl::EnqueueArgs(cl::NDRange(outputImage->width, outputImage->height), cl::NDRange(32, 32)),
+        cl::EnqueueArgs(cl::NDRange(outputImage->width, outputImage->height), cl::NDRange(32, 32)),
 #endif
-           inputImage.getImage2D(), outputImage->getImage2D(), linear_sampler);
+        inputImage.getImage2D(), outputImage->getImage2D(), linear_sampler);
 }
 
-template
-void clRescaleImage(gls::OpenCLContext* cLContext,
-                    const gls::cl_image_2d<gls::rgba_pixel>& inputImage,
-                    gls::cl_image_2d<gls::rgba_pixel>* outputImage);
+template void clRescaleImage(gls::OpenCLContext *cLContext,
+                             const gls::cl_image_2d<gls::rgba_pixel> &inputImage,
+                             gls::cl_image_2d<gls::rgba_pixel> *outputImage);
 
-template
-void clRescaleImage(gls::OpenCLContext* cLContext,
-                    const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                    gls::cl_image_2d<gls::rgba_pixel_float>* outputImage);
+template void clRescaleImage(gls::OpenCLContext *cLContext,
+                             const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                             gls::cl_image_2d<gls::rgba_pixel_float> *outputImage);

--- a/src/demosaic_cpu.cpp
+++ b/src/demosaic_cpu.cpp
@@ -84,22 +84,22 @@ void interpolateGreen(const gls::image<gls::luma_pixel_16>& rawImage,
         int color = (y & 1) == (r.y & 1) ? red : blue;
         int x0 = (y & 1) == (g.y & 1) ? g.x + 1 : g.x;
 
-        int g_left  = (*rgbImage)[y][x0 - 1][green];
-        int c_xy    = (*rgbImage)[y][x0][color];
-        int c_left  = (*rgbImage)[y][x0 - 2][color];
+        int g_left = (*rgbImage)[y][x0 - 1][green];
+        int c_xy = (*rgbImage)[y][x0][color];
+        int c_left = (*rgbImage)[y][x0 - 2][color];
 
         for (int x = x0 + 2; x < width - 2; x += 2) {
             int g_right = (*rgbImage)[y][x + 1][green];
-            int g_up    = (*rgbImage)[y - 1][x][green];
-            int g_down  = (*rgbImage)[y + 1][x][green];
-            int g_dh    = abs(g_left - g_right);
-            int g_dv    = abs(g_up - g_down);
+            int g_up = (*rgbImage)[y - 1][x][green];
+            int g_down = (*rgbImage)[y + 1][x][green];
+            int g_dh = abs(g_left - g_right);
+            int g_dv = abs(g_up - g_down);
 
             int c_right = (*rgbImage)[y][x + 2][color];
-            int c_up    = (*rgbImage)[y - 2][x][color];
-            int c_down  = (*rgbImage)[y + 2][x][color];
-            int c_dh    = abs(c_left + c_right - 2 * c_xy);
-            int c_dv    = abs(c_up + c_down - 2 * c_xy);
+            int c_up = (*rgbImage)[y - 2][x][color];
+            int c_down = (*rgbImage)[y + 2][x][color];
+            int c_dh = abs(c_left + c_right - 2 * c_xy);
+            int c_dv = abs(c_up + c_down - 2 * c_xy);
 
             // Minimum derivative value for edge directed interpolation (avoid aliasing)
             int dThreshold = 1200;
@@ -129,7 +129,7 @@ void interpolateGreen(const gls::image<gls::luma_pixel_16>& rawImage,
             (*rgbImage)[y][x][green] = clamp_uint16(sample);
             g_left = g_right;
             c_left = c_xy;
-            c_xy   = c_right;
+            c_xy = c_right;
         }
     }
 }
@@ -175,19 +175,19 @@ void interpolateRedBlue(gls::image<gls::rgb_pixel_16>* image, BayerPattern bayer
                         }
                     } else if (((x + c.x) & 1) == (c.x & 1) && ((y + c.y) & 1) != (c.y & 1)) {
                         // Pixel at green location - vertical
-                        int g_up    = (*image)[y + c.y - 1][x + c.x][green];
-                        int g_down  = (*image)[y + c.y + 1][x + c.x][green];
+                        int g_up = (*image)[y + c.y - 1][x + c.x][green];
+                        int g_down = (*image)[y + c.y + 1][x + c.x][green];
 
-                        int c_up    = g_up - (*image)[y + c.y - 1][x + c.x][color];
-                        int c_down  = g_down - (*image)[y + c.y + 1][x + c.x][color];
+                        int c_up = g_up - (*image)[y + c.y - 1][x + c.x][color];
+                        int c_down = g_down - (*image)[y + c.y + 1][x + c.x][color];
 
                         sample = cg - (c_up + c_down) / 2;
                     } else {
                         // Pixel at green location - horizontal
-                        int g_left  = (*image)[y + c.y][x + c.x - 1][green];
+                        int g_left = (*image)[y + c.y][x + c.x - 1][green];
                         int g_right = (*image)[y + c.y][x + c.x + 1][green];
 
-                        int c_left  = g_left - (*image)[y + c.y][x + c.x - 1][color];
+                        int c_left = g_left - (*image)[y + c.y][x + c.x - 1][color];
                         int c_right = g_right - (*image)[y + c.y][x + c.x + 1][color];
 
                         sample = cg - (c_left + c_right) / 2;
@@ -200,25 +200,30 @@ void interpolateRedBlue(gls::image<gls::rgb_pixel_16>* image, BayerPattern bayer
     }
 }
 
-gls::image<gls::rgb_pixel_16>::unique_ptr demosaicImageCPU(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                           gls::tiff_metadata* metadata, bool auto_white_balance) {
+gls::image<gls::rgb_pixel_16>::unique_ptr demosaicImageCPU(
+    const gls::image<gls::luma_pixel_16>& rawImage, gls::tiff_metadata* metadata,
+    bool auto_white_balance) {
     DemosaicParameters demosaicParameters;
     unpackDNGMetadata(rawImage, metadata, &demosaicParameters, auto_white_balance, nullptr, false);
 
     printf("Begin demosaicing image (CPU)...\n");
 
     const auto offsets = bayerOffsets[demosaicParameters.bayerPattern];
-    gls::image<gls::luma_pixel_16> scaledRawImage = gls::image<gls::luma_pixel_16>(rawImage.width, rawImage.height);
+    gls::image<gls::luma_pixel_16> scaledRawImage =
+        gls::image<gls::luma_pixel_16>(rawImage.width, rawImage.height);
     for (int y = 0; y < rawImage.height / 2; y++) {
         for (int x = 0; x < rawImage.width / 2; x++) {
             for (int c = 0; c < 4; c++) {
                 const auto& o = offsets[c];
-                scaledRawImage[2 * y + o.y][2 * x + o.x] = clamp_uint16(demosaicParameters.scale_mul[c] * (rawImage[2 * y + o.y][2 * x + o.x] - demosaicParameters.black_level));
+                scaledRawImage[2 * y + o.y][2 * x + o.x] = clamp_uint16(
+                    demosaicParameters.scale_mul[c] *
+                    (rawImage[2 * y + o.y][2 * x + o.x] - demosaicParameters.black_level));
             }
         }
     }
 
-    auto rgbImage = std::make_unique<gls::image<gls::rgb_pixel_16>>(rawImage.width, rawImage.height);
+    auto rgbImage =
+        std::make_unique<gls::image<gls::rgb_pixel_16>>(rawImage.width, rawImage.height);
 
     printf("interpolating green channel...\n");
     interpolateGreen(scaledRawImage, rgbImage.get(), demosaicParameters.bayerPattern);
@@ -230,8 +235,9 @@ gls::image<gls::rgb_pixel_16>::unique_ptr demosaicImageCPU(const gls::image<gls:
     for (int y = 0; y < rgbImage->height; y++) {
         for (int x = 0; x < rgbImage->width; x++) {
             auto& p = (*rgbImage)[y][x];
-            const auto op = demosaicParameters.rgb_cam * /* mCamMul * */ gls::Vector<3>({ (float) p[0], (float) p[1], (float) p[2] });
-            p = { clamp_uint16(op[0]), clamp_uint16(op[1]), clamp_uint16(op[2]) };
+            const auto op = demosaicParameters.rgb_cam *
+                            /* mCamMul * */ gls::Vector<3>({(float)p[0], (float)p[1], (float)p[2]});
+            p = {clamp_uint16(op[0]), clamp_uint16(op[1]), clamp_uint16(op[2])};
         }
     }
 

--- a/src/demosaic_utils.cpp
+++ b/src/demosaic_utils.cpp
@@ -13,18 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "demosaic.hpp"
-
-#include <numeric>
-#include <iomanip>
 #include <cstring>
+#include <iomanip>
+#include <numeric>
 
+#include "ThreadPool.hpp"
+#include "demosaic.hpp"
 #include "gls_color_science.hpp"
 #include "gls_image.hpp"
-#include "ThreadPool.hpp"
 
-gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3> *pre_mul, const gls::Matrix<3, 3> &cam_xyz)
-{
+gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3>* pre_mul, const gls::Matrix<3, 3>& cam_xyz) {
     // Compute sRGB -> XYZ -> Camera
     auto rgb_cam = cam_xyz * xyz_rgb;
 
@@ -36,18 +34,12 @@ gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3> *pre_mul, const gls::Matrix<3, 3>
     auto cam_white = rgb_cam * gls::Vector<3>({1, 1, 1});
 
     gls::Matrix<3, 3> mPreMul = {
-        {1 / cam_white[0], 0, 0},
-        {0, 1 / cam_white[1], 0},
-        {0, 0, 1 / cam_white[2]}};
+        {1 / cam_white[0], 0, 0}, {0, 1 / cam_white[1], 0}, {0, 0, 1 / cam_white[2]}};
 
-    for (int i = 0; i < 3; i++)
-    {
-        if (cam_white[i] > 0.00001)
-        {
+    for (int i = 0; i < 3; i++) {
+        if (cam_white[i] > 0.00001) {
             (*pre_mul)[i] = 1 / cam_white[i];
-        }
-        else
-        {
+        } else {
             throw std::range_error("");
         }
     }
@@ -56,75 +48,65 @@ gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3> *pre_mul, const gls::Matrix<3, 3>
     return inverse(mPreMul * rgb_cam);
 }
 
-gls::rectangle alignToQuad(const gls::rectangle &rect)
-{
+gls::rectangle alignToQuad(const gls::rectangle& rect) {
     gls::rectangle alignedRect = rect;
-    if (alignedRect.y & 1)
-    {
+    if (alignedRect.y & 1) {
         alignedRect.y += 1;
         alignedRect.height -= 1;
     }
-    if (alignedRect.height & 1)
-    {
+    if (alignedRect.height & 1) {
         alignedRect.height -= 1;
     }
-    if (alignedRect.x & 1)
-    {
+    if (alignedRect.x & 1) {
         alignedRect.x += 1;
         alignedRect.width -= 1;
     }
-    if (alignedRect.width & 1)
-    {
+    if (alignedRect.width & 1) {
         alignedRect.width -= 1;
     }
     return alignedRect;
 }
 
-std::ostream &operator<<(std::ostream &os, const std::span<const float> &s)
-{
-    for (int i = 0; i < s.size(); i++)
-    {
+std::ostream& operator<<(std::ostream& os, const std::span<const float>& s) {
+    for (int i = 0; i < s.size(); i++) {
         os << s[i];
-        if (i < s.size() - 1)
-        {
+        if (i < s.size() - 1) {
             os << ", ";
         }
     }
     return os;
 }
 
-void matrixFromColorChecker(const std::array<RawPatchStats, 24> &rawStats, gls::Matrix<3, 3> *cam_xyz, gls::Vector<3> *pre_mul)
-{
+void matrixFromColorChecker(const std::array<RawPatchStats, 24>& rawStats,
+                            gls::Matrix<3, 3>* cam_xyz, gls::Vector<3>* pre_mul) {
     // ColorChecker Chart under 6500-kelvin illumination
-    static const gls::Matrix<24, 3> gmb_xyY = {
-        {0.400, 0.350, 10.1}, // Dark Skin
-        {0.377, 0.345, 35.8}, // Light Skin
-        {0.247, 0.251, 19.3}, // Blue Sky
-        {0.337, 0.422, 13.3}, // Foliage
-        {0.265, 0.240, 24.3}, // Blue Flower
-        {0.261, 0.343, 43.1}, // Bluish Green
-        {0.506, 0.407, 30.1}, // Orange
-        {0.211, 0.175, 12.0}, // Purplish Blue
-        {0.453, 0.306, 19.8}, // Moderate Red
-        {0.285, 0.202, 6.6},  // Purple
-        {0.380, 0.489, 44.3}, // Yellow Green
-        {0.473, 0.438, 43.1}, // Orange Yellow
-        {0.187, 0.129, 6.1},  // Blue
-        {0.305, 0.478, 23.4}, // Green
-        {0.539, 0.313, 12.0}, // Red
-        {0.448, 0.470, 59.1}, // Yellow
-        {0.364, 0.233, 19.8}, // Magenta
-        {0.196, 0.252, 19.8}, // Cyan
-        {0.310, 0.316, 90.0}, // White
-        {0.310, 0.316, 59.1}, // Neutral 8
-        {0.310, 0.316, 36.2}, // Neutral 6.5
-        {0.310, 0.316, 19.8}, // Neutral 5
-        {0.310, 0.316, 9.0},  // Neutral 3.5
-        {0.310, 0.316, 3.1}}; // Black
+    static const gls::Matrix<24, 3> gmb_xyY = {{0.400, 0.350, 10.1},  // Dark Skin
+                                               {0.377, 0.345, 35.8},  // Light Skin
+                                               {0.247, 0.251, 19.3},  // Blue Sky
+                                               {0.337, 0.422, 13.3},  // Foliage
+                                               {0.265, 0.240, 24.3},  // Blue Flower
+                                               {0.261, 0.343, 43.1},  // Bluish Green
+                                               {0.506, 0.407, 30.1},  // Orange
+                                               {0.211, 0.175, 12.0},  // Purplish Blue
+                                               {0.453, 0.306, 19.8},  // Moderate Red
+                                               {0.285, 0.202, 6.6},   // Purple
+                                               {0.380, 0.489, 44.3},  // Yellow Green
+                                               {0.473, 0.438, 43.1},  // Orange Yellow
+                                               {0.187, 0.129, 6.1},   // Blue
+                                               {0.305, 0.478, 23.4},  // Green
+                                               {0.539, 0.313, 12.0},  // Red
+                                               {0.448, 0.470, 59.1},  // Yellow
+                                               {0.364, 0.233, 19.8},  // Magenta
+                                               {0.196, 0.252, 19.8},  // Cyan
+                                               {0.310, 0.316, 90.0},  // White
+                                               {0.310, 0.316, 59.1},  // Neutral 8
+                                               {0.310, 0.316, 36.2},  // Neutral 6.5
+                                               {0.310, 0.316, 19.8},  // Neutral 5
+                                               {0.310, 0.316, 9.0},   // Neutral 3.5
+                                               {0.310, 0.316, 3.1}};  // Black
 
     gls::Matrix<24, 3> gmb_xyz;
-    for (int sq = 0; sq < 24; sq++)
-    {
+    for (int sq = 0; sq < 24; sq++) {
         gmb_xyz[sq][0] = gmb_xyY[sq][2] * gmb_xyY[sq][0] / gmb_xyY[sq][1];
         gmb_xyz[sq][1] = gmb_xyY[sq][2];
         gmb_xyz[sq][2] = gmb_xyY[sq][2] * (1 - gmb_xyY[sq][0] - gmb_xyY[sq][1]) / gmb_xyY[sq][1];
@@ -132,15 +114,11 @@ void matrixFromColorChecker(const std::array<RawPatchStats, 24> &rawStats, gls::
 
     gls::Matrix<24, 3> inverse = pseudoinverse(gmb_xyz);
 
-    for (int pass = 0; pass < 2; pass++)
-    {
-        for (int i = 0; i < 3 /* colors */; i++)
-        {
-            for (int j = 0; j < 3; j++)
-            {
+    for (int pass = 0; pass < 2; pass++) {
+        for (int i = 0; i < 3 /* colors */; i++) {
+            for (int j = 0; j < 3; j++) {
                 (*cam_xyz)[i][j] = 0;
-                for (int k = 0; k < 24; k++)
-                {
+                for (int k = 0; k < 24; k++) {
                     (*cam_xyz)[i][j] += rawStats[k].mean[i] * inverse[k][j];
                 }
             }
@@ -153,58 +131,55 @@ void matrixFromColorChecker(const std::array<RawPatchStats, 24> &rawStats, gls::
     *cam_xyz = *cam_xyz / ((*cam_xyz)[1][0] + (*cam_xyz)[1][1] + (*cam_xyz)[1][2]);
     *pre_mul = *pre_mul / (*pre_mul)[1];
 
-    std::cout << "ColorChecker Color Matrix: " << std::fixed << std::setw(6) << std::setprecision(4) << cam_xyz->span() << std::endl;
-    std::cout << "ColorChecker White Point: " << std::fixed << std::setw(6) << std::setprecision(4) << *pre_mul << std::endl;
+    std::cout << "ColorChecker Color Matrix: " << std::fixed << std::setw(6) << std::setprecision(4)
+              << cam_xyz->span() << std::endl;
+    std::cout << "ColorChecker White Point: " << std::fixed << std::setw(6) << std::setprecision(4)
+              << *pre_mul << std::endl;
 }
 
-void colorcheck(const gls::image<gls::luma_pixel_16> &rawImage, BayerPattern bayerPattern, uint32_t black, std::array<gls::rectangle, 24> gmb_samples)
-{
+void colorcheck(const gls::image<gls::luma_pixel_16>& rawImage, BayerPattern bayerPattern,
+                uint32_t black, std::array<gls::rectangle, 24> gmb_samples) {
     // ColorChecker Chart under 6500-kelvin illumination
-    static gls::Matrix<24, 3> gmb_xyY = {
-        {0.400, 0.350, 10.1}, // Dark Skin
-        {0.377, 0.345, 35.8}, // Light Skin
-        {0.247, 0.251, 19.3}, // Blue Sky
-        {0.337, 0.422, 13.3}, // Foliage
-        {0.265, 0.240, 24.3}, // Blue Flower
-        {0.261, 0.343, 43.1}, // Bluish Green
-        {0.506, 0.407, 30.1}, // Orange
-        {0.211, 0.175, 12.0}, // Purplish Blue
-        {0.453, 0.306, 19.8}, // Moderate Red
-        {0.285, 0.202, 6.6},  // Purple
-        {0.380, 0.489, 44.3}, // Yellow Green
-        {0.473, 0.438, 43.1}, // Orange Yellow
-        {0.187, 0.129, 6.1},  // Blue
-        {0.305, 0.478, 23.4}, // Green
-        {0.539, 0.313, 12.0}, // Red
-        {0.448, 0.470, 59.1}, // Yellow
-        {0.364, 0.233, 19.8}, // Magenta
-        {0.196, 0.252, 19.8}, // Cyan
-        {0.310, 0.316, 90.0}, // White
-        {0.310, 0.316, 59.1}, // Neutral 8
-        {0.310, 0.316, 36.2}, // Neutral 6.5
-        {0.310, 0.316, 19.8}, // Neutral 5
-        {0.310, 0.316, 9.0},  // Neutral 3.5
-        {0.310, 0.316, 3.1}}; // Black
+    static gls::Matrix<24, 3> gmb_xyY = {{0.400, 0.350, 10.1},  // Dark Skin
+                                         {0.377, 0.345, 35.8},  // Light Skin
+                                         {0.247, 0.251, 19.3},  // Blue Sky
+                                         {0.337, 0.422, 13.3},  // Foliage
+                                         {0.265, 0.240, 24.3},  // Blue Flower
+                                         {0.261, 0.343, 43.1},  // Bluish Green
+                                         {0.506, 0.407, 30.1},  // Orange
+                                         {0.211, 0.175, 12.0},  // Purplish Blue
+                                         {0.453, 0.306, 19.8},  // Moderate Red
+                                         {0.285, 0.202, 6.6},   // Purple
+                                         {0.380, 0.489, 44.3},  // Yellow Green
+                                         {0.473, 0.438, 43.1},  // Orange Yellow
+                                         {0.187, 0.129, 6.1},   // Blue
+                                         {0.305, 0.478, 23.4},  // Green
+                                         {0.539, 0.313, 12.0},  // Red
+                                         {0.448, 0.470, 59.1},  // Yellow
+                                         {0.364, 0.233, 19.8},  // Magenta
+                                         {0.196, 0.252, 19.8},  // Cyan
+                                         {0.310, 0.316, 90.0},  // White
+                                         {0.310, 0.316, 59.1},  // Neutral 8
+                                         {0.310, 0.316, 36.2},  // Neutral 6.5
+                                         {0.310, 0.316, 19.8},  // Neutral 5
+                                         {0.310, 0.316, 9.0},   // Neutral 3.5
+                                         {0.310, 0.316, 3.1}};  // Black
 
     const auto offsets = bayerOffsets[bayerPattern];
 
-    auto *writeRawImage = (gls::image<gls::luma_pixel_16> *)&rawImage;
+    auto* writeRawImage = (gls::image<gls::luma_pixel_16>*)&rawImage;
 
     gls::Matrix<24, 4> gmb_cam;
     gls::Matrix<24, 3> gmb_xyz;
 
-    for (int sq = 0; sq < 24; sq++)
-    {
+    for (int sq = 0; sq < 24; sq++) {
         gmb_cam[sq] = {0, 0, 0, 0};
         std::array<int, 3> count = {0, 0, 0};
         auto patch = alignToQuad(gmb_samples[sq]);
-        for (int y = patch.y; y < patch.y + patch.height; y += 2)
-        {
-            for (int x = patch.x; x < patch.x + patch.width; x += 2)
-            {
-                for (int c = 0; c < 4; c++)
-                {
-                    const auto &o = offsets[c];
+        for (int y = patch.y; y < patch.y + patch.height; y += 2) {
+            for (int x = patch.x; x < patch.x + patch.width; x += 2) {
+                for (int c = 0; c < 4; c++) {
+                    const auto& o = offsets[c];
                     int val = rawImage[y + o.y][x + o.x];
                     gmb_cam[sq][c == 3 ? 1 : c] += (float)val;
                     count[c == 3 ? 1 : c]++;
@@ -214,8 +189,7 @@ void colorcheck(const gls::image<gls::luma_pixel_16> &rawImage, BayerPattern bay
             }
         }
 
-        for (int c = 0; c < 3; c++)
-        {
+        for (int c = 0; c < 3; c++) {
             gmb_cam[sq][c] = gmb_cam[sq][c] / (float)count[c] - (float)black;
         }
 
@@ -227,15 +201,11 @@ void colorcheck(const gls::image<gls::luma_pixel_16> &rawImage, BayerPattern bay
     gls::Matrix<24, 3> inverse = pseudoinverse(gmb_xyz);
 
     gls::Matrix<3, 3> cam_xyz;
-    for (int pass = 0; pass < 2; pass++)
-    {
-        for (int i = 0; i < 3 /* colors */; i++)
-        {
-            for (int j = 0; j < 3; j++)
-            {
+    for (int pass = 0; pass < 2; pass++) {
+        for (int i = 0; i < 3 /* colors */; i++) {
+            for (int j = 0; j < 3; j++) {
                 cam_xyz[i][j] = 0;
-                for (int k = 0; k < 24; k++)
-                    cam_xyz[i][j] += gmb_cam[k][i] * inverse[k][j];
+                for (int k = 0; k < 24; k++) cam_xyz[i][j] += gmb_cam[k][i] * inverse[k][j];
             }
         }
 
@@ -243,14 +213,11 @@ void colorcheck(const gls::image<gls::luma_pixel_16> &rawImage, BayerPattern bay
         cam_xyz_coeff(&pre_mul, cam_xyz);
 
         gls::Vector<4> balance;
-        for (int c = 0; c < 4; c++)
-        {
+        for (int c = 0; c < 4; c++) {
             balance[c] = pre_mul[c == 3 ? 1 : c] * gmb_cam[20][c];
         }
-        for (int sq = 0; sq < 24; sq++)
-        {
-            for (int c = 0; c < 4; c++)
-            {
+        for (int sq = 0; sq < 24; sq++) {
+            for (int c = 0; c < 4; c++) {
                 gmb_cam[sq][c] *= balance[c];
             }
         }
@@ -266,30 +233,23 @@ void colorcheck(const gls::image<gls::luma_pixel_16> &rawImage, BayerPattern bay
     // printf("\n");
 }
 
-void white_balance(const gls::image<gls::luma_pixel_16> &rawImage, gls::Vector<3> *wb_mul, uint32_t white, uint32_t black, BayerPattern bayerPattern)
-{
+void white_balance(const gls::image<gls::luma_pixel_16>& rawImage, gls::Vector<3>* wb_mul,
+                   uint32_t white, uint32_t black, BayerPattern bayerPattern) {
     const auto offsets = bayerOffsets[bayerPattern];
 
     std::array<float, 8> fsum{/* zero */};
-    for (int y = 0; y < rawImage.height / 2; y += 8)
-    {
-        for (int x = 0; x < rawImage.width / 2; x += 8)
-        {
+    for (int y = 0; y < rawImage.height / 2; y += 8) {
+        for (int x = 0; x < rawImage.width / 2; x += 8) {
             std::array<uint32_t, 8> sum{/* zero */};
-            for (int j = y; j < 8 && j < rawImage.height / 2; j++)
-            {
-                for (int i = x; i < 8 && i < rawImage.width / 2; i++)
-                {
-                    for (int c = 0; c < 4; c++)
-                    {
-                        const auto &o = offsets[c];
+            for (int j = y; j < 8 && j < rawImage.height / 2; j++) {
+                for (int i = x; i < 8 && i < rawImage.width / 2; i++) {
+                    for (int c = 0; c < 4; c++) {
+                        const auto& o = offsets[c];
                         uint32_t val = rawImage[2 * j + o.y][2 * i + o.x];
-                        if (val > white - 25)
-                        {
+                        if (val > white - 25) {
                             goto skip_block;
                         }
-                        if ((val -= black) < 0)
-                        {
+                        if ((val -= black) < 0) {
                             val = 0;
                         }
                         sum[c] += val;
@@ -297,8 +257,7 @@ void white_balance(const gls::image<gls::luma_pixel_16> &rawImage, gls::Vector<3
                     }
                 }
             }
-            for (int i = 0; i < 8; i++)
-            {
+            for (int i = 0; i < 8; i++) {
                 fsum[i] += (float)sum[i];
             }
         skip_block:;
@@ -308,10 +267,8 @@ void white_balance(const gls::image<gls::luma_pixel_16> &rawImage, gls::Vector<3
     fsum[1] += fsum[3];
     fsum[5] += fsum[7];
 
-    for (int c = 0; c < 3; c++)
-    {
-        if (fsum[c] != 0)
-        {
+    for (int c = 0; c < 3; c++) {
+        if (fsum[c] != 0) {
             (*wb_mul)[c] = fsum[c + 4] / fsum[c];
         }
     }
@@ -319,17 +276,15 @@ void white_balance(const gls::image<gls::luma_pixel_16> &rawImage, gls::Vector<3
     *wb_mul = *wb_mul / (*wb_mul)[1];
 }
 
-float unpackDNGMetadata(const gls::image<gls::luma_pixel_16> &rawImage,
-                        gls::tiff_metadata *dng_metadata,
-                        DemosaicParameters *demosaicParameters,
-                        bool auto_white_balance, const gls::rectangle *gmb_position,
-                        bool rotate_180, float *highlights)
-{
+float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
+                        gls::tiff_metadata* dng_metadata, DemosaicParameters* demosaicParameters,
+                        bool auto_white_balance, const gls::rectangle* gmb_position,
+                        bool rotate_180, float* highlights) {
     const auto color_matrix1 = getVector<float>(*dng_metadata, TIFFTAG_COLORMATRIX1);
     const auto color_matrix2 = getVector<float>(*dng_metadata, TIFFTAG_COLORMATRIX2);
 
     // If present ColorMatrix2 is usually D65 and ColorMatrix1 is Standard Light A
-    const auto &color_matrix = color_matrix2.empty() ? color_matrix1 : color_matrix2;
+    const auto& color_matrix = color_matrix2.empty() ? color_matrix1 : color_matrix2;
 
     auto as_shot_neutral = getVector<float>(*dng_metadata, TIFFTAG_ASSHOTNEUTRAL);
     // std::cout << "as_shot_neutral: " << gls::Vector<3>(as_shot_neutral) << std::endl;
@@ -337,7 +292,8 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16> &rawImage,
     float baseline_exposure = 0;
     getValue(*dng_metadata, TIFFTAG_BASELINEEXPOSURE, &baseline_exposure);
     float exposure_multiplier = pow(2.0, baseline_exposure);
-    // std::cout << "baseline_exposure: " << baseline_exposure  << ", exposure_multiplier: " << exposure_multiplier << std::endl;
+    // std::cout << "baseline_exposure: " << baseline_exposure  << ", exposure_multiplier: " <<
+    // exposure_multiplier << std::endl;
 
     const auto black_level_vec = getVector<float>(*dng_metadata, TIFFTAG_BLACKLEVEL);
     const auto white_level_vec = getVector<uint32_t>(*dng_metadata, TIFFTAG_WHITELEVEL);
@@ -347,65 +303,63 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16> &rawImage,
     demosaicParameters->white_level = white_level_vec.empty() ? 0xffff : white_level_vec[0];
     demosaicParameters->exposure_multiplier = std::min(exposure_multiplier, 1.0f);
 
-    demosaicParameters->bayerPattern = std::memcmp(cfa_pattern.data(), "\00\01\01\02", 4) == 0   ? BayerPattern::rggb
-                                       : std::memcmp(cfa_pattern.data(), "\02\01\01\00", 4) == 0 ? BayerPattern::bggr
-                                       : std::memcmp(cfa_pattern.data(), "\01\00\02\01", 4) == 0 ? BayerPattern::grbg
-                                                                                                 : BayerPattern::gbrg;
+    demosaicParameters->bayerPattern =
+        std::memcmp(cfa_pattern.data(), "\00\01\01\02", 4) == 0
+            ? BayerPattern::rggb
+            : std::memcmp(cfa_pattern.data(), "\02\01\01\00", 4) == 0
+                  ? BayerPattern::bggr
+                  : std::memcmp(cfa_pattern.data(), "\01\00\02\01", 4) == 0 ? BayerPattern::grbg
+                                                                            : BayerPattern::gbrg;
 
-    // std::cout << "bayerPattern: " << BayerPatternName[demosaicParameters->bayerPattern] << std::endl;
+    // std::cout << "bayerPattern: " << BayerPatternName[demosaicParameters->bayerPattern] <<
+    // std::endl;
 
     gls::Vector<3> pre_mul;
     gls::Matrix<3, 3> cam_xyz;
-    if (gmb_position)
-    {
-        demosaicParameters->noiseModel.rawNlf = estimateRawParameters(rawImage, &cam_xyz, &pre_mul,
-                                                                      demosaicParameters->black_level,
-                                                                      demosaicParameters->white_level,
-                                                                      demosaicParameters->bayerPattern,
-                                                                      *gmb_position, rotate_180);
+    if (gmb_position) {
+        demosaicParameters->noiseModel.rawNlf =
+            estimateRawParameters(rawImage, &cam_xyz, &pre_mul, demosaicParameters->black_level,
+                                  demosaicParameters->white_level, demosaicParameters->bayerPattern,
+                                  *gmb_position, rotate_180);
 
         // Obtain the rgb_cam matrix and pre_mul
         demosaicParameters->rgb_cam = cam_xyz_coeff(&pre_mul, cam_xyz);
-    }
-    else
-    {
+    } else {
         cam_xyz = color_matrix;
         // Obtain the rgb_cam matrix and pre_mul
         demosaicParameters->rgb_cam = cam_xyz_coeff(&pre_mul, cam_xyz);
 
         // If cam_mul is available use that instead of pre_mul
-        if (!as_shot_neutral.empty() && !auto_white_balance)
-        {
+        if (!as_shot_neutral.empty() && !auto_white_balance) {
             pre_mul = 1.0f / gls::Vector<3>(as_shot_neutral);
         }
     }
 
-    // std::cout << "cam_xyz: " << std::fixed << std::setprecision(4) << cam_xyz.span() << std::endl;
-    // std::cout << "*** pre_mul: " << pre_mul / pre_mul[1] << std::endl;
+    // std::cout << "cam_xyz: " << std::fixed << std::setprecision(4) << cam_xyz.span() <<
+    // std::endl; std::cout << "*** pre_mul: " << pre_mul / pre_mul[1] << std::endl;
 
-    if (auto_white_balance)
-    {
+    if (auto_white_balance) {
         auto minmax = std::minmax_element(std::begin(pre_mul), std::end(pre_mul));
-        for (int c = 0; c < 4; c++)
-        {
+        for (int c = 0; c < 4; c++) {
             int pre_mul_idx = c == 3 ? 1 : c;
-            (demosaicParameters->scale_mul)[c] = std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) * 65535.0 / (demosaicParameters->white_level - demosaicParameters->black_level);
+            (demosaicParameters->scale_mul)[c] =
+                std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) *
+                65535.0 / (demosaicParameters->white_level - demosaicParameters->black_level);
         }
 
         auto cam_to_ycbcr = cam_ycbcr(demosaicParameters->rgb_cam);
-        gls::Vector<3> cam_mul = autoWhiteBalance(rawImage, cam_to_ycbcr,
-                                                  demosaicParameters->scale_mul, demosaicParameters->white_level,
-                                                  demosaicParameters->black_level, demosaicParameters->bayerPattern,
-                                                  highlights);
+        gls::Vector<3> cam_mul = autoWhiteBalance(
+            rawImage, cam_to_ycbcr, demosaicParameters->scale_mul, demosaicParameters->white_level,
+            demosaicParameters->black_level, demosaicParameters->bayerPattern, highlights);
 
         // printf("Auto White Balance: %f, %f, %f\n", cam_mul[0], cam_mul[1], cam_mul[2]);
 
         // Convert cam_mul from camera to XYZ
         const auto cam_mul_xyz = cam_xyz * cam_mul;
-        // std::cout << "cam_mul_xyz: " << cam_mul_xyz << ", CCT: " << XYZtoCorColorTemp(cam_mul_xyz) << std::endl;
+        // std::cout << "cam_mul_xyz: " << cam_mul_xyz << ", CCT: " <<
+        // XYZtoCorColorTemp(cam_mul_xyz) << std::endl;
 
-        for (int c = 0; c < 3; c++)
-        {
+        for (int c = 0; c < 3; c++) {
             as_shot_neutral[c] = 1 / cam_mul[c];
         }
         (*dng_metadata)[TIFFTAG_ASSHOTNEUTRAL] = as_shot_neutral;
@@ -417,64 +371,39 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16> &rawImage,
 
     // Scale Input Image
     auto minmax = std::minmax_element(std::begin(pre_mul), std::end(pre_mul));
-    for (int c = 0; c < 4; c++)
-    {
+    for (int c = 0; c < 4; c++) {
         int pre_mul_idx = c == 3 ? 1 : c;
-        (demosaicParameters->scale_mul)[c] = std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) * 65535.0 / (demosaicParameters->white_level - demosaicParameters->black_level);
+        (demosaicParameters->scale_mul)[c] =
+            std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) * 65535.0 /
+            (demosaicParameters->white_level - demosaicParameters->black_level);
     }
-    printf("scale_mul: %f, %f, %f, %f\n", (demosaicParameters->scale_mul)[0], (demosaicParameters->scale_mul)[1], (demosaicParameters->scale_mul)[2], (demosaicParameters->scale_mul)[3]);
+    printf("scale_mul: %f, %f, %f, %f\n", (demosaicParameters->scale_mul)[0],
+           (demosaicParameters->scale_mul)[1], (demosaicParameters->scale_mul)[2],
+           (demosaicParameters->scale_mul)[3]);
 
     return exposure_multiplier;
 }
 
-const char *GMBColorNames[24]{
-    "DarkSkin",
-    "LightSkin",
-    "BlueSky",
-    "Foliage",
-    "BlueFlower",
-    "BluishGreen",
-    "Orange",
-    "PurplishBlue",
-    "ModerateRed",
-    "Purple",
-    "YellowGreen",
-    "OrangeYellow",
-    "Blue",
-    "Green",
-    "Red",
-    "Yellow",
-    "Magenta",
-    "Cyan",
-    "White",
-    "Neutral_8",
-    "Neutral_6_5",
-    "Neutral_5",
-    "Neutral_3_5",
-    "Black"};
+const char* GMBColorNames[24]{
+    "DarkSkin", "LightSkin",    "BlueSky",     "Foliage",   "BlueFlower",  "BluishGreen",
+    "Orange",   "PurplishBlue", "ModerateRed", "Purple",    "YellowGreen", "OrangeYellow",
+    "Blue",     "Green",        "Red",         "Yellow",    "Magenta",     "Cyan",
+    "White",    "Neutral_8",    "Neutral_6_5", "Neutral_5", "Neutral_3_5", "Black"};
 
-float square(float x)
-{
-    return x * x;
-}
+float square(float x) { return x * x; }
 
-enum
-{
-    red = 0,
-    green = 1,
-    blue = 2,
-    green2 = 3
-};
+enum { red = 0, green = 1, blue = 2, green2 = 3 };
 
 // Collect mean and variance of ColorChecker patches
-void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float black_level, float white_level, BayerPattern bayerPattern, const gls::rectangle &gmb_position, bool rotate_180, std::array<RawPatchStats, 24> *stats)
-{
+void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float black_level,
+                          float white_level, BayerPattern bayerPattern,
+                          const gls::rectangle& gmb_position, bool rotate_180,
+                          std::array<RawPatchStats, 24>* stats) {
     gls::image<gls::luma_pixel_16> red_channel(rawImage.width / 2, rawImage.height / 2);
     gls::image<gls::luma_pixel_16> green_channel(rawImage.width / 2, rawImage.height / 2);
     gls::image<gls::luma_pixel_16> blue_channel(rawImage.width / 2, rawImage.height / 2);
     gls::image<gls::luma_pixel_16> green2_channel(rawImage.width / 2, rawImage.height / 2);
-    for (int i = 0; i < green_channel.pixels().size(); i++)
-    {
+    for (int i = 0; i < green_channel.pixels().size(); i++) {
         red_channel.pixels()[i].luma = 0;
         green_channel.pixels()[i].luma = 0;
         blue_channel.pixels()[i].luma = 0;
@@ -483,7 +412,8 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float 
 
     //    gls::image<gls::luma_pixel_16>* zapMama = (gls::image<gls::luma_pixel_16> *) &rawImage;
 
-    // std::cout << "colorCheckerRawStats rectangle: " << gmb_position.x << ", " << gmb_position.y << ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
+    // std::cout << "colorCheckerRawStats rectangle: " << gmb_position.x << ", " << gmb_position.y
+    // << ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
 
     int patch_width = gmb_position.width / 6;
     int patch_height = gmb_position.height / 4;
@@ -495,14 +425,12 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float 
     const gls::point g2 = offsets[green2];
 
     int patchIdx = 0;
-    for (int row = 0; row < 4; row++)
-    {
-        for (int col = 0; col < 6; col++, patchIdx++)
-        {
-            gls::rectangle patch = alignToQuad({gmb_position.x + col * patch_width + (int)(0.25 * patch_width),
-                                                gmb_position.y + row * patch_height + (int)(0.25 * patch_height),
-                                                (int)(0.5 * patch_width),
-                                                (int)(0.5 * patch_height)});
+    for (int row = 0; row < 4; row++) {
+        for (int col = 0; col < 6; col++, patchIdx++) {
+            gls::rectangle patch =
+                alignToQuad({gmb_position.x + col * patch_width + (int)(0.25 * patch_width),
+                             gmb_position.y + row * patch_height + (int)(0.25 * patch_height),
+                             (int)(0.5 * patch_width), (int)(0.5 * patch_height)});
 
             const int patchSamples = patch.width * patch.height / 4;
 
@@ -511,17 +439,20 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float 
             float avgR = 0;
             float avgB = 0;
 
-            for (int y = 0; y < patch.height; y += 2)
-            {
-                for (int x = 0; x < patch.width; x += 2)
-                {
+            for (int y = 0; y < patch.height; y += 2) {
+                for (int x = 0; x < patch.width; x += 2) {
                     const int y_off = patch.y + y;
                     const int x_off = patch.x + x;
                     gls::rgba_pixel_fp32 p = {
-                        std::clamp((rawImage[y_off + r.y][x_off + r.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + g.y][x_off + g.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + b.y][x_off + b.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level, 0.0f, 1.0f)};
+                        std::clamp((rawImage[y_off + r.y][x_off + r.x] - black_level) / white_level,
+                                   0.0f, 1.0f),
+                        std::clamp((rawImage[y_off + g.y][x_off + g.x] - black_level) / white_level,
+                                   0.0f, 1.0f),
+                        std::clamp((rawImage[y_off + b.y][x_off + b.x] - black_level) / white_level,
+                                   0.0f, 1.0f),
+                        std::clamp(
+                            (rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level,
+                            0.0f, 1.0f)};
 
                     avgR += p[0];
                     avgG1 += p[1];
@@ -540,17 +471,20 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float 
             float varB = 0;
             float varG2 = 0;
 
-            for (int y = 0; y < patch.height; y += 2)
-            {
-                for (int x = 0; x < patch.width; x += 2)
-                {
+            for (int y = 0; y < patch.height; y += 2) {
+                for (int x = 0; x < patch.width; x += 2) {
                     const int y_off = patch.y + y;
                     const int x_off = patch.x + x;
                     gls::rgba_pixel_fp32 p = {
-                        std::clamp((rawImage[y_off + r.y][x_off + r.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + g.y][x_off + g.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + b.y][x_off + b.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level, 0.0f, 1.0f)};
+                        std::clamp((rawImage[y_off + r.y][x_off + r.x] - black_level) / white_level,
+                                   0.0f, 1.0f),
+                        std::clamp((rawImage[y_off + g.y][x_off + g.x] - black_level) / white_level,
+                                   0.0f, 1.0f),
+                        std::clamp((rawImage[y_off + b.y][x_off + b.x] - black_level) / white_level,
+                                   0.0f, 1.0f),
+                        std::clamp(
+                            (rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level,
+                            0.0f, 1.0f)};
 
                     red_channel[(patch.y + y) / 2][(patch.x + x) / 2] = 0xffff * p.red;
                     green_channel[(patch.y + y) / 2][(patch.x + x) / 2] = 0xffff * p.green;
@@ -578,43 +512,50 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float 
         }
     }
 
-    if (rotate_180)
-    {
+    if (rotate_180) {
         std::reverse(stats->begin(), stats->end());
     }
 
     //    for (int patchIdx = 0; patchIdx < 24; patchIdx++) {
-    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg: {"
-    //                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " << (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << ", " << (*stats)[patchIdx].mean[3] << "}, var: {"
-    //                                          << (*stats)[patchIdx].variance[0] << ", " << (*stats)[patchIdx].variance[1] << ", " << (*stats)[patchIdx].variance[2] << ", " << (*stats)[patchIdx].variance[3] << "}" << std::endl;
+    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg:
+    //        {"
+    //                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " <<
+    //                  (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << ", " <<
+    //                  (*stats)[patchIdx].mean[3] << "}, var: {"
+    //                                          << (*stats)[patchIdx].variance[0] << ", " <<
+    //                                          (*stats)[patchIdx].variance[1] << ", " <<
+    //                                          (*stats)[patchIdx].variance[2] << ", " <<
+    //                                          (*stats)[patchIdx].variance[3] << "}" << std::endl;
     //
     //    }
 
     static int file_count = 0;
-    red_channel.write_png_file("/Users/fabio/red_channel" + std::to_string(file_count) + ".png", false);
-    green_channel.write_png_file("/Users/fabio/green_channel" + std::to_string(file_count) + ".png", false);
-    blue_channel.write_png_file("/Users/fabio/blue_channel" + std::to_string(file_count) + ".png", false);
-    green2_channel.write_png_file("/Users/fabio/green2_channel" + std::to_string(file_count++) + ".png", false);
+    red_channel.write_png_file("/Users/fabio/red_channel" + std::to_string(file_count) + ".png",
+                               false);
+    green_channel.write_png_file("/Users/fabio/green_channel" + std::to_string(file_count) + ".png",
+                                 false);
+    blue_channel.write_png_file("/Users/fabio/blue_channel" + std::to_string(file_count) + ".png",
+                                false);
+    green2_channel.write_png_file(
+        "/Users/fabio/green2_channel" + std::to_string(file_count++) + ".png", false);
 }
 
 // Collect mean and variance of ColorChecker patches
-void colorCheckerStats(gls::image<gls::rgba_pixel_float> *image, const gls::rectangle &gmb_position, bool rotate_180, std::array<PatchStats, 24> *stats)
-{
-    // std::cout << "colorCheckerStats rectangle: " << gmb_position.x << ", " << gmb_position.y << ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
+void colorCheckerStats(gls::image<gls::rgba_pixel_float>* image, const gls::rectangle& gmb_position,
+                       bool rotate_180, std::array<PatchStats, 24>* stats) {
+    // std::cout << "colorCheckerStats rectangle: " << gmb_position.x << ", " << gmb_position.y <<
+    // ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
 
     int patch_width = gmb_position.width / 6;
     int patch_height = gmb_position.height / 4;
 
     int patchIdx = 0;
-    for (int row = 0; row < 4; row++)
-    {
-        for (int col = 0; col < 6; col++, patchIdx++)
-        {
+    for (int row = 0; row < 4; row++) {
+        for (int col = 0; col < 6; col++, patchIdx++) {
             gls::rectangle patch = {
                 gmb_position.x + col * patch_width + (int)(0.25 * patch_width),
                 gmb_position.y + row * patch_height + (int)(0.25 * patch_height),
-                (int)(0.5 * patch_width),
-                (int)(0.5 * patch_height)};
+                (int)(0.5 * patch_width), (int)(0.5 * patch_height)};
 
             int patchSamples = patch.width * patch.height;
 
@@ -622,11 +563,9 @@ void colorCheckerStats(gls::image<gls::rgba_pixel_float> *image, const gls::rect
             float avgCb = 0;
             float avgCr = 0;
 
-            for (int y = 0; y < patch.height; y++)
-            {
-                for (int x = 0; x < patch.width; x++)
-                {
-                    const auto &p = (*image)[patch.y + y][patch.x + x];
+            for (int y = 0; y < patch.height; y++) {
+                for (int x = 0; x < patch.width; x++) {
+                    const auto& p = (*image)[patch.y + y][patch.x + x];
                     avgY += p[0];
                     avgCb += p[1];
                     avgCr += p[2];
@@ -641,11 +580,9 @@ void colorCheckerStats(gls::image<gls::rgba_pixel_float> *image, const gls::rect
             float varCb = 0;
             float varCr = 0;
 
-            for (int y = 0; y < patch.height; y++)
-            {
-                for (int x = 0; x < patch.width; x++)
-                {
-                    const auto &p = (*image)[patch.y + y][patch.x + x];
+            for (int y = 0; y < patch.height; y++) {
+                for (int x = 0; x < patch.width; x++) {
+                    const auto& p = (*image)[patch.y + y][patch.x + x];
                     varY += square(p[0] - avgY);
                     varCb += square(p[1] - avgCb);
                     varCr += square(p[2] - avgCr);
@@ -662,22 +599,26 @@ void colorCheckerStats(gls::image<gls::rgba_pixel_float> *image, const gls::rect
         }
     }
 
-    if (rotate_180)
-    {
+    if (rotate_180) {
         std::reverse(stats->begin(), stats->end());
     }
 
     //    for (int patchIdx = 0; patchIdx < 24; patchIdx++) {
-    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg: {"
-    //                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " << (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << "}, var: {"
-    //                                          << (*stats)[patchIdx].variance[0] << ", " << (*stats)[patchIdx].variance[1] << ", " << (*stats)[patchIdx].variance[2] << "}" << std::endl;
+    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg:
+    //        {"
+    //                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " <<
+    //                  (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << "}, var:
+    //                  {"
+    //                                          << (*stats)[patchIdx].variance[0] << ", " <<
+    //                                          (*stats)[patchIdx].variance[1] << ", " <<
+    //                                          (*stats)[patchIdx].variance[2] << "}" << std::endl;
     //    }
 }
 
 // Slope Regression of a set of points
 template <size_t N>
-std::pair<float, float> linear_regression(const gls::Vector<N> &x, const gls::Vector<N> &y, float *errorSquare = nullptr)
-{
+std::pair<float, float> linear_regression(const gls::Vector<N>& x, const gls::Vector<N>& y,
+                                          float* errorSquare = nullptr) {
     const auto s_x = std::accumulate(x.begin(), x.end(), 0.0);
     const auto s_y = std::accumulate(y.begin(), y.end(), 0.0);
     const auto s_xx = std::inner_product(x.begin(), x.end(), x.begin(), 0.0);
@@ -685,11 +626,9 @@ std::pair<float, float> linear_regression(const gls::Vector<N> &x, const gls::Ve
     const auto b = (N * s_xy - s_x * s_y) / (N * s_xx - s_x * s_x);
     const auto a = (s_y - b * s_x) / N;
 
-    if (errorSquare)
-    {
+    if (errorSquare) {
         *errorSquare = 0;
-        for (int i = 0; i < x.size(); i++)
-        {
+        for (int i = 0; i < x.size(); i++) {
             float p = a + b * x[i];
             float diff = p - y[i];
             *errorSquare += diff * diff;
@@ -699,132 +638,96 @@ std::pair<float, float> linear_regression(const gls::Vector<N> &x, const gls::Ve
     return {a, b};
 }
 
-// Estimate the Sensor's Noise Level Function (NLF: variance vs intensity), which is linear going through zero
-gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float> *image, const gls::rectangle &gmb_position, bool rotate_180)
-{
+// Estimate the Sensor's Noise Level Function (NLF: variance vs intensity), which is linear going
+// through zero
+gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float>* image,
+                                     const gls::rectangle& gmb_position, bool rotate_180) {
     std::array<PatchStats, 24> stats;
     colorCheckerStats(image, gmb_position, rotate_180, &stats);
 
-    gls::Vector<6> y_intensity = {
-        stats[Black].mean[0],
-        stats[Neutral_3_5].mean[0],
-        stats[Neutral_5].mean[0],
-        stats[Neutral_6_5].mean[0],
-        stats[Neutral_8].mean[0],
-        stats[White].mean[0]};
+    gls::Vector<6> y_intensity = {stats[Black].mean[0],     stats[Neutral_3_5].mean[0],
+                                  stats[Neutral_5].mean[0], stats[Neutral_6_5].mean[0],
+                                  stats[Neutral_8].mean[0], stats[White].mean[0]};
 
-    gls::Vector<6> y_variance = {
-        stats[Black].variance[0],
-        stats[Neutral_3_5].variance[0],
-        stats[Neutral_5].variance[0],
-        stats[Neutral_6_5].variance[0],
-        stats[Neutral_8].variance[0],
-        stats[White].variance[0]};
+    gls::Vector<6> y_variance = {stats[Black].variance[0],     stats[Neutral_3_5].variance[0],
+                                 stats[Neutral_5].variance[0], stats[Neutral_6_5].variance[0],
+                                 stats[Neutral_8].variance[0], stats[White].variance[0]};
 
-    gls::Vector<6> cb_variance = {
-        stats[Black].variance[1],
-        stats[Neutral_3_5].variance[1],
-        stats[Neutral_5].variance[1],
-        stats[Neutral_6_5].variance[1],
-        stats[Neutral_8].variance[1],
-        stats[White].variance[1]};
+    gls::Vector<6> cb_variance = {stats[Black].variance[1],     stats[Neutral_3_5].variance[1],
+                                  stats[Neutral_5].variance[1], stats[Neutral_6_5].variance[1],
+                                  stats[Neutral_8].variance[1], stats[White].variance[1]};
 
-    gls::Vector<6> cr_variance = {
-        stats[Black].variance[2],
-        stats[Neutral_3_5].variance[2],
-        stats[Neutral_5].variance[2],
-        stats[Neutral_6_5].variance[2],
-        stats[Neutral_8].variance[2],
-        stats[White].variance[2]};
+    gls::Vector<6> cr_variance = {stats[Black].variance[2],     stats[Neutral_3_5].variance[2],
+                                  stats[Neutral_5].variance[2], stats[Neutral_6_5].variance[2],
+                                  stats[Neutral_8].variance[2], stats[White].variance[2]};
 
     //    std::cout << "NLF Stats:" << std::endl;
     //    for (int patch = Black; patch >= White; patch--) {
-    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patch] << ": " << std::setprecision(4) << std::scientific << stats[patch].mean[0] << ", "
-    //                  << stats[patch].variance[0] << ", " << stats[patch].variance[1] << ", " << stats[patch].variance[2] << std::endl;
+    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patch] << ": " <<
+    //        std::setprecision(4) << std::scientific << stats[patch].mean[0] << ", "
+    //                  << stats[patch].variance[0] << ", " << stats[patch].variance[1] << ", " <<
+    //                  stats[patch].variance[2] << std::endl;
     //    }
 
     float y_err2;
     auto nlf_y = linear_regression(y_intensity, y_variance, &y_err2);
-    auto nlf_cb = std::accumulate(cb_variance.begin(), cb_variance.end(), 0.0f) / cb_variance.size();
-    auto nlf_cr = std::accumulate(cr_variance.begin(), cr_variance.end(), 0.0f) / cr_variance.size();
+    auto nlf_cb =
+        std::accumulate(cb_variance.begin(), cb_variance.end(), 0.0f) / cb_variance.size();
+    auto nlf_cr =
+        std::accumulate(cr_variance.begin(), cr_variance.end(), 0.0f) / cr_variance.size();
 
     // std::cout << std::setprecision(4) << std::scientific
     //           << "\nnlf_y: " << nlf_y.first << ":" << nlf_y.second << " (" << y_err2 << ")"
     //           << ", nlf_cb: " << nlf_cb << ", nlf_cr: " << nlf_cr << std::endl;
 
-    // NFL for Y passes by 0, just use the slope, NFL for Cb and and Cr is mostly flat, just return the average
+    // NFL for Y passes by 0, just use the slope, NFL for Cb and and Cr is mostly flat, just return
+    // the average
     return {nlf_y.second, nlf_cb, nlf_cr};
 }
 
-RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16> &rawImage, gls::Matrix<3, 3> *cam_xyz, gls::Vector<3> *pre_mul,
-                             float black_level, float white_level, BayerPattern bayerPattern, const gls::rectangle &gmb_position, bool rotate_180)
-{
+RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage,
+                             gls::Matrix<3, 3>* cam_xyz, gls::Vector<3>* pre_mul, float black_level,
+                             float white_level, BayerPattern bayerPattern,
+                             const gls::rectangle& gmb_position, bool rotate_180) {
     std::array<RawPatchStats, 24> rawStats;
-    colorCheckerRawStats(rawImage, black_level, white_level, bayerPattern, gmb_position, rotate_180, &rawStats);
+    colorCheckerRawStats(rawImage, black_level, white_level, bayerPattern, gmb_position, rotate_180,
+                         &rawStats);
 
-    gls::Vector<6> red_intensity = {
-        rawStats[Black].mean[0],
-        rawStats[Neutral_3_5].mean[0],
-        rawStats[Neutral_5].mean[0],
-        rawStats[Neutral_6_5].mean[0],
-        rawStats[Neutral_8].mean[0],
-        rawStats[White].mean[0]};
+    gls::Vector<6> red_intensity = {rawStats[Black].mean[0],     rawStats[Neutral_3_5].mean[0],
+                                    rawStats[Neutral_5].mean[0], rawStats[Neutral_6_5].mean[0],
+                                    rawStats[Neutral_8].mean[0], rawStats[White].mean[0]};
 
-    gls::Vector<6> green_intensity = {
-        rawStats[Black].mean[1],
-        rawStats[Neutral_3_5].mean[1],
-        rawStats[Neutral_5].mean[1],
-        rawStats[Neutral_6_5].mean[1],
-        rawStats[Neutral_8].mean[1],
-        rawStats[White].mean[1]};
+    gls::Vector<6> green_intensity = {rawStats[Black].mean[1],     rawStats[Neutral_3_5].mean[1],
+                                      rawStats[Neutral_5].mean[1], rawStats[Neutral_6_5].mean[1],
+                                      rawStats[Neutral_8].mean[1], rawStats[White].mean[1]};
 
-    gls::Vector<6> blue_intensity = {
-        rawStats[Black].mean[2],
-        rawStats[Neutral_3_5].mean[2],
-        rawStats[Neutral_5].mean[2],
-        rawStats[Neutral_6_5].mean[2],
-        rawStats[Neutral_8].mean[2],
-        rawStats[White].mean[2]};
+    gls::Vector<6> blue_intensity = {rawStats[Black].mean[2],     rawStats[Neutral_3_5].mean[2],
+                                     rawStats[Neutral_5].mean[2], rawStats[Neutral_6_5].mean[2],
+                                     rawStats[Neutral_8].mean[2], rawStats[White].mean[2]};
 
-    gls::Vector<6> green2_intensity = {
-        rawStats[Black].mean[3],
-        rawStats[Neutral_3_5].mean[3],
-        rawStats[Neutral_5].mean[3],
-        rawStats[Neutral_6_5].mean[3],
-        rawStats[Neutral_8].mean[3],
-        rawStats[White].mean[3]};
+    gls::Vector<6> green2_intensity = {rawStats[Black].mean[3],     rawStats[Neutral_3_5].mean[3],
+                                       rawStats[Neutral_5].mean[3], rawStats[Neutral_6_5].mean[3],
+                                       rawStats[Neutral_8].mean[3], rawStats[White].mean[3]};
 
     gls::Vector<6> red_variance = {
-        rawStats[Black].variance[0],
-        rawStats[Neutral_3_5].variance[0],
-        rawStats[Neutral_5].variance[0],
-        rawStats[Neutral_6_5].variance[0],
-        rawStats[Neutral_8].variance[0],
-        rawStats[White].variance[0]};
+        rawStats[Black].variance[0],     rawStats[Neutral_3_5].variance[0],
+        rawStats[Neutral_5].variance[0], rawStats[Neutral_6_5].variance[0],
+        rawStats[Neutral_8].variance[0], rawStats[White].variance[0]};
 
     gls::Vector<6> green_variance = {
-        rawStats[Black].variance[1],
-        rawStats[Neutral_3_5].variance[1],
-        rawStats[Neutral_5].variance[1],
-        rawStats[Neutral_6_5].variance[1],
-        rawStats[Neutral_8].variance[1],
-        rawStats[White].variance[1]};
+        rawStats[Black].variance[1],     rawStats[Neutral_3_5].variance[1],
+        rawStats[Neutral_5].variance[1], rawStats[Neutral_6_5].variance[1],
+        rawStats[Neutral_8].variance[1], rawStats[White].variance[1]};
 
     gls::Vector<6> blue_variance = {
-        rawStats[Black].variance[2],
-        rawStats[Neutral_3_5].variance[2],
-        rawStats[Neutral_5].variance[2],
-        rawStats[Neutral_6_5].variance[2],
-        rawStats[Neutral_8].variance[2],
-        rawStats[White].variance[2]};
+        rawStats[Black].variance[2],     rawStats[Neutral_3_5].variance[2],
+        rawStats[Neutral_5].variance[2], rawStats[Neutral_6_5].variance[2],
+        rawStats[Neutral_8].variance[2], rawStats[White].variance[2]};
 
     gls::Vector<6> green2_variance = {
-        rawStats[Black].variance[3],
-        rawStats[Neutral_3_5].variance[3],
-        rawStats[Neutral_5].variance[3],
-        rawStats[Neutral_6_5].variance[3],
-        rawStats[Neutral_8].variance[3],
-        rawStats[White].variance[3]};
+        rawStats[Black].variance[3],     rawStats[Neutral_3_5].variance[3],
+        rawStats[Neutral_5].variance[3], rawStats[Neutral_6_5].variance[3],
+        rawStats[Neutral_8].variance[3], rawStats[White].variance[3]};
 
     // Derive color matrix
     matrixFromColorChecker(rawStats, cam_xyz, pre_mul);
@@ -836,10 +739,14 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16> &rawImage, gls
     auto nlf_g2 = linear_regression(green2_intensity, green2_variance, &g2_err2);
 
     //    std::cout << std::setprecision(2) << std::scientific
-    //              << "raw nlf_r: " << nlf_r.first << ":" << nlf_r.second << " (" << r_err2 << "), "
-    //              << "raw nlf_g: " << nlf_g.first << ":" << nlf_g.second << " (" << g_err2 << "), "
-    //              << "raw nlf_b: " << nlf_b.first << ":" << nlf_b.second << " (" << b_err2 << "), "
-    //              << "raw nlf_g2: " << nlf_g2.first << ":" << nlf_g2.second << " (" << g2_err2 << ")" << std::endl;
+    //              << "raw nlf_r: " << nlf_r.first << ":" << nlf_r.second << " (" << r_err2 << "),
+    //              "
+    //              << "raw nlf_g: " << nlf_g.first << ":" << nlf_g.second << " (" << g_err2 << "),
+    //              "
+    //              << "raw nlf_b: " << nlf_b.first << ":" << nlf_b.second << " (" << b_err2 << "),
+    //              "
+    //              << "raw nlf_g2: " << nlf_g2.first << ":" << nlf_g2.second << " (" << g2_err2 <<
+    //              ")" << std::endl;
 
     // std::cout << std::setprecision(2) << std::scientific << "raw nlf (r g b g2): "
     //           << nlf_r.second << ", "
@@ -847,24 +754,28 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16> &rawImage, gls
     //           << nlf_b.second << ", "
     //           << nlf_g2.second << std::endl;
 
-    return {{nlf_r.first, nlf_g.first, nlf_b.first, nlf_g2.first}, {nlf_r.second, nlf_g.second, nlf_b.second, nlf_g2.second}};
+    return {{nlf_r.first, nlf_g.first, nlf_b.first, nlf_g2.first},
+            {nlf_r.second, nlf_g.second, nlf_b.second, nlf_g2.second}};
 }
 
-gls::Vector<3> extractNlfFromColorChecker(gls::image<gls::rgba_pixel_float> *yCbCrImage, const gls::rectangle gmb_position, bool rotate_180, int scale)
-{
-    const gls::rectangle position = {
-        (int)round(gmb_position.x / (float)scale),
-        (int)round(gmb_position.y / (float)scale),
-        (int)round(gmb_position.width / (float)scale),
-        (int)round(gmb_position.height / (float)scale)};
+gls::Vector<3> extractNlfFromColorChecker(gls::image<gls::rgba_pixel_float>* yCbCrImage,
+                                          const gls::rectangle gmb_position, bool rotate_180,
+                                          int scale) {
+    const gls::rectangle position = {(int)round(gmb_position.x / (float)scale),
+                                     (int)round(gmb_position.y / (float)scale),
+                                     (int)round(gmb_position.width / (float)scale),
+                                     (int)round(gmb_position.height / (float)scale)};
     gls::Vector<3> nlf_parameters = estimateNlfParameters(yCbCrImage, position, rotate_180);
-    // std::cout << "Scale " << scale << " nlf parameters: " << std::setprecision(4) << std::scientific << nlf_parameters[0] << ", " << nlf_parameters[1] << ", " << nlf_parameters[2] << std::endl;
+    // std::cout << "Scale " << scale << " nlf parameters: " << std::setprecision(4) <<
+    // std::scientific << nlf_parameters[0] << ", " << nlf_parameters[1] << ", " <<
+    // nlf_parameters[2] << std::endl;
 
     //    gls::image<gls::rgb_pixel> output(yCbCrImage->width, yCbCrImage->height);
     //    for (int y = 0; y < output.height; y++) {
     //        for (int x = 0; x < output.width; x++) {
     //            const auto& p = (*yCbCrImage)[y][x];
-    //            output[y][x] = {clamp_uint8(255 * p[0]), clamp_uint8(128 * p[1] + 127), clamp_uint8(128 * p[2] + 127)};
+    //            output[y][x] = {clamp_uint8(255 * p[0]), clamp_uint8(128 * p[1] + 127),
+    //            clamp_uint8(128 * p[2] + 127)};
     //        }
     //    }
     //    output.write_png_file("/Users/fabio/ColorChecker" + std::to_string(scale) + ".png");
@@ -872,90 +783,76 @@ gls::Vector<3> extractNlfFromColorChecker(gls::image<gls::rgba_pixel_float> *yCb
     return nlf_parameters;
 }
 
-gls::Matrix<3, 3> cam_ycbcr(const gls::Matrix<3, 3> &rgb_cam)
-{
-    // Convert image to YCbCr for Luma/Chroma Denoising, use the camera's primaries to derive the transform
+gls::Matrix<3, 3> cam_ycbcr(const gls::Matrix<3, 3>& rgb_cam) {
+    // Convert image to YCbCr for Luma/Chroma Denoising, use the camera's primaries to derive the
+    // transform
     const auto cam_y = xyz_rgb[1] * rgb_cam;
     const auto KR = cam_y[0];
     const auto KG = cam_y[1];
     const auto KB = cam_y[2];
 
     // See: https://en.wikipedia.org/wiki/YCbCr
-    return {
-        {KR, KG, KB},
-        {-0.5f * KR / (1.0f - KB), -0.5f * KG / (1 - KB), 0.5f},
-        {0.5f, -0.5f * KG / (1 - KR), -0.5f * KB / (1 - KR)}};
+    return {{KR, KG, KB},
+            {-0.5f * KR / (1.0f - KB), -0.5f * KG / (1 - KB), 0.5f},
+            {0.5f, -0.5f * KG / (1 - KR), -0.5f * KB / (1 - KR)}};
 }
 
-struct WhiteBalanceStats
-{
+struct WhiteBalanceStats {
     gls::Vector<3> wbGain;
     float diffAverage;
     int whitePixelsCount;
 };
 
 const gls::Matrix<3, 3> srgb_ycbcr = {
-    {0.2126, 0.7152, 0.0722},
-    {-0.1146, -0.3854, 0.5},
-    {0.5, -0.4542, -0.0458}};
+    {0.2126, 0.7152, 0.0722}, {-0.1146, -0.3854, 0.5}, {0.5, -0.4542, -0.0458}};
 
-const gls::Matrix<3, 3> ycbcr_srgb = {
-    {
-        1,
-        0,
-        1.5748,
-    },
-    {
-        1,
-        -0.1873,
-        -0.4681,
-    },
-    {1, 1.8556, 0}};
+const gls::Matrix<3, 3> ycbcr_srgb = {{
+                                          1,
+                                          0,
+                                          1.5748,
+                                      },
+                                      {
+                                          1,
+                                          -0.1873,
+                                          -0.4681,
+                                      },
+                                      {1, 1.8556, 0}};
 
-gls::Vector<3> readQuad(const gls::image<gls::luma_pixel_16> &rawImage, int x, int y, BayerPattern bayerPattern)
-{
-    const auto &offsets = bayerOffsets[bayerPattern];
-    const auto &Or = offsets[0];
-    const auto &Og1 = offsets[1];
-    const auto &Ob = offsets[2];
-    const auto &Og2 = offsets[3];
+gls::Vector<3> readQuad(const gls::image<gls::luma_pixel_16>& rawImage, int x, int y,
+                        BayerPattern bayerPattern) {
+    const auto& offsets = bayerOffsets[bayerPattern];
+    const auto& Or = offsets[0];
+    const auto& Og1 = offsets[1];
+    const auto& Ob = offsets[2];
+    const auto& Og2 = offsets[3];
 
-    return {
-        (float)rawImage[y + Or.y][x + Or.x],
-        ((float)rawImage[y + Og1.y][x + Og1.x] +
-         (float)rawImage[y + Og2.y][x + Og2.x]) /
-            2.0f,
-        (float)rawImage[y + Ob.y][x + Ob.x]};
+    return {(float)rawImage[y + Or.y][x + Or.x],
+            ((float)rawImage[y + Og1.y][x + Og1.x] + (float)rawImage[y + Og2.y][x + Og2.x]) / 2.0f,
+            (float)rawImage[y + Ob.y][x + Ob.x]};
 }
 
-std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma_pixel_16> &rawImage, const gls::Matrix<3, 3> &rgb_ycbcr,
-                                                      const gls::Vector<3> &scale_mul, float white, float black, BayerPattern bayerPattern,
-                                                      float highlightsFraction)
-{
+std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(
+    const gls::image<gls::luma_pixel_16>& rawImage, const gls::Matrix<3, 3>& rgb_ycbcr,
+    const gls::Vector<3>& scale_mul, float white, float black, BayerPattern bayerPattern,
+    float highlightsFraction) {
     int highlightPixels = 0;
     // Compute the average ycbcr values
     gls::Vector<3> M = {0, 0, 0};
     gls::image<gls::rgb_pixel_fp32> YUV(rawImage.width / 2, rawImage.height / 2);
-    for (int y = 0; y < rawImage.height; y += 2)
-    {
-        for (int x = 0; x < rawImage.width; x += 2)
-        {
+    for (int y = 0; y < rawImage.height; y += 2) {
+        for (int x = 0; x < rawImage.width; x += 2) {
             // Compute the RGB value in the target color space clipping the highlights to white
-            auto rgb = (scale_mul * (readQuad(rawImage, x, y, bayerPattern) - black)) / (float)0xffff;
+            auto rgb =
+                (scale_mul * (readQuad(rawImage, x, y, bayerPattern) - black)) / (float)0xffff;
             bool highlights = false;
-            for (int c = 0; c < 3; c++)
-            {
-                if (rgb[c] > 1.0)
-                {
+            for (int c = 0; c < 3; c++) {
+                if (rgb[c] > 1.0) {
                     rgb[c] = 1.0;
-                }
-                else if (rgb[c] > 0.5)
-                {
+                } else if (rgb[c] > 0.5) {
                     highlights = true;
                 }
             }
-            if (highlights)
-            {
+            if (highlights) {
                 highlightPixels++;
             }
 
@@ -969,24 +866,21 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
 
 #if DUMP_YUV_IMAGE
     gls::image<gls::rgb_pixel> srgb8Image(YUV.width, YUV.height);
-    YUV.apply([&srgb8Image](const gls::rgb_pixel_fp32 &p, int x, int y)
-              {
+    YUV.apply([&srgb8Image](const gls::rgb_pixel_fp32& p, int x, int y) {
         const auto rgb = ycbcr_srgb * gls::Vector<3>(p.v);
-        srgb8Image[y][x] = {
-            (uint8_t) std::clamp(sqrt(rgb[0]) * 255, 0.0f, 255.0f),
-            (uint8_t) std::clamp(sqrt(rgb[1]) * 255, 0.0f, 255.0f),
-            (uint8_t) std::clamp(sqrt(rgb[2]) * 255, 0.0f, 255.0f)
-        }; });
+        srgb8Image[y][x] = {(uint8_t)std::clamp(sqrt(rgb[0]) * 255, 0.0f, 255.0f),
+                            (uint8_t)std::clamp(sqrt(rgb[1]) * 255, 0.0f, 255.0f),
+                            (uint8_t)std::clamp(sqrt(rgb[2]) * 255, 0.0f, 255.0f)};
+    });
     static int image_count = 0;
-    srgb8Image.write_jpeg_file("/Users/fabio/rgbImage" + std::to_string(image_count++) + ".jpg", 95);
+    srgb8Image.write_jpeg_file("/Users/fabio/rgbImage" + std::to_string(image_count++) + ".jpg",
+                               95);
 #endif
 
     // Compute the ycbcr average absolute differences
     gls::Vector<3> D = {0, 0, 0};
-    for (int y = 0; y < YUV.height; y++)
-    {
-        for (int x = 0; x < YUV.width; x++)
-        {
+    for (int y = 0; y < YUV.height; y++) {
+        for (int x = 0; x < YUV.width; x++) {
             D += abs(gls::Vector<3>(YUV[y][x].v) - M);
         }
     }
@@ -999,26 +893,23 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
 
     int whitePixelsCount = 0;
     float YMax = 0;
-    for (int y = 0; y < YUV.height; y++)
-    {
-        for (int x = 0; x < YUV.width; x++)
-        {
-            const auto &p = YUV[y][x];
+    for (int y = 0; y < YUV.height; y++) {
+        for (int x = 0; x < YUV.width; x++) {
+            const auto& p = YUV[y][x];
 
             // Near white region pixels
             if (fabs(p[1] - (M[1] + copysign(D[1], M[1]))) < Wr * D[1] &&
-                fabs(p[2] - (WCr * M[2] + copysign(D[2], M[2]))) < Wr * D[2])
-            {
+                fabs(p[2] - (WCr * M[2] + copysign(D[2], M[2]))) < Wr * D[2]) {
                 const auto rgb = (readQuad(rawImage, 2 * x, 2 * y, bayerPattern) - black) / white;
 
                 float Y = p[0];
-                if (Y > YMax)
-                {
+                if (Y > YMax) {
                     YMax = Y;
                 }
 
-                size_t histEntry = std::clamp((size_t)round((rgbWhiteAverageHist.size() - 1) * Y), 0UL, rgbWhiteAverageHist.size() - 1);
-                auto &entry = rgbWhiteAverageHist[histEntry];
+                size_t histEntry = std::clamp((size_t)round((rgbWhiteAverageHist.size() - 1) * Y),
+                                              0UL, rgbWhiteAverageHist.size() - 1);
+                auto& entry = rgbWhiteAverageHist[histEntry];
                 entry.first += rgb;
                 entry.second++;
 
@@ -1027,10 +918,10 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
         }
     }
 
-    int histMaxEntry = (int)std::clamp((size_t)round((rgbWhiteAverageHist.size() - 1) * YMax), 0UL, rgbWhiteAverageHist.size() - 1);
+    int histMaxEntry = (int)std::clamp((size_t)round((rgbWhiteAverageHist.size() - 1) * YMax), 0UL,
+                                       rgbWhiteAverageHist.size() - 1);
 
-    if (histMaxEntry == 0)
-    {
+    if (histMaxEntry == 0) {
         return {{1, 1, 1}, 0};
     }
 
@@ -1038,14 +929,12 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
     gls::Vector<3> rgbWhite90Average = {0, 0, 0};
 
     // Only consider the top highlightsFraction of whitePixelsCount
-    for (int i = histMaxEntry; i >= 0; i--)
-    {
-        auto &entry = rgbWhiteAverageHist[i];
+    for (int i = histMaxEntry; i >= 0; i--) {
+        auto& entry = rgbWhiteAverageHist[i];
         rgbWhite90Average += entry.first;
         white90PixelsCount += entry.second;
 
-        if (white90PixelsCount > highlightsFraction * whitePixelsCount)
-        {
+        if (white90PixelsCount > highlightsFraction * whitePixelsCount) {
             break;
         }
     }
@@ -1056,21 +945,20 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
 }
 
 template <size_t N>
-float lenght(const gls::Vector<N> &vec)
-{
+float lenght(const gls::Vector<N>& vec) {
     float sumSq = 0;
-    for (const auto &v : vec)
-    {
+    for (const auto& v : vec) {
         sumSq += v * v;
     }
     return sqrt(sumSq);
 }
 
-gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16> &rawImage, const gls::Matrix<3, 3> &rgb_ycbcr,
-                                const gls::Vector<4> &scale_mul4, float white, float black, BayerPattern bayerPattern,
-                                float *highlights)
-{
-    const gls::Vector<3> scale_mul = gls::Vector<3>{scale_mul4[0], scale_mul4[1], scale_mul4[2]} / scale_mul4[1];
+gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16>& rawImage,
+                                const gls::Matrix<3, 3>& rgb_ycbcr,
+                                const gls::Vector<4>& scale_mul4, float white, float black,
+                                BayerPattern bayerPattern, float* highlights) {
+    const gls::Vector<3> scale_mul =
+        gls::Vector<3>{scale_mul4[0], scale_mul4[1], scale_mul4[2]} / scale_mul4[1];
 
     const int hTiles = 4;
     const int vTiles = 4;
@@ -1084,26 +972,26 @@ gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16> &rawImage, 
     auto t_start = std::chrono::high_resolution_clock::now();
 
     std::array<std::array<std::future<std::pair<gls::Vector<3>, int>>, hTiles>, vTiles> results;
-    for (int y = 0; y < vTiles; y++)
-    {
-        for (int x = 0; x < hTiles; x++)
-        {
-            results[y][x] = threadPool.enqueue([x, y, tileWidth, tileHeight, rgb_ycbcr, white, black, bayerPattern, &rawImage, &scale_mul]() -> std::pair<gls::Vector<3>, int>
-                                               {
+    for (int y = 0; y < vTiles; y++) {
+        for (int x = 0; x < hTiles; x++) {
+            results[y][x] = threadPool.enqueue([x, y, tileWidth, tileHeight, rgb_ycbcr, white,
+                                                black, bayerPattern, &rawImage,
+                                                &scale_mul]() -> std::pair<gls::Vector<3>, int> {
                 int tile_x = x * tileWidth;
                 int tile_y = y * tileHeight;
-                const auto rawTile = gls::image<gls::luma_pixel_16>(rawImage, tile_x, tile_y, tileWidth, tileHeight);
-                return autoWhiteBalanceKernel(rawTile, rgb_ycbcr, scale_mul, white, black, bayerPattern, /*highlightsFraction=*/ 0.01); });
+                const auto rawTile =
+                    gls::image<gls::luma_pixel_16>(rawImage, tile_x, tile_y, tileWidth, tileHeight);
+                return autoWhiteBalanceKernel(rawTile, rgb_ycbcr, scale_mul, white, black,
+                                              bayerPattern, /*highlightsFraction=*/0.01);
+            });
         }
     }
 
     gls::Vector<3> wbGain = {0, 0, 0};
     float highlightPixels = 0;
-    for (int y = 0; y < vTiles; y++)
-    {
-        for (int x = 0; x < hTiles; x++)
-        {
-            const auto &res = results[y][x].get();
+    for (int y = 0; y < vTiles; y++) {
+        for (int x = 0; x < hTiles; x++) {
+            const auto& res = results[y][x].get();
             wbGain += res.first;
             highlightPixels += res.second;
         }
@@ -1111,34 +999,32 @@ gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16> &rawImage, 
     wbGain /= (float)vTiles * hTiles;
     wbGain /= (float)wbGain[1];
     highlightPixels /= rawImage.width * rawImage.height / 4;
-    if (highlights)
-    {
+    if (highlights) {
         *highlights = highlightPixels;
     }
 
     auto t_end = std::chrono::high_resolution_clock::now();
     double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
     const auto diff = lenght(wbGain - scale_mul);
-    // std::cout << "wbGain: " << wbGain << ", wbGain - scale_mul: " << wbGain - scale_mul << ", diffLen: " << diff << ", highlightPixels: " << highlightPixels << ", execution time: " << elapsed_time_ms << "ms." << std::endl;
+    // std::cout << "wbGain: " << wbGain << ", wbGain - scale_mul: " << wbGain - scale_mul << ",
+    // diffLen: " << diff << ", highlightPixels: " << highlightPixels << ", execution time: " <<
+    // elapsed_time_ms << "ms." << std::endl;
 
     return wbGain;
 }
 
 // From https://john-chapman.github.io/2019/03/29/convolution.html
 
-void KernelOptimizeBilinear2d(int width, const std::vector<float> &weightsIn,
-                              std::vector<std::array<float, 3>> *weightsOut)
-{
+void KernelOptimizeBilinear2d(int width, const std::vector<float>& weightsIn,
+                              std::vector<std::array<float, 3>>* weightsOut) {
     const int outWidth = width / 2 + 1;
     const int halfWidth = width / 2;
 
     weightsOut->resize(outWidth * outWidth);
 
     int row, col;
-    for (row = 0; row < width - 1; row += 2)
-    {
-        for (col = 0; col < width - 1; col += 2)
-        {
+    for (row = 0; row < width - 1; row += 2) {
+        for (col = 0; col < width - 1; col += 2) {
             float w1 = weightsIn[(row * width) + col];
             float w2 = weightsIn[(row * width) + col + 1];
             float w3 = weightsIn[((row + 1) * width) + col];
@@ -1166,8 +1052,7 @@ void KernelOptimizeBilinear2d(int width, const std::vector<float> &weightsIn,
         (*weightsOut)[k] = {w3, (float)(col - halfWidth), y3};
     }
 
-    for (col = 0; col < width - 1; col += 2)
-    {
+    for (col = 0; col < width - 1; col += 2) {
         float w1 = weightsIn[(row * width) + col];
         float w2 = weightsIn[(row * width) + col + 1];
         float w3 = w1 + w2;

--- a/src/demosaic_utils.cpp
+++ b/src/demosaic_utils.cpp
@@ -377,9 +377,9 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
             std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) * 65535.0 /
             (demosaicParameters->white_level - demosaicParameters->black_level);
     }
-    printf("scale_mul: %f, %f, %f, %f\n", (demosaicParameters->scale_mul)[0],
-           (demosaicParameters->scale_mul)[1], (demosaicParameters->scale_mul)[2],
-           (demosaicParameters->scale_mul)[3]);
+    // printf("scale_mul: %f, %f, %f, %f\n", (demosaicParameters->scale_mul)[0],
+    //        (demosaicParameters->scale_mul)[1], (demosaicParameters->scale_mul)[2],
+    //        (demosaicParameters->scale_mul)[3]);
 
     return exposure_multiplier;
 }

--- a/src/demosaic_utils.cpp
+++ b/src/demosaic_utils.cpp
@@ -23,7 +23,8 @@
 #include "gls_image.hpp"
 #include "ThreadPool.hpp"
 
-gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3>* pre_mul, const gls::Matrix<3, 3>& cam_xyz) {
+gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3> *pre_mul, const gls::Matrix<3, 3> &cam_xyz)
+{
     // Compute sRGB -> XYZ -> Camera
     auto rgb_cam = cam_xyz * xyz_rgb;
 
@@ -32,18 +33,21 @@ gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3>* pre_mul, const gls::Matrix<3, 3>
     // that highlight clipping is white in both camera and target
     // color spaces, so that clipping doesn't turn pink
 
-    auto cam_white = rgb_cam * gls::Vector<3>({ 1, 1, 1 });
+    auto cam_white = rgb_cam * gls::Vector<3>({1, 1, 1});
 
     gls::Matrix<3, 3> mPreMul = {
-        { 1 / cam_white[0], 0, 0 },
-        { 0, 1 / cam_white[1], 0 },
-        { 0, 0, 1 / cam_white[2] }
-    };
+        {1 / cam_white[0], 0, 0},
+        {0, 1 / cam_white[1], 0},
+        {0, 0, 1 / cam_white[2]}};
 
-    for (int i = 0; i < 3; i++) {
-        if (cam_white[i] > 0.00001) {
+    for (int i = 0; i < 3; i++)
+    {
+        if (cam_white[i] > 0.00001)
+        {
             (*pre_mul)[i] = 1 / cam_white[i];
-        } else {
+        }
+        else
+        {
             throw std::range_error("");
         }
     }
@@ -52,65 +56,75 @@ gls::Matrix<3, 3> cam_xyz_coeff(gls::Vector<3>* pre_mul, const gls::Matrix<3, 3>
     return inverse(mPreMul * rgb_cam);
 }
 
-gls::rectangle alignToQuad(const gls::rectangle& rect) {
+gls::rectangle alignToQuad(const gls::rectangle &rect)
+{
     gls::rectangle alignedRect = rect;
-    if (alignedRect.y & 1) {
+    if (alignedRect.y & 1)
+    {
         alignedRect.y += 1;
         alignedRect.height -= 1;
     }
-    if (alignedRect.height & 1) {
+    if (alignedRect.height & 1)
+    {
         alignedRect.height -= 1;
     }
-    if (alignedRect.x & 1) {
+    if (alignedRect.x & 1)
+    {
         alignedRect.x += 1;
         alignedRect.width -= 1;
     }
-    if (alignedRect.width & 1) {
+    if (alignedRect.width & 1)
+    {
         alignedRect.width -= 1;
     }
     return alignedRect;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::span<const float>& s) {
-    for (int i = 0; i < s.size(); i++) {
+std::ostream &operator<<(std::ostream &os, const std::span<const float> &s)
+{
+    for (int i = 0; i < s.size(); i++)
+    {
         os << s[i];
-        if (i < s.size() - 1) {
+        if (i < s.size() - 1)
+        {
             os << ", ";
         }
     }
     return os;
 }
 
-void matrixFromColorChecker(const std::array<RawPatchStats, 24>& rawStats, gls::Matrix<3, 3>* cam_xyz, gls::Vector<3>* pre_mul) {
-// ColorChecker Chart under 6500-kelvin illumination
-  static const gls::Matrix<24, 3> gmb_xyY = {
-    { 0.400, 0.350, 10.1 },        // Dark Skin
-    { 0.377, 0.345, 35.8 },        // Light Skin
-    { 0.247, 0.251, 19.3 },        // Blue Sky
-    { 0.337, 0.422, 13.3 },        // Foliage
-    { 0.265, 0.240, 24.3 },        // Blue Flower
-    { 0.261, 0.343, 43.1 },        // Bluish Green
-    { 0.506, 0.407, 30.1 },        // Orange
-    { 0.211, 0.175, 12.0 },        // Purplish Blue
-    { 0.453, 0.306, 19.8 },        // Moderate Red
-    { 0.285, 0.202, 6.6  },        // Purple
-    { 0.380, 0.489, 44.3 },        // Yellow Green
-    { 0.473, 0.438, 43.1 },        // Orange Yellow
-    { 0.187, 0.129, 6.1  },        // Blue
-    { 0.305, 0.478, 23.4 },        // Green
-    { 0.539, 0.313, 12.0 },        // Red
-    { 0.448, 0.470, 59.1 },        // Yellow
-    { 0.364, 0.233, 19.8 },        // Magenta
-    { 0.196, 0.252, 19.8 },        // Cyan
-    { 0.310, 0.316, 90.0 },        // White
-    { 0.310, 0.316, 59.1 },        // Neutral 8
-    { 0.310, 0.316, 36.2 },        // Neutral 6.5
-    { 0.310, 0.316, 19.8 },        // Neutral 5
-    { 0.310, 0.316, 9.0 },         // Neutral 3.5
-    { 0.310, 0.316, 3.1 } };       // Black
+void matrixFromColorChecker(const std::array<RawPatchStats, 24> &rawStats, gls::Matrix<3, 3> *cam_xyz, gls::Vector<3> *pre_mul)
+{
+    // ColorChecker Chart under 6500-kelvin illumination
+    static const gls::Matrix<24, 3> gmb_xyY = {
+        {0.400, 0.350, 10.1}, // Dark Skin
+        {0.377, 0.345, 35.8}, // Light Skin
+        {0.247, 0.251, 19.3}, // Blue Sky
+        {0.337, 0.422, 13.3}, // Foliage
+        {0.265, 0.240, 24.3}, // Blue Flower
+        {0.261, 0.343, 43.1}, // Bluish Green
+        {0.506, 0.407, 30.1}, // Orange
+        {0.211, 0.175, 12.0}, // Purplish Blue
+        {0.453, 0.306, 19.8}, // Moderate Red
+        {0.285, 0.202, 6.6},  // Purple
+        {0.380, 0.489, 44.3}, // Yellow Green
+        {0.473, 0.438, 43.1}, // Orange Yellow
+        {0.187, 0.129, 6.1},  // Blue
+        {0.305, 0.478, 23.4}, // Green
+        {0.539, 0.313, 12.0}, // Red
+        {0.448, 0.470, 59.1}, // Yellow
+        {0.364, 0.233, 19.8}, // Magenta
+        {0.196, 0.252, 19.8}, // Cyan
+        {0.310, 0.316, 90.0}, // White
+        {0.310, 0.316, 59.1}, // Neutral 8
+        {0.310, 0.316, 36.2}, // Neutral 6.5
+        {0.310, 0.316, 19.8}, // Neutral 5
+        {0.310, 0.316, 9.0},  // Neutral 3.5
+        {0.310, 0.316, 3.1}}; // Black
 
     gls::Matrix<24, 3> gmb_xyz;
-    for (int sq = 0; sq < 24; sq++) {
+    for (int sq = 0; sq < 24; sq++)
+    {
         gmb_xyz[sq][0] = gmb_xyY[sq][2] * gmb_xyY[sq][0] / gmb_xyY[sq][1];
         gmb_xyz[sq][1] = gmb_xyY[sq][2];
         gmb_xyz[sq][2] = gmb_xyY[sq][2] * (1 - gmb_xyY[sq][0] - gmb_xyY[sq][1]) / gmb_xyY[sq][1];
@@ -118,11 +132,15 @@ void matrixFromColorChecker(const std::array<RawPatchStats, 24>& rawStats, gls::
 
     gls::Matrix<24, 3> inverse = pseudoinverse(gmb_xyz);
 
-    for (int pass=0; pass < 2; pass++) {
-        for (int i = 0; i < 3 /* colors */; i++) {
-            for (int j = 0; j < 3; j++) {
+    for (int pass = 0; pass < 2; pass++)
+    {
+        for (int i = 0; i < 3 /* colors */; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
                 (*cam_xyz)[i][j] = 0;
-                for (int k = 0; k < 24; k++) {
+                for (int k = 0; k < 24; k++)
+                {
                     (*cam_xyz)[i][j] += rawStats[k].mean[i] * inverse[k][j];
                 }
             }
@@ -139,51 +157,56 @@ void matrixFromColorChecker(const std::array<RawPatchStats, 24>& rawStats, gls::
     std::cout << "ColorChecker White Point: " << std::fixed << std::setw(6) << std::setprecision(4) << *pre_mul << std::endl;
 }
 
-void colorcheck(const gls::image<gls::luma_pixel_16>& rawImage, BayerPattern bayerPattern, uint32_t black, std::array<gls::rectangle, 24> gmb_samples) {
-// ColorChecker Chart under 6500-kelvin illumination
-  static gls::Matrix<24, 3> gmb_xyY = {
-    { 0.400, 0.350, 10.1 },        // Dark Skin
-    { 0.377, 0.345, 35.8 },        // Light Skin
-    { 0.247, 0.251, 19.3 },        // Blue Sky
-    { 0.337, 0.422, 13.3 },        // Foliage
-    { 0.265, 0.240, 24.3 },        // Blue Flower
-    { 0.261, 0.343, 43.1 },        // Bluish Green
-    { 0.506, 0.407, 30.1 },        // Orange
-    { 0.211, 0.175, 12.0 },        // Purplish Blue
-    { 0.453, 0.306, 19.8 },        // Moderate Red
-    { 0.285, 0.202, 6.6  },        // Purple
-    { 0.380, 0.489, 44.3 },        // Yellow Green
-    { 0.473, 0.438, 43.1 },        // Orange Yellow
-    { 0.187, 0.129, 6.1  },        // Blue
-    { 0.305, 0.478, 23.4 },        // Green
-    { 0.539, 0.313, 12.0 },        // Red
-    { 0.448, 0.470, 59.1 },        // Yellow
-    { 0.364, 0.233, 19.8 },        // Magenta
-    { 0.196, 0.252, 19.8 },        // Cyan
-    { 0.310, 0.316, 90.0 },        // White
-    { 0.310, 0.316, 59.1 },        // Neutral 8
-    { 0.310, 0.316, 36.2 },        // Neutral 6.5
-    { 0.310, 0.316, 19.8 },        // Neutral 5
-    { 0.310, 0.316, 9.0 },         // Neutral 3.5
-    { 0.310, 0.316, 3.1 } };       // Black
+void colorcheck(const gls::image<gls::luma_pixel_16> &rawImage, BayerPattern bayerPattern, uint32_t black, std::array<gls::rectangle, 24> gmb_samples)
+{
+    // ColorChecker Chart under 6500-kelvin illumination
+    static gls::Matrix<24, 3> gmb_xyY = {
+        {0.400, 0.350, 10.1}, // Dark Skin
+        {0.377, 0.345, 35.8}, // Light Skin
+        {0.247, 0.251, 19.3}, // Blue Sky
+        {0.337, 0.422, 13.3}, // Foliage
+        {0.265, 0.240, 24.3}, // Blue Flower
+        {0.261, 0.343, 43.1}, // Bluish Green
+        {0.506, 0.407, 30.1}, // Orange
+        {0.211, 0.175, 12.0}, // Purplish Blue
+        {0.453, 0.306, 19.8}, // Moderate Red
+        {0.285, 0.202, 6.6},  // Purple
+        {0.380, 0.489, 44.3}, // Yellow Green
+        {0.473, 0.438, 43.1}, // Orange Yellow
+        {0.187, 0.129, 6.1},  // Blue
+        {0.305, 0.478, 23.4}, // Green
+        {0.539, 0.313, 12.0}, // Red
+        {0.448, 0.470, 59.1}, // Yellow
+        {0.364, 0.233, 19.8}, // Magenta
+        {0.196, 0.252, 19.8}, // Cyan
+        {0.310, 0.316, 90.0}, // White
+        {0.310, 0.316, 59.1}, // Neutral 8
+        {0.310, 0.316, 36.2}, // Neutral 6.5
+        {0.310, 0.316, 19.8}, // Neutral 5
+        {0.310, 0.316, 9.0},  // Neutral 3.5
+        {0.310, 0.316, 3.1}}; // Black
 
     const auto offsets = bayerOffsets[bayerPattern];
 
-    auto* writeRawImage = (gls::image<gls::luma_pixel_16>*) &rawImage;
+    auto *writeRawImage = (gls::image<gls::luma_pixel_16> *)&rawImage;
 
     gls::Matrix<24, 4> gmb_cam;
     gls::Matrix<24, 3> gmb_xyz;
 
-    for (int sq = 0; sq < 24; sq++) {
+    for (int sq = 0; sq < 24; sq++)
+    {
         gmb_cam[sq] = {0, 0, 0, 0};
-        std::array<int, 3> count = { 0, 0, 0 };
+        std::array<int, 3> count = {0, 0, 0};
         auto patch = alignToQuad(gmb_samples[sq]);
-        for (int y = patch.y; y < patch.y + patch.height; y += 2) {
-            for (int x = patch.x; x < patch.x + patch.width; x += 2) {
-                for (int c = 0; c < 4; c++) {
-                    const auto& o = offsets[c];
+        for (int y = patch.y; y < patch.y + patch.height; y += 2)
+        {
+            for (int x = patch.x; x < patch.x + patch.width; x += 2)
+            {
+                for (int c = 0; c < 4; c++)
+                {
+                    const auto &o = offsets[c];
                     int val = rawImage[y + o.y][x + o.x];
-                    gmb_cam[sq][c == 3 ? 1 : c] += (float) val;
+                    gmb_cam[sq][c == 3 ? 1 : c] += (float)val;
                     count[c == 3 ? 1 : c]++;
                     // Mark image to identify sampled areas
                     (*writeRawImage)[y + o.y][x + o.x] = black + (val - black) / 2;
@@ -191,8 +214,9 @@ void colorcheck(const gls::image<gls::luma_pixel_16>& rawImage, BayerPattern bay
             }
         }
 
-        for (int c = 0; c < 3; c++) {
-            gmb_cam[sq][c] = gmb_cam[sq][c] / (float) count[c] - (float) black;
+        for (int c = 0; c < 3; c++)
+        {
+            gmb_cam[sq][c] = gmb_cam[sq][c] / (float)count[c] - (float)black;
         }
 
         gmb_xyz[sq][0] = gmb_xyY[sq][2] * gmb_xyY[sq][0] / gmb_xyY[sq][1];
@@ -203,9 +227,12 @@ void colorcheck(const gls::image<gls::luma_pixel_16>& rawImage, BayerPattern bay
     gls::Matrix<24, 3> inverse = pseudoinverse(gmb_xyz);
 
     gls::Matrix<3, 3> cam_xyz;
-    for (int pass=0; pass < 2; pass++) {
-        for (int i = 0; i < 3 /* colors */; i++) {
-            for (int j = 0; j < 3; j++) {
+    for (int pass = 0; pass < 2; pass++)
+    {
+        for (int i = 0; i < 3 /* colors */; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
                 cam_xyz[i][j] = 0;
                 for (int k = 0; k < 24; k++)
                     cam_xyz[i][j] += gmb_cam[k][i] * inverse[k][j];
@@ -216,86 +243,101 @@ void colorcheck(const gls::image<gls::luma_pixel_16>& rawImage, BayerPattern bay
         cam_xyz_coeff(&pre_mul, cam_xyz);
 
         gls::Vector<4> balance;
-        for (int c = 0; c < 4; c++) {
+        for (int c = 0; c < 4; c++)
+        {
             balance[c] = pre_mul[c == 3 ? 1 : c] * gmb_cam[20][c];
         }
-        for (int sq = 0; sq < 24; sq++) {
-            for (int c = 0; c < 4; c++) {
+        for (int sq = 0; sq < 24; sq++)
+        {
+            for (int c = 0; c < 4; c++)
+            {
                 gmb_cam[sq][c] *= balance[c];
             }
         }
     }
 
     float norm = 1 / (cam_xyz[1][0] + cam_xyz[1][1] + cam_xyz[1][2]);
-    printf("DCRaw Color Matrix: ");
-    for (int c = 0; c < 3; c++) {
-        for (int j = 0; j < 3; j++)
-            printf("%.4f, ", cam_xyz[c][j] * norm);
-    }
-    printf("\n");
+    // printf("DCRaw Color Matrix: ");
+    // for (int c = 0; c < 3; c++)
+    // {
+    // for (int j = 0; j < 3; j++)
+    // printf("%.4f, ", cam_xyz[c][j] * norm);
+    // }
+    // printf("\n");
 }
 
-void white_balance(const gls::image<gls::luma_pixel_16>& rawImage, gls::Vector<3>* wb_mul, uint32_t white, uint32_t black, BayerPattern bayerPattern) {
+void white_balance(const gls::image<gls::luma_pixel_16> &rawImage, gls::Vector<3> *wb_mul, uint32_t white, uint32_t black, BayerPattern bayerPattern)
+{
     const auto offsets = bayerOffsets[bayerPattern];
 
-    std::array<float, 8> fsum { /* zero */ };
-    for (int y = 0; y < rawImage.height/2; y += 8) {
-        for (int x = 0; x < rawImage.width/2; x += 8) {
-            std::array<uint32_t, 8> sum { /* zero */ };
-            for (int j = y; j < 8 && j < rawImage.height/2; j++) {
-                for (int i = x; i < 8 && i < rawImage.width/2; i++) {
-                    for (int c = 0; c < 4; c++) {
-                        const auto& o = offsets[c];
+    std::array<float, 8> fsum{/* zero */};
+    for (int y = 0; y < rawImage.height / 2; y += 8)
+    {
+        for (int x = 0; x < rawImage.width / 2; x += 8)
+        {
+            std::array<uint32_t, 8> sum{/* zero */};
+            for (int j = y; j < 8 && j < rawImage.height / 2; j++)
+            {
+                for (int i = x; i < 8 && i < rawImage.width / 2; i++)
+                {
+                    for (int c = 0; c < 4; c++)
+                    {
+                        const auto &o = offsets[c];
                         uint32_t val = rawImage[2 * j + o.y][2 * i + o.x];
-                        if (val > white - 25) {
+                        if (val > white - 25)
+                        {
                             goto skip_block;
                         }
-                        if ((val -= black) < 0) {
+                        if ((val -= black) < 0)
+                        {
                             val = 0;
                         }
                         sum[c] += val;
-                        sum[c+4]++;
+                        sum[c + 4]++;
                     }
                 }
             }
-            for (int i = 0; i < 8; i++) {
-                fsum[i] += (float) sum[i];
+            for (int i = 0; i < 8; i++)
+            {
+                fsum[i] += (float)sum[i];
             }
-            skip_block:
-            ;
+        skip_block:;
         }
     }
     // Aggregate green2 data to green
     fsum[1] += fsum[3];
     fsum[5] += fsum[7];
 
-    for (int c = 0; c < 3; c++) {
-        if (fsum[c] != 0) {
-            (*wb_mul)[c] = fsum[c+4] / fsum[c];
+    for (int c = 0; c < 3; c++)
+    {
+        if (fsum[c] != 0)
+        {
+            (*wb_mul)[c] = fsum[c + 4] / fsum[c];
         }
     }
     // Normalize with green = 1
     *wb_mul = *wb_mul / (*wb_mul)[1];
 }
 
-float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
-                        gls::tiff_metadata* dng_metadata,
-                        DemosaicParameters* demosaicParameters,
-                        bool auto_white_balance, const gls::rectangle* gmb_position,
-                        bool rotate_180, float* highlights) {
+float unpackDNGMetadata(const gls::image<gls::luma_pixel_16> &rawImage,
+                        gls::tiff_metadata *dng_metadata,
+                        DemosaicParameters *demosaicParameters,
+                        bool auto_white_balance, const gls::rectangle *gmb_position,
+                        bool rotate_180, float *highlights)
+{
     const auto color_matrix1 = getVector<float>(*dng_metadata, TIFFTAG_COLORMATRIX1);
     const auto color_matrix2 = getVector<float>(*dng_metadata, TIFFTAG_COLORMATRIX2);
 
     // If present ColorMatrix2 is usually D65 and ColorMatrix1 is Standard Light A
-    const auto& color_matrix = color_matrix2.empty() ? color_matrix1 : color_matrix2;
+    const auto &color_matrix = color_matrix2.empty() ? color_matrix1 : color_matrix2;
 
     auto as_shot_neutral = getVector<float>(*dng_metadata, TIFFTAG_ASSHOTNEUTRAL);
-    std::cout << "as_shot_neutral: " << gls::Vector<3>(as_shot_neutral) << std::endl;
+    // std::cout << "as_shot_neutral: " << gls::Vector<3>(as_shot_neutral) << std::endl;
 
     float baseline_exposure = 0;
     getValue(*dng_metadata, TIFFTAG_BASELINEEXPOSURE, &baseline_exposure);
     float exposure_multiplier = pow(2.0, baseline_exposure);
-    std::cout << "baseline_exposure: " << baseline_exposure  << ", exposure_multiplier: " << exposure_multiplier << std::endl;
+    // std::cout << "baseline_exposure: " << baseline_exposure  << ", exposure_multiplier: " << exposure_multiplier << std::endl;
 
     const auto black_level_vec = getVector<float>(*dng_metadata, TIFFTAG_BLACKLEVEL);
     const auto white_level_vec = getVector<uint32_t>(*dng_metadata, TIFFTAG_WHITELEVEL);
@@ -305,16 +347,17 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
     demosaicParameters->white_level = white_level_vec.empty() ? 0xffff : white_level_vec[0];
     demosaicParameters->exposure_multiplier = std::min(exposure_multiplier, 1.0f);
 
-    demosaicParameters->bayerPattern = std::memcmp(cfa_pattern.data(), "\00\01\01\02", 4) == 0 ? BayerPattern::rggb
-                                     : std::memcmp(cfa_pattern.data(), "\02\01\01\00", 4) == 0 ? BayerPattern::bggr
-                                     : std::memcmp(cfa_pattern.data(), "\01\00\02\01", 4) == 0 ? BayerPattern::grbg
-                                     : BayerPattern::gbrg;
+    demosaicParameters->bayerPattern = std::memcmp(cfa_pattern.data(), "\00\01\01\02", 4) == 0   ? BayerPattern::rggb
+                                       : std::memcmp(cfa_pattern.data(), "\02\01\01\00", 4) == 0 ? BayerPattern::bggr
+                                       : std::memcmp(cfa_pattern.data(), "\01\00\02\01", 4) == 0 ? BayerPattern::grbg
+                                                                                                 : BayerPattern::gbrg;
 
-    std::cout << "bayerPattern: " << BayerPatternName[demosaicParameters->bayerPattern] << std::endl;
+    // std::cout << "bayerPattern: " << BayerPatternName[demosaicParameters->bayerPattern] << std::endl;
 
     gls::Vector<3> pre_mul;
     gls::Matrix<3, 3> cam_xyz;
-    if (gmb_position) {
+    if (gmb_position)
+    {
         demosaicParameters->noiseModel.rawNlf = estimateRawParameters(rawImage, &cam_xyz, &pre_mul,
                                                                       demosaicParameters->black_level,
                                                                       demosaicParameters->white_level,
@@ -323,23 +366,28 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
 
         // Obtain the rgb_cam matrix and pre_mul
         demosaicParameters->rgb_cam = cam_xyz_coeff(&pre_mul, cam_xyz);
-    } else {
+    }
+    else
+    {
         cam_xyz = color_matrix;
         // Obtain the rgb_cam matrix and pre_mul
         demosaicParameters->rgb_cam = cam_xyz_coeff(&pre_mul, cam_xyz);
 
         // If cam_mul is available use that instead of pre_mul
-        if (!as_shot_neutral.empty() && !auto_white_balance) {
+        if (!as_shot_neutral.empty() && !auto_white_balance)
+        {
             pre_mul = 1.0f / gls::Vector<3>(as_shot_neutral);
         }
     }
 
-    std::cout << "cam_xyz: " << std::fixed << std::setprecision(4) << cam_xyz.span() << std::endl;
-    std::cout << "*** pre_mul: " << pre_mul / pre_mul[1] << std::endl;
+    // std::cout << "cam_xyz: " << std::fixed << std::setprecision(4) << cam_xyz.span() << std::endl;
+    // std::cout << "*** pre_mul: " << pre_mul / pre_mul[1] << std::endl;
 
-    if (auto_white_balance) {
+    if (auto_white_balance)
+    {
         auto minmax = std::minmax_element(std::begin(pre_mul), std::end(pre_mul));
-        for (int c = 0; c < 4; c++) {
+        for (int c = 0; c < 4; c++)
+        {
             int pre_mul_idx = c == 3 ? 1 : c;
             (demosaicParameters->scale_mul)[c] = std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) * 65535.0 / (demosaicParameters->white_level - demosaicParameters->black_level);
         }
@@ -350,25 +398,27 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
                                                   demosaicParameters->black_level, demosaicParameters->bayerPattern,
                                                   highlights);
 
-        printf("Auto White Balance: %f, %f, %f\n", cam_mul[0], cam_mul[1], cam_mul[2]);
+        // printf("Auto White Balance: %f, %f, %f\n", cam_mul[0], cam_mul[1], cam_mul[2]);
 
         // Convert cam_mul from camera to XYZ
         const auto cam_mul_xyz = cam_xyz * cam_mul;
-        std::cout << "cam_mul_xyz: " << cam_mul_xyz << ", CCT: " << XYZtoCorColorTemp(cam_mul_xyz) << std::endl;
+        // std::cout << "cam_mul_xyz: " << cam_mul_xyz << ", CCT: " << XYZtoCorColorTemp(cam_mul_xyz) << std::endl;
 
-        for (int c = 0; c < 3; c++) {
+        for (int c = 0; c < 3; c++)
+        {
             as_shot_neutral[c] = 1 / cam_mul[c];
         }
         (*dng_metadata)[TIFFTAG_ASSHOTNEUTRAL] = as_shot_neutral;
 
         pre_mul = cam_mul;
 
-        std::cout << "*** auto_white_balance pre_mul: " << pre_mul / pre_mul[1] << std::endl;
+        // std::cout << "*** auto_white_balance pre_mul: " << pre_mul / pre_mul[1] << std::endl;
     }
 
     // Scale Input Image
     auto minmax = std::minmax_element(std::begin(pre_mul), std::end(pre_mul));
-    for (int c = 0; c < 4; c++) {
+    for (int c = 0; c < 4; c++)
+    {
         int pre_mul_idx = c == 3 ? 1 : c;
         (demosaicParameters->scale_mul)[c] = std::max(exposure_multiplier, 1.0f) * (pre_mul[pre_mul_idx] / *minmax.first) * 65535.0 / (demosaicParameters->white_level - demosaicParameters->black_level);
     }
@@ -377,7 +427,7 @@ float unpackDNGMetadata(const gls::image<gls::luma_pixel_16>& rawImage,
     return exposure_multiplier;
 }
 
-const char* GMBColorNames[24] {
+const char *GMBColorNames[24]{
     "DarkSkin",
     "LightSkin",
     "BlueSky",
@@ -401,31 +451,39 @@ const char* GMBColorNames[24] {
     "Neutral_6_5",
     "Neutral_5",
     "Neutral_3_5",
-    "Black"
-};
+    "Black"};
 
-float square(float x) {
+float square(float x)
+{
     return x * x;
 }
 
-enum { red = 0, green = 1, blue = 2, green2 = 3 };
+enum
+{
+    red = 0,
+    green = 1,
+    blue = 2,
+    green2 = 3
+};
 
 // Collect mean and variance of ColorChecker patches
-void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float black_level, float white_level, BayerPattern bayerPattern, const gls::rectangle& gmb_position, bool rotate_180, std::array<RawPatchStats, 24>* stats) {
-    gls::image<gls::luma_pixel_16> red_channel(rawImage.width/2, rawImage.height/2);
-    gls::image<gls::luma_pixel_16> green_channel(rawImage.width/2, rawImage.height/2);
-    gls::image<gls::luma_pixel_16> blue_channel(rawImage.width/2, rawImage.height/2);
-    gls::image<gls::luma_pixel_16> green2_channel(rawImage.width/2, rawImage.height/2);
-    for (int i = 0; i < green_channel.pixels().size(); i++) {
+void colorCheckerRawStats(const gls::image<gls::luma_pixel_16> &rawImage, float black_level, float white_level, BayerPattern bayerPattern, const gls::rectangle &gmb_position, bool rotate_180, std::array<RawPatchStats, 24> *stats)
+{
+    gls::image<gls::luma_pixel_16> red_channel(rawImage.width / 2, rawImage.height / 2);
+    gls::image<gls::luma_pixel_16> green_channel(rawImage.width / 2, rawImage.height / 2);
+    gls::image<gls::luma_pixel_16> blue_channel(rawImage.width / 2, rawImage.height / 2);
+    gls::image<gls::luma_pixel_16> green2_channel(rawImage.width / 2, rawImage.height / 2);
+    for (int i = 0; i < green_channel.pixels().size(); i++)
+    {
         red_channel.pixels()[i].luma = 0;
         green_channel.pixels()[i].luma = 0;
         blue_channel.pixels()[i].luma = 0;
         green2_channel.pixels()[i].luma = 0;
     }
 
-//    gls::image<gls::luma_pixel_16>* zapMama = (gls::image<gls::luma_pixel_16> *) &rawImage;
+    //    gls::image<gls::luma_pixel_16>* zapMama = (gls::image<gls::luma_pixel_16> *) &rawImage;
 
-    std::cout << "colorCheckerRawStats rectangle: " << gmb_position.x << ", " << gmb_position.y << ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
+    // std::cout << "colorCheckerRawStats rectangle: " << gmb_position.x << ", " << gmb_position.y << ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
 
     int patch_width = gmb_position.width / 6;
     int patch_height = gmb_position.height / 4;
@@ -437,13 +495,14 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float 
     const gls::point g2 = offsets[green2];
 
     int patchIdx = 0;
-    for (int row = 0; row < 4; row++) {
-        for (int col = 0; col < 6; col++, patchIdx++) {
-            gls::rectangle patch = alignToQuad({
-                gmb_position.x + col * patch_width + (int) (0.25 * patch_width),
-                gmb_position.y + row * patch_height + (int) (0.25 * patch_height),
-                (int) (0.5 * patch_width),
-                (int) (0.5 * patch_height) });
+    for (int row = 0; row < 4; row++)
+    {
+        for (int col = 0; col < 6; col++, patchIdx++)
+        {
+            gls::rectangle patch = alignToQuad({gmb_position.x + col * patch_width + (int)(0.25 * patch_width),
+                                                gmb_position.y + row * patch_height + (int)(0.25 * patch_height),
+                                                (int)(0.5 * patch_width),
+                                                (int)(0.5 * patch_height)});
 
             const int patchSamples = patch.width * patch.height / 4;
 
@@ -452,16 +511,17 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float 
             float avgR = 0;
             float avgB = 0;
 
-            for (int y = 0; y < patch.height; y += 2) {
-                for (int x = 0; x < patch.width; x += 2) {
+            for (int y = 0; y < patch.height; y += 2)
+            {
+                for (int x = 0; x < patch.width; x += 2)
+                {
                     const int y_off = patch.y + y;
                     const int x_off = patch.x + x;
                     gls::rgba_pixel_fp32 p = {
                         std::clamp((rawImage[y_off + r.y][x_off + r.x] - black_level) / white_level, 0.0f, 1.0f),
                         std::clamp((rawImage[y_off + g.y][x_off + g.x] - black_level) / white_level, 0.0f, 1.0f),
                         std::clamp((rawImage[y_off + b.y][x_off + b.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level, 0.0f, 1.0f)
-                    };
+                        std::clamp((rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level, 0.0f, 1.0f)};
 
                     avgR += p[0];
                     avgG1 += p[1];
@@ -480,31 +540,32 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float 
             float varB = 0;
             float varG2 = 0;
 
-            for (int y = 0; y < patch.height; y += 2) {
-                for (int x = 0; x < patch.width; x += 2) {
+            for (int y = 0; y < patch.height; y += 2)
+            {
+                for (int x = 0; x < patch.width; x += 2)
+                {
                     const int y_off = patch.y + y;
                     const int x_off = patch.x + x;
                     gls::rgba_pixel_fp32 p = {
                         std::clamp((rawImage[y_off + r.y][x_off + r.x] - black_level) / white_level, 0.0f, 1.0f),
                         std::clamp((rawImage[y_off + g.y][x_off + g.x] - black_level) / white_level, 0.0f, 1.0f),
                         std::clamp((rawImage[y_off + b.y][x_off + b.x] - black_level) / white_level, 0.0f, 1.0f),
-                        std::clamp((rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level, 0.0f, 1.0f)
-                    };
+                        std::clamp((rawImage[y_off + g2.y][x_off + g2.x] - black_level) / white_level, 0.0f, 1.0f)};
 
-                    red_channel[(patch.y + y)/2][(patch.x + x)/2] = 0xffff * p.red;
-                    green_channel[(patch.y + y)/2][(patch.x + x)/2] = 0xffff * p.green;
-                    blue_channel[(patch.y + y)/2][(patch.x + x)/2] = 0xffff * p.blue;
-                    green2_channel[(patch.y + y)/2][(patch.x + x)/2] = 0xffff * p.alpha;
+                    red_channel[(patch.y + y) / 2][(patch.x + x) / 2] = 0xffff * p.red;
+                    green_channel[(patch.y + y) / 2][(patch.x + x) / 2] = 0xffff * p.green;
+                    blue_channel[(patch.y + y) / 2][(patch.x + x) / 2] = 0xffff * p.blue;
+                    green2_channel[(patch.y + y) / 2][(patch.x + x) / 2] = 0xffff * p.alpha;
 
                     varR += square(p[0] - avgR);
                     varG1 += square(p[1] - avgG1);
                     varB += square(p[2] - avgB);
                     varG2 += square(p[3] - avgG2);
 
-//                    (*zapMama)[y_off + r.y][x_off + r.x] = 0.0f;
-//                    (*zapMama)[y_off + g.y][x_off + g.x] = 0.0f;
-//                    (*zapMama)[y_off + b.y][x_off + b.x] = 0.0f;
-//                    (*zapMama)[y_off + g2.y][x_off + g2.x] = 0.0f;
+                    //                    (*zapMama)[y_off + r.y][x_off + r.x] = 0.0f;
+                    //                    (*zapMama)[y_off + g.y][x_off + g.x] = 0.0f;
+                    //                    (*zapMama)[y_off + b.y][x_off + b.x] = 0.0f;
+                    //                    (*zapMama)[y_off + g2.y][x_off + g2.x] = 0.0f;
                 }
             }
 
@@ -517,16 +578,17 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float 
         }
     }
 
-    if (rotate_180) {
+    if (rotate_180)
+    {
         std::reverse(stats->begin(), stats->end());
     }
 
-//    for (int patchIdx = 0; patchIdx < 24; patchIdx++) {
-//        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg: {"
-//                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " << (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << ", " << (*stats)[patchIdx].mean[3] << "}, var: {"
-//                                          << (*stats)[patchIdx].variance[0] << ", " << (*stats)[patchIdx].variance[1] << ", " << (*stats)[patchIdx].variance[2] << ", " << (*stats)[patchIdx].variance[3] << "}" << std::endl;
-//
-//    }
+    //    for (int patchIdx = 0; patchIdx < 24; patchIdx++) {
+    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg: {"
+    //                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " << (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << ", " << (*stats)[patchIdx].mean[3] << "}, var: {"
+    //                                          << (*stats)[patchIdx].variance[0] << ", " << (*stats)[patchIdx].variance[1] << ", " << (*stats)[patchIdx].variance[2] << ", " << (*stats)[patchIdx].variance[3] << "}" << std::endl;
+    //
+    //    }
 
     static int file_count = 0;
     red_channel.write_png_file("/Users/fabio/red_channel" + std::to_string(file_count) + ".png", false);
@@ -536,20 +598,23 @@ void colorCheckerRawStats(const gls::image<gls::luma_pixel_16>& rawImage, float 
 }
 
 // Collect mean and variance of ColorChecker patches
-void colorCheckerStats(gls::image<gls::rgba_pixel_float>* image, const gls::rectangle& gmb_position, bool rotate_180, std::array<PatchStats, 24>* stats) {
+void colorCheckerStats(gls::image<gls::rgba_pixel_float> *image, const gls::rectangle &gmb_position, bool rotate_180, std::array<PatchStats, 24> *stats)
+{
     // std::cout << "colorCheckerStats rectangle: " << gmb_position.x << ", " << gmb_position.y << ", " << gmb_position.width << ", " << gmb_position.height << std::endl;
 
     int patch_width = gmb_position.width / 6;
     int patch_height = gmb_position.height / 4;
 
     int patchIdx = 0;
-    for (int row = 0; row < 4; row++) {
-        for (int col = 0; col < 6; col++, patchIdx++) {
+    for (int row = 0; row < 4; row++)
+    {
+        for (int col = 0; col < 6; col++, patchIdx++)
+        {
             gls::rectangle patch = {
-                gmb_position.x + col * patch_width + (int) (0.25 * patch_width),
-                gmb_position.y + row * patch_height + (int) (0.25 * patch_height),
-                (int) (0.5 * patch_width),
-                (int) (0.5 * patch_height) };
+                gmb_position.x + col * patch_width + (int)(0.25 * patch_width),
+                gmb_position.y + row * patch_height + (int)(0.25 * patch_height),
+                (int)(0.5 * patch_width),
+                (int)(0.5 * patch_height)};
 
             int patchSamples = patch.width * patch.height;
 
@@ -557,9 +622,11 @@ void colorCheckerStats(gls::image<gls::rgba_pixel_float>* image, const gls::rect
             float avgCb = 0;
             float avgCr = 0;
 
-            for (int y = 0; y < patch.height; y++) {
-                for (int x = 0; x < patch.width; x++) {
-                    const auto& p = (*image)[patch.y + y][patch.x + x];
+            for (int y = 0; y < patch.height; y++)
+            {
+                for (int x = 0; x < patch.width; x++)
+                {
+                    const auto &p = (*image)[patch.y + y][patch.x + x];
                     avgY += p[0];
                     avgCb += p[1];
                     avgCr += p[2];
@@ -574,9 +641,11 @@ void colorCheckerStats(gls::image<gls::rgba_pixel_float>* image, const gls::rect
             float varCb = 0;
             float varCr = 0;
 
-            for (int y = 0; y < patch.height; y++) {
-                for (int x = 0; x < patch.width; x++) {
-                    const auto& p = (*image)[patch.y + y][patch.x + x];
+            for (int y = 0; y < patch.height; y++)
+            {
+                for (int x = 0; x < patch.width; x++)
+                {
+                    const auto &p = (*image)[patch.y + y][patch.x + x];
                     varY += square(p[0] - avgY);
                     varCb += square(p[1] - avgCb);
                     varCr += square(p[2] - avgCr);
@@ -593,41 +662,46 @@ void colorCheckerStats(gls::image<gls::rgba_pixel_float>* image, const gls::rect
         }
     }
 
-    if (rotate_180) {
+    if (rotate_180)
+    {
         std::reverse(stats->begin(), stats->end());
     }
 
-//    for (int patchIdx = 0; patchIdx < 24; patchIdx++) {
-//        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg: {"
-//                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " << (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << "}, var: {"
-//                                          << (*stats)[patchIdx].variance[0] << ", " << (*stats)[patchIdx].variance[1] << ", " << (*stats)[patchIdx].variance[2] << "}" << std::endl;
-//    }
+    //    for (int patchIdx = 0; patchIdx < 24; patchIdx++) {
+    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patchIdx] << " - avg: {"
+    //                  << std::setprecision(2) << (*stats)[patchIdx].mean[0] << ", " << (*stats)[patchIdx].mean[1] << ", " << (*stats)[patchIdx].mean[2] << "}, var: {"
+    //                                          << (*stats)[patchIdx].variance[0] << ", " << (*stats)[patchIdx].variance[1] << ", " << (*stats)[patchIdx].variance[2] << "}" << std::endl;
+    //    }
 }
 
 // Slope Regression of a set of points
 template <size_t N>
-std::pair<float, float> linear_regression(const gls::Vector<N>& x, const gls::Vector<N>& y, float *errorSquare = nullptr) {
-    const auto s_x  = std::accumulate(x.begin(), x.end(), 0.0);
-    const auto s_y  = std::accumulate(y.begin(), y.end(), 0.0);
+std::pair<float, float> linear_regression(const gls::Vector<N> &x, const gls::Vector<N> &y, float *errorSquare = nullptr)
+{
+    const auto s_x = std::accumulate(x.begin(), x.end(), 0.0);
+    const auto s_y = std::accumulate(y.begin(), y.end(), 0.0);
     const auto s_xx = std::inner_product(x.begin(), x.end(), x.begin(), 0.0);
     const auto s_xy = std::inner_product(x.begin(), x.end(), y.begin(), 0.0);
-    const auto b    = (N * s_xy - s_x * s_y) / (N * s_xx - s_x * s_x);
-    const auto a    = (s_y - b * s_x) / N;
+    const auto b = (N * s_xy - s_x * s_y) / (N * s_xx - s_x * s_x);
+    const auto a = (s_y - b * s_x) / N;
 
-    if (errorSquare) {
+    if (errorSquare)
+    {
         *errorSquare = 0;
-        for (int i = 0; i < x.size(); i++) {
+        for (int i = 0; i < x.size(); i++)
+        {
             float p = a + b * x[i];
             float diff = p - y[i];
             *errorSquare += diff * diff;
         }
     }
 
-    return { a, b };
+    return {a, b};
 }
 
 // Estimate the Sensor's Noise Level Function (NLF: variance vs intensity), which is linear going through zero
-gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float>* image, const gls::rectangle& gmb_position, bool rotate_180) {
+gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float> *image, const gls::rectangle &gmb_position, bool rotate_180)
+{
     std::array<PatchStats, 24> stats;
     colorCheckerStats(image, gmb_position, rotate_180, &stats);
 
@@ -637,8 +711,7 @@ gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float>* image, c
         stats[Neutral_5].mean[0],
         stats[Neutral_6_5].mean[0],
         stats[Neutral_8].mean[0],
-        stats[White].mean[0]
-    };
+        stats[White].mean[0]};
 
     gls::Vector<6> y_variance = {
         stats[Black].variance[0],
@@ -646,8 +719,7 @@ gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float>* image, c
         stats[Neutral_5].variance[0],
         stats[Neutral_6_5].variance[0],
         stats[Neutral_8].variance[0],
-        stats[White].variance[0]
-    };
+        stats[White].variance[0]};
 
     gls::Vector<6> cb_variance = {
         stats[Black].variance[1],
@@ -655,8 +727,7 @@ gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float>* image, c
         stats[Neutral_5].variance[1],
         stats[Neutral_6_5].variance[1],
         stats[Neutral_8].variance[1],
-        stats[White].variance[1]
-    };
+        stats[White].variance[1]};
 
     gls::Vector<6> cr_variance = {
         stats[Black].variance[2],
@@ -664,30 +735,30 @@ gls::Vector<3> estimateNlfParameters(gls::image<gls::rgba_pixel_float>* image, c
         stats[Neutral_5].variance[2],
         stats[Neutral_6_5].variance[2],
         stats[Neutral_8].variance[2],
-        stats[White].variance[2]
-    };
+        stats[White].variance[2]};
 
-//    std::cout << "NLF Stats:" << std::endl;
-//    for (int patch = Black; patch >= White; patch--) {
-//        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patch] << ": " << std::setprecision(4) << std::scientific << stats[patch].mean[0] << ", "
-//                  << stats[patch].variance[0] << ", " << stats[patch].variance[1] << ", " << stats[patch].variance[2] << std::endl;
-//    }
+    //    std::cout << "NLF Stats:" << std::endl;
+    //    for (int patch = Black; patch >= White; patch--) {
+    //        std::cout << std::setw(12) << std::setfill(' ') << GMBColorNames[patch] << ": " << std::setprecision(4) << std::scientific << stats[patch].mean[0] << ", "
+    //                  << stats[patch].variance[0] << ", " << stats[patch].variance[1] << ", " << stats[patch].variance[2] << std::endl;
+    //    }
 
     float y_err2;
     auto nlf_y = linear_regression(y_intensity, y_variance, &y_err2);
     auto nlf_cb = std::accumulate(cb_variance.begin(), cb_variance.end(), 0.0f) / cb_variance.size();
     auto nlf_cr = std::accumulate(cr_variance.begin(), cr_variance.end(), 0.0f) / cr_variance.size();
 
-    std::cout << std::setprecision(4) << std::scientific
-              << "\nnlf_y: " << nlf_y.first << ":" << nlf_y.second << " (" << y_err2 << ")"
-              << ", nlf_cb: " << nlf_cb << ", nlf_cr: " << nlf_cr << std::endl;
+    // std::cout << std::setprecision(4) << std::scientific
+    //           << "\nnlf_y: " << nlf_y.first << ":" << nlf_y.second << " (" << y_err2 << ")"
+    //           << ", nlf_cb: " << nlf_cb << ", nlf_cr: " << nlf_cr << std::endl;
 
     // NFL for Y passes by 0, just use the slope, NFL for Cb and and Cr is mostly flat, just return the average
     return {nlf_y.second, nlf_cb, nlf_cr};
 }
 
-RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls::Matrix<3, 3>* cam_xyz, gls::Vector<3>* pre_mul,
-                             float black_level, float white_level, BayerPattern bayerPattern, const gls::rectangle& gmb_position, bool rotate_180) {
+RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16> &rawImage, gls::Matrix<3, 3> *cam_xyz, gls::Vector<3> *pre_mul,
+                             float black_level, float white_level, BayerPattern bayerPattern, const gls::rectangle &gmb_position, bool rotate_180)
+{
     std::array<RawPatchStats, 24> rawStats;
     colorCheckerRawStats(rawImage, black_level, white_level, bayerPattern, gmb_position, rotate_180, &rawStats);
 
@@ -697,8 +768,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].mean[0],
         rawStats[Neutral_6_5].mean[0],
         rawStats[Neutral_8].mean[0],
-        rawStats[White].mean[0]
-    };
+        rawStats[White].mean[0]};
 
     gls::Vector<6> green_intensity = {
         rawStats[Black].mean[1],
@@ -706,8 +776,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].mean[1],
         rawStats[Neutral_6_5].mean[1],
         rawStats[Neutral_8].mean[1],
-        rawStats[White].mean[1]
-    };
+        rawStats[White].mean[1]};
 
     gls::Vector<6> blue_intensity = {
         rawStats[Black].mean[2],
@@ -715,8 +784,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].mean[2],
         rawStats[Neutral_6_5].mean[2],
         rawStats[Neutral_8].mean[2],
-        rawStats[White].mean[2]
-    };
+        rawStats[White].mean[2]};
 
     gls::Vector<6> green2_intensity = {
         rawStats[Black].mean[3],
@@ -724,8 +792,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].mean[3],
         rawStats[Neutral_6_5].mean[3],
         rawStats[Neutral_8].mean[3],
-        rawStats[White].mean[3]
-    };
+        rawStats[White].mean[3]};
 
     gls::Vector<6> red_variance = {
         rawStats[Black].variance[0],
@@ -733,8 +800,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].variance[0],
         rawStats[Neutral_6_5].variance[0],
         rawStats[Neutral_8].variance[0],
-        rawStats[White].variance[0]
-    };
+        rawStats[White].variance[0]};
 
     gls::Vector<6> green_variance = {
         rawStats[Black].variance[1],
@@ -742,8 +808,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].variance[1],
         rawStats[Neutral_6_5].variance[1],
         rawStats[Neutral_8].variance[1],
-        rawStats[White].variance[1]
-    };
+        rawStats[White].variance[1]};
 
     gls::Vector<6> blue_variance = {
         rawStats[Black].variance[2],
@@ -751,8 +816,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].variance[2],
         rawStats[Neutral_6_5].variance[2],
         rawStats[Neutral_8].variance[2],
-        rawStats[White].variance[2]
-    };
+        rawStats[White].variance[2]};
 
     gls::Vector<6> green2_variance = {
         rawStats[Black].variance[3],
@@ -760,8 +824,7 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
         rawStats[Neutral_5].variance[3],
         rawStats[Neutral_6_5].variance[3],
         rawStats[Neutral_8].variance[3],
-        rawStats[White].variance[3]
-    };
+        rawStats[White].variance[3]};
 
     // Derive color matrix
     matrixFromColorChecker(rawStats, cam_xyz, pre_mul);
@@ -772,44 +835,45 @@ RawNLF estimateRawParameters(const gls::image<gls::luma_pixel_16>& rawImage, gls
     auto nlf_b = linear_regression(blue_intensity, blue_variance, &b_err2);
     auto nlf_g2 = linear_regression(green2_intensity, green2_variance, &g2_err2);
 
-//    std::cout << std::setprecision(2) << std::scientific
-//              << "raw nlf_r: " << nlf_r.first << ":" << nlf_r.second << " (" << r_err2 << "), "
-//              << "raw nlf_g: " << nlf_g.first << ":" << nlf_g.second << " (" << g_err2 << "), "
-//              << "raw nlf_b: " << nlf_b.first << ":" << nlf_b.second << " (" << b_err2 << "), "
-//              << "raw nlf_g2: " << nlf_g2.first << ":" << nlf_g2.second << " (" << g2_err2 << ")" << std::endl;
+    //    std::cout << std::setprecision(2) << std::scientific
+    //              << "raw nlf_r: " << nlf_r.first << ":" << nlf_r.second << " (" << r_err2 << "), "
+    //              << "raw nlf_g: " << nlf_g.first << ":" << nlf_g.second << " (" << g_err2 << "), "
+    //              << "raw nlf_b: " << nlf_b.first << ":" << nlf_b.second << " (" << b_err2 << "), "
+    //              << "raw nlf_g2: " << nlf_g2.first << ":" << nlf_g2.second << " (" << g2_err2 << ")" << std::endl;
 
-    std::cout << std::setprecision(2) << std::scientific << "raw nlf (r g b g2): "
-              << nlf_r.second << ", "
-              << nlf_g.second << ", "
-              << nlf_b.second << ", "
-              << nlf_g2.second << std::endl;
+    // std::cout << std::setprecision(2) << std::scientific << "raw nlf (r g b g2): "
+    //           << nlf_r.second << ", "
+    //           << nlf_g.second << ", "
+    //           << nlf_b.second << ", "
+    //           << nlf_g2.second << std::endl;
 
-    return { { nlf_r.first, nlf_g.first, nlf_b.first, nlf_g2.first }, { nlf_r.second, nlf_g.second, nlf_b.second, nlf_g2.second } };
+    return {{nlf_r.first, nlf_g.first, nlf_b.first, nlf_g2.first}, {nlf_r.second, nlf_g.second, nlf_b.second, nlf_g2.second}};
 }
 
-gls::Vector<3> extractNlfFromColorChecker(gls::image<gls::rgba_pixel_float>* yCbCrImage, const gls::rectangle gmb_position, bool rotate_180, int scale) {
+gls::Vector<3> extractNlfFromColorChecker(gls::image<gls::rgba_pixel_float> *yCbCrImage, const gls::rectangle gmb_position, bool rotate_180, int scale)
+{
     const gls::rectangle position = {
-        (int) round(gmb_position.x / (float) scale),
-        (int) round(gmb_position.y / (float) scale),
-        (int) round(gmb_position.width / (float) scale),
-        (int) round(gmb_position.height / (float) scale)
-    };
+        (int)round(gmb_position.x / (float)scale),
+        (int)round(gmb_position.y / (float)scale),
+        (int)round(gmb_position.width / (float)scale),
+        (int)round(gmb_position.height / (float)scale)};
     gls::Vector<3> nlf_parameters = estimateNlfParameters(yCbCrImage, position, rotate_180);
-    std::cout << "Scale " << scale << " nlf parameters: " << std::setprecision(4) << std::scientific << nlf_parameters[0] << ", " << nlf_parameters[1] << ", " << nlf_parameters[2] << std::endl;
+    // std::cout << "Scale " << scale << " nlf parameters: " << std::setprecision(4) << std::scientific << nlf_parameters[0] << ", " << nlf_parameters[1] << ", " << nlf_parameters[2] << std::endl;
 
-//    gls::image<gls::rgb_pixel> output(yCbCrImage->width, yCbCrImage->height);
-//    for (int y = 0; y < output.height; y++) {
-//        for (int x = 0; x < output.width; x++) {
-//            const auto& p = (*yCbCrImage)[y][x];
-//            output[y][x] = {clamp_uint8(255 * p[0]), clamp_uint8(128 * p[1] + 127), clamp_uint8(128 * p[2] + 127)};
-//        }
-//    }
-//    output.write_png_file("/Users/fabio/ColorChecker" + std::to_string(scale) + ".png");
+    //    gls::image<gls::rgb_pixel> output(yCbCrImage->width, yCbCrImage->height);
+    //    for (int y = 0; y < output.height; y++) {
+    //        for (int x = 0; x < output.width; x++) {
+    //            const auto& p = (*yCbCrImage)[y][x];
+    //            output[y][x] = {clamp_uint8(255 * p[0]), clamp_uint8(128 * p[1] + 127), clamp_uint8(128 * p[2] + 127)};
+    //        }
+    //    }
+    //    output.write_png_file("/Users/fabio/ColorChecker" + std::to_string(scale) + ".png");
 
     return nlf_parameters;
 }
 
-gls::Matrix<3, 3> cam_ycbcr(const gls::Matrix<3, 3>& rgb_cam) {
+gls::Matrix<3, 3> cam_ycbcr(const gls::Matrix<3, 3> &rgb_cam)
+{
     // Convert image to YCbCr for Luma/Chroma Denoising, use the camera's primaries to derive the transform
     const auto cam_y = xyz_rgb[1] * rgb_cam;
     const auto KR = cam_y[0];
@@ -818,65 +882,80 @@ gls::Matrix<3, 3> cam_ycbcr(const gls::Matrix<3, 3>& rgb_cam) {
 
     // See: https://en.wikipedia.org/wiki/YCbCr
     return {
-        {  KR,                      KG,                     KB                   },
-        { -0.5f * KR / (1.0f - KB), -0.5f * KG / (1 - KB),  0.5f                 },
-        {  0.5f,                    -0.5f * KG / (1 - KR), -0.5f * KB / (1 - KR) }
-    };
+        {KR, KG, KB},
+        {-0.5f * KR / (1.0f - KB), -0.5f * KG / (1 - KB), 0.5f},
+        {0.5f, -0.5f * KG / (1 - KR), -0.5f * KB / (1 - KR)}};
 }
 
-struct WhiteBalanceStats {
+struct WhiteBalanceStats
+{
     gls::Vector<3> wbGain;
     float diffAverage;
     int whitePixelsCount;
 };
 
 const gls::Matrix<3, 3> srgb_ycbcr = {
-    {  0.2126,  0.7152,  0.0722 },
-    { -0.1146, -0.3854,  0.5    },
-    {  0.5,    -0.4542, -0.0458 }
-};
+    {0.2126, 0.7152, 0.0722},
+    {-0.1146, -0.3854, 0.5},
+    {0.5, -0.4542, -0.0458}};
 
 const gls::Matrix<3, 3> ycbcr_srgb = {
-    { 1,  0,       1.5748, },
-    { 1, -0.1873, -0.4681, },
-    { 1,  1.8556,  0       }
-};
+    {
+        1,
+        0,
+        1.5748,
+    },
+    {
+        1,
+        -0.1873,
+        -0.4681,
+    },
+    {1, 1.8556, 0}};
 
-gls::Vector<3> readQuad(const gls::image<gls::luma_pixel_16>& rawImage, int x, int y, BayerPattern bayerPattern) {
-    const auto& offsets = bayerOffsets[bayerPattern];
-    const auto& Or  = offsets[0];
-    const auto& Og1 = offsets[1];
-    const auto& Ob  = offsets[2];
-    const auto& Og2 = offsets[3];
+gls::Vector<3> readQuad(const gls::image<gls::luma_pixel_16> &rawImage, int x, int y, BayerPattern bayerPattern)
+{
+    const auto &offsets = bayerOffsets[bayerPattern];
+    const auto &Or = offsets[0];
+    const auto &Og1 = offsets[1];
+    const auto &Ob = offsets[2];
+    const auto &Og2 = offsets[3];
 
     return {
-        (float) rawImage[y + Or.y][x + Or.x],
-        ((float) rawImage[y + Og1.y][x + Og1.x] +
-         (float) rawImage[y + Og2.y][x + Og2.x]) / 2.0f,
-        (float) rawImage[y + Ob.y][x + Ob.x]
-    };
+        (float)rawImage[y + Or.y][x + Or.x],
+        ((float)rawImage[y + Og1.y][x + Og1.x] +
+         (float)rawImage[y + Og2.y][x + Og2.x]) /
+            2.0f,
+        (float)rawImage[y + Ob.y][x + Ob.x]};
 }
 
-std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma_pixel_16>& rawImage, const gls::Matrix<3, 3>& rgb_ycbcr,
-                                         const gls::Vector<3>& scale_mul, float white, float black, BayerPattern bayerPattern,
-                                         float highlightsFraction) {
+std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma_pixel_16> &rawImage, const gls::Matrix<3, 3> &rgb_ycbcr,
+                                                      const gls::Vector<3> &scale_mul, float white, float black, BayerPattern bayerPattern,
+                                                      float highlightsFraction)
+{
     int highlightPixels = 0;
     // Compute the average ycbcr values
-    gls::Vector<3> M = { 0, 0, 0 };
+    gls::Vector<3> M = {0, 0, 0};
     gls::image<gls::rgb_pixel_fp32> YUV(rawImage.width / 2, rawImage.height / 2);
-    for (int y = 0; y < rawImage.height; y += 2) {
-        for (int x = 0; x < rawImage.width; x += 2) {
+    for (int y = 0; y < rawImage.height; y += 2)
+    {
+        for (int x = 0; x < rawImage.width; x += 2)
+        {
             // Compute the RGB value in the target color space clipping the highlights to white
-            auto rgb = (scale_mul * (readQuad(rawImage, x, y, bayerPattern) - black)) / (float) 0xffff;
+            auto rgb = (scale_mul * (readQuad(rawImage, x, y, bayerPattern) - black)) / (float)0xffff;
             bool highlights = false;
-            for (int c = 0; c < 3; c++) {
-                if (rgb[c] > 1.0) {
+            for (int c = 0; c < 3; c++)
+            {
+                if (rgb[c] > 1.0)
+                {
                     rgb[c] = 1.0;
-                } else if (rgb[c] > 0.5) {
+                }
+                else if (rgb[c] > 0.5)
+                {
                     highlights = true;
                 }
             }
-            if (highlights) {
+            if (highlights)
+            {
                 highlightPixels++;
             }
 
@@ -886,54 +965,60 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
             M += ycbcr;
         }
     }
-    M /= (float) rawImage.height * rawImage.width / 4;
+    M /= (float)rawImage.height * rawImage.width / 4;
 
 #if DUMP_YUV_IMAGE
     gls::image<gls::rgb_pixel> srgb8Image(YUV.width, YUV.height);
-    YUV.apply([&srgb8Image](const gls::rgb_pixel_fp32 &p, int x, int y) {
+    YUV.apply([&srgb8Image](const gls::rgb_pixel_fp32 &p, int x, int y)
+              {
         const auto rgb = ycbcr_srgb * gls::Vector<3>(p.v);
         srgb8Image[y][x] = {
             (uint8_t) std::clamp(sqrt(rgb[0]) * 255, 0.0f, 255.0f),
             (uint8_t) std::clamp(sqrt(rgb[1]) * 255, 0.0f, 255.0f),
             (uint8_t) std::clamp(sqrt(rgb[2]) * 255, 0.0f, 255.0f)
-        };
-    });
+        }; });
     static int image_count = 0;
     srgb8Image.write_jpeg_file("/Users/fabio/rgbImage" + std::to_string(image_count++) + ".jpg", 95);
 #endif
 
     // Compute the ycbcr average absolute differences
-    gls::Vector<3> D = { 0, 0, 0 };
-    for (int y = 0; y < YUV.height; y++) {
-        for (int x = 0; x < YUV.width; x++) {
+    gls::Vector<3> D = {0, 0, 0};
+    for (int y = 0; y < YUV.height; y++)
+    {
+        for (int x = 0; x < YUV.width; x++)
+        {
             D += abs(gls::Vector<3>(YUV[y][x].v) - M);
         }
     }
-    D /= (float) YUV.height * YUV.width;
+    D /= (float)YUV.height * YUV.width;
 
-    std::array<std::pair<gls::Vector<3>, int>, 128> rgbWhiteAverageHist = { };
+    std::array<std::pair<gls::Vector<3>, int>, 128> rgbWhiteAverageHist = {};
 
     const float Wr = 1.5;
     const float WCr = 1.5;
 
     int whitePixelsCount = 0;
     float YMax = 0;
-    for (int y = 0; y < YUV.height; y++) {
-        for (int x = 0; x < YUV.width; x++) {
-            const auto& p = YUV[y][x];
+    for (int y = 0; y < YUV.height; y++)
+    {
+        for (int x = 0; x < YUV.width; x++)
+        {
+            const auto &p = YUV[y][x];
 
             // Near white region pixels
             if (fabs(p[1] - (M[1] + copysign(D[1], M[1]))) < Wr * D[1] &&
-                fabs(p[2] - (WCr * M[2] + copysign(D[2], M[2]))) < Wr * D[2]) {
+                fabs(p[2] - (WCr * M[2] + copysign(D[2], M[2]))) < Wr * D[2])
+            {
                 const auto rgb = (readQuad(rawImage, 2 * x, 2 * y, bayerPattern) - black) / white;
 
                 float Y = p[0];
-                if (Y > YMax) {
+                if (Y > YMax)
+                {
                     YMax = Y;
                 }
 
-                size_t histEntry = std::clamp((size_t) round((rgbWhiteAverageHist.size() - 1) * Y), 0UL, rgbWhiteAverageHist.size() - 1);
-                auto& entry = rgbWhiteAverageHist[histEntry];
+                size_t histEntry = std::clamp((size_t)round((rgbWhiteAverageHist.size() - 1) * Y), 0UL, rgbWhiteAverageHist.size() - 1);
+                auto &entry = rgbWhiteAverageHist[histEntry];
                 entry.first += rgb;
                 entry.second++;
 
@@ -942,44 +1027,50 @@ std::pair<gls::Vector<3>, int> autoWhiteBalanceKernel(const gls::image<gls::luma
         }
     }
 
-    int histMaxEntry = (int) std::clamp((size_t) round((rgbWhiteAverageHist.size() - 1) * YMax), 0UL, rgbWhiteAverageHist.size() - 1);
+    int histMaxEntry = (int)std::clamp((size_t)round((rgbWhiteAverageHist.size() - 1) * YMax), 0UL, rgbWhiteAverageHist.size() - 1);
 
-    if (histMaxEntry == 0) {
-        return { { 1, 1, 1 }, 0 };
+    if (histMaxEntry == 0)
+    {
+        return {{1, 1, 1}, 0};
     }
 
     int white90PixelsCount = 0;
-    gls::Vector<3> rgbWhite90Average = { 0, 0, 0 };
+    gls::Vector<3> rgbWhite90Average = {0, 0, 0};
 
     // Only consider the top highlightsFraction of whitePixelsCount
-    for (int i = histMaxEntry; i >= 0; i--) {
-        auto& entry = rgbWhiteAverageHist[i];
+    for (int i = histMaxEntry; i >= 0; i--)
+    {
+        auto &entry = rgbWhiteAverageHist[i];
         rgbWhite90Average += entry.first;
         white90PixelsCount += entry.second;
 
-        if (white90PixelsCount > highlightsFraction * whitePixelsCount) {
+        if (white90PixelsCount > highlightsFraction * whitePixelsCount)
+        {
             break;
         }
     }
-    rgbWhite90Average /= (float) white90PixelsCount;
+    rgbWhite90Average /= (float)white90PixelsCount;
 
     auto wbGain = YMax / rgbWhite90Average;
-    return { wbGain / wbGain[1], highlightPixels };
+    return {wbGain / wbGain[1], highlightPixels};
 }
 
 template <size_t N>
-float lenght(const gls::Vector<N>& vec) {
+float lenght(const gls::Vector<N> &vec)
+{
     float sumSq = 0;
-    for (const auto& v : vec) {
+    for (const auto &v : vec)
+    {
         sumSq += v * v;
     }
     return sqrt(sumSq);
 }
 
-gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16>& rawImage, const gls::Matrix<3, 3>& rgb_ycbcr,
-                                const gls::Vector<4>& scale_mul4, float white, float black, BayerPattern bayerPattern,
-                                float* highlights) {
-    const gls::Vector<3> scale_mul = gls::Vector<3> { scale_mul4[0], scale_mul4[1], scale_mul4[2] } / scale_mul4[1];
+gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16> &rawImage, const gls::Matrix<3, 3> &rgb_ycbcr,
+                                const gls::Vector<4> &scale_mul4, float white, float black, BayerPattern bayerPattern,
+                                float *highlights)
+{
+    const gls::Vector<3> scale_mul = gls::Vector<3>{scale_mul4[0], scale_mul4[1], scale_mul4[2]} / scale_mul4[1];
 
     const int hTiles = 4;
     const int vTiles = 4;
@@ -993,53 +1084,61 @@ gls::Vector<3> autoWhiteBalance(const gls::image<gls::luma_pixel_16>& rawImage, 
     auto t_start = std::chrono::high_resolution_clock::now();
 
     std::array<std::array<std::future<std::pair<gls::Vector<3>, int>>, hTiles>, vTiles> results;
-    for (int y = 0; y < vTiles; y++) {
-        for (int x = 0; x < hTiles; x++) {
-            results[y][x] = threadPool.enqueue([x, y, tileWidth, tileHeight, rgb_ycbcr, white, black, bayerPattern, &rawImage, &scale_mul]() -> std::pair<gls::Vector<3>, int> {
+    for (int y = 0; y < vTiles; y++)
+    {
+        for (int x = 0; x < hTiles; x++)
+        {
+            results[y][x] = threadPool.enqueue([x, y, tileWidth, tileHeight, rgb_ycbcr, white, black, bayerPattern, &rawImage, &scale_mul]() -> std::pair<gls::Vector<3>, int>
+                                               {
                 int tile_x = x * tileWidth;
                 int tile_y = y * tileHeight;
                 const auto rawTile = gls::image<gls::luma_pixel_16>(rawImage, tile_x, tile_y, tileWidth, tileHeight);
-                return autoWhiteBalanceKernel(rawTile, rgb_ycbcr, scale_mul, white, black, bayerPattern, /*highlightsFraction=*/ 0.01);
-            });
+                return autoWhiteBalanceKernel(rawTile, rgb_ycbcr, scale_mul, white, black, bayerPattern, /*highlightsFraction=*/ 0.01); });
         }
     }
 
-    gls::Vector<3> wbGain = { 0, 0, 0 };
+    gls::Vector<3> wbGain = {0, 0, 0};
     float highlightPixels = 0;
-    for (int y = 0; y < vTiles; y++) {
-        for (int x = 0; x < hTiles; x++) {
-            const auto& res = results[y][x].get();
+    for (int y = 0; y < vTiles; y++)
+    {
+        for (int x = 0; x < hTiles; x++)
+        {
+            const auto &res = results[y][x].get();
             wbGain += res.first;
             highlightPixels += res.second;
         }
     }
-    wbGain /= (float) vTiles * hTiles;
-    wbGain /= (float) wbGain[1];
+    wbGain /= (float)vTiles * hTiles;
+    wbGain /= (float)wbGain[1];
     highlightPixels /= rawImage.width * rawImage.height / 4;
-    if (highlights) {
+    if (highlights)
+    {
         *highlights = highlightPixels;
     }
 
     auto t_end = std::chrono::high_resolution_clock::now();
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
     const auto diff = lenght(wbGain - scale_mul);
-    std::cout << "wbGain: " << wbGain << ", wbGain - scale_mul: " << wbGain - scale_mul << ", diffLen: " << diff << ", highlightPixels: " << highlightPixels << ", execution time: " << elapsed_time_ms << "ms." << std::endl;
+    // std::cout << "wbGain: " << wbGain << ", wbGain - scale_mul: " << wbGain - scale_mul << ", diffLen: " << diff << ", highlightPixels: " << highlightPixels << ", execution time: " << elapsed_time_ms << "ms." << std::endl;
 
     return wbGain;
 }
 
 // From https://john-chapman.github.io/2019/03/29/convolution.html
 
-void KernelOptimizeBilinear2d(int width, const std::vector<float>& weightsIn,
-                              std::vector<std::array<float, 3>>* weightsOut) {
+void KernelOptimizeBilinear2d(int width, const std::vector<float> &weightsIn,
+                              std::vector<std::array<float, 3>> *weightsOut)
+{
     const int outWidth = width / 2 + 1;
     const int halfWidth = width / 2;
 
     weightsOut->resize(outWidth * outWidth);
 
     int row, col;
-    for (row = 0; row < width - 1; row += 2) {
-        for (col = 0; col < width - 1; col += 2) {
+    for (row = 0; row < width - 1; row += 2)
+    {
+        for (col = 0; col < width - 1; col += 2)
+        {
             float w1 = weightsIn[(row * width) + col];
             float w2 = weightsIn[(row * width) + col + 1];
             float w3 = weightsIn[((row + 1) * width) + col];
@@ -1067,7 +1166,8 @@ void KernelOptimizeBilinear2d(int width, const std::vector<float>& weightsIn,
         (*weightsOut)[k] = {w3, (float)(col - halfWidth), y3};
     }
 
-    for (col = 0; col < width - 1; col += 2) {
+    for (col = 0; col < width - 1; col += 2)
+    {
         float w1 = weightsIn[(row * width) + col];
         float w2 = weightsIn[(row * width) + col + 1];
         float w3 = w1 + w2;

--- a/src/homography.cpp
+++ b/src/homography.cpp
@@ -75,26 +75,28 @@ gls::Vector<N, T> minEigenvectorSVD(gls::Matrix<N, N, T> A) {
 }
 
 template <typename TP>
-void buildHomogeneousLinearLeastSquaresMatrix(const std::vector<Point2f>& src, const std::vector<Point2f>& dst, TP& P) {
-    const int count = (int) src.size();
+void buildHomogeneousLinearLeastSquaresMatrix(const std::vector<Point2f>& src,
+                                              const std::vector<Point2f>& dst, TP& P) {
+    const int count = (int)src.size();
     assert(dst.size() == count);
     assert(P.width == 9 && P.height == 2 * count);
 
     for (int i = 0; i < count; i++) {
-        const gls::basic_point<double> p1 = { src[i].x, src[i].y };
-        const gls::basic_point<double> p2 = { dst[i].x, dst[i].y };
+        const gls::basic_point<double> p1 = {src[i].x, src[i].y};
+        const gls::basic_point<double> p2 = {dst[i].x, dst[i].y};
 
-        gls::Vector<9, double> dx = { -p1.x,   -p1.y, -1, 0, 0, 0, p1.x * p2.x, p1.y * p2.x, p2.x };
-        gls::Vector<9, double> dy = { 0, 0, 0, -p1.x, -p1.y, -1,   p1.x * p2.y, p1.y * p2.y, p2.y };
+        gls::Vector<9, double> dx = {-p1.x, -p1.y, -1, 0, 0, 0, p1.x * p2.x, p1.y * p2.x, p2.x};
+        gls::Vector<9, double> dy = {0, 0, 0, -p1.x, -p1.y, -1, p1.x * p2.y, p1.y * p2.y, p2.y};
 
         for (int j = 0; j < 9; j++) {
-            P[2 * i][j]     = dx[j];
+            P[2 * i][j] = dx[j];
             P[2 * i + 1][j] = dy[j];
         }
     }
 }
 
-gls::Matrix<3, 3> getPerspectiveTransformSVD(const std::vector<Point2f>& src, const std::vector<Point2f>& dst) {
+gls::Matrix<3, 3> getPerspectiveTransformSVD(const std::vector<Point2f>& src,
+                                             const std::vector<Point2f>& dst) {
     gls::Matrix<9, 9, double> ata;
 
     if (src.size() == 4 && dst.size() == 4) {
@@ -103,7 +105,7 @@ gls::Matrix<3, 3> getPerspectiveTransformSVD(const std::vector<Point2f>& src, co
 
         ata = transpose(A) * A;
     } else {
-        int count = (int) src.size();
+        int count = (int)src.size();
 
         auto A = gls::image<double>(9, 2 * count);
         buildHomogeneousLinearLeastSquaresMatrix(src, dst, A);
@@ -125,8 +127,9 @@ gls::Matrix<3, 3> getPerspectiveTransformSVD(const std::vector<Point2f>& src, co
 }
 
 template <typename TA, typename TB>
-void getPerspectiveTransformAB(const std::vector<Point2f>& src, const std::vector<Point2f>& dst, TA& a, TB& b) {
-    const int count = (int) src.size();
+void getPerspectiveTransformAB(const std::vector<Point2f>& src, const std::vector<Point2f>& dst,
+                               TA& a, TB& b) {
+    const int count = (int)src.size();
     assert(a.width == 8 && a.height == 2 * count);
     assert(b.width == 1 && b.height == 2 * count);
 
@@ -147,8 +150,9 @@ void getPerspectiveTransformAB(const std::vector<Point2f>& src, const std::vecto
     }
 }
 
-gls::Matrix<3, 3> getPerspectiveTransformLSM2(const std::vector<Point2f>& src, const std::vector<Point2f>& dst) {
-    int count = (int) src.size();
+gls::Matrix<3, 3> getPerspectiveTransformLSM2(const std::vector<Point2f>& src,
+                                              const std::vector<Point2f>& dst) {
+    int count = (int)src.size();
     gls::Matrix<8, 8> ata;
     gls::Vector<8> atb;
 
@@ -159,7 +163,7 @@ gls::Matrix<3, 3> getPerspectiveTransformLSM2(const std::vector<Point2f>& src, c
 
         const auto at = transpose(a);
         ata = at * a;
-        atb = gls::Vector<8> (at * b);
+        atb = gls::Vector<8>(at * b);
     } else {
         auto a = gls::image<float>(8, 2 * count);
         auto b = gls::image<float>(1, 2 * count);
@@ -184,11 +188,7 @@ gls::Matrix<3, 3> getPerspectiveTransformLSM2(const std::vector<Point2f>& src, c
     // return inverse(aa) * bb;
     const auto h = LUSolve(ata, atb);
 
-    return {
-        h[0], h[1], h[2],
-        h[3], h[4], h[5],
-        h[6], h[7], 1
-    };
+    return {h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], 1};
 }
 
 // Jacobi Solver - Computes Eigenvalues and Eigenvectors of Symmetric Square Matrices
@@ -358,7 +358,7 @@ void Jacobi(const gls::Matrix<N, N, T>& A, gls::Vector<N, T>* W, gls::Matrix<N, 
 }
 
 gls::Matrix<3, 3> findHomography(const std::vector<Point2f>& M, const std::vector<Point2f>& m) {
-    const int count = (int) M.size();
+    const int count = (int)M.size();
 
     typedef gls::Vector<2, double> vec2;
 
@@ -372,16 +372,16 @@ gls::Matrix<3, 3> findHomography(const std::vector<Point2f>& M, const std::vecto
         cm += vec2(m[i]);
         cM += vec2(M[i]);
     }
-    cm /= (double) count;
-    cM /= (double) count;
+    cm /= (double)count;
+    cM /= (double)count;
 
     // Find the mean distance from the barycenter
     for (int i = 0; i < count; i++) {
         sm += abs(vec2(m[i]) - cm);
         sM += abs(vec2(M[i]) - cM);
     }
-    sm /= (double) count;
-    sM /= (double) count;
+    sm /= (double)count;
+    sM /= (double)count;
 
     const auto eps = std::numeric_limits<double>::epsilon();
     if (fabs(sm[0]) < eps || fabs(sm[1]) < eps || fabs(sM[0]) < eps || fabs(sM[1]) < eps) {
@@ -395,8 +395,10 @@ gls::Matrix<3, 3> findHomography(const std::vector<Point2f>& M, const std::vecto
         const auto p1 = (vec2(M[i]) - cM) / sM;
         const auto p2 = (vec2(m[i]) - cm) / sm;
 
-        const gls::Vector<9, double> Lx = { p1[0], p1[1], 1, 0, 0, 0, -p2[0] * p1[0], -p2[0] * p1[1], -p2[0] };
-        const gls::Vector<9, double> Ly = { 0, 0, 0, p1[0], p1[1], 1, -p2[1] * p1[0], -p2[1] * p1[1], -p2[1] };
+        const gls::Vector<9, double> Lx = {p1[0],          p1[1],          1,     0, 0, 0,
+                                           -p2[0] * p1[0], -p2[0] * p1[1], -p2[0]};
+        const gls::Vector<9, double> Ly = {
+            0, 0, 0, p1[0], p1[1], 1, -p2[1] * p1[0], -p2[1] * p1[1], -p2[1]};
 
         // Only build the top diagonal elements, replicate the rest with completeSymm (see below)
         for (int j = 0; j < 9; j++) {
@@ -417,22 +419,15 @@ gls::Matrix<3, 3> findHomography(const std::vector<Point2f>& M, const std::vecto
     const auto H0 = gls::Matrix<3, 3, double>(matV[8]);
 #endif
 
-    const gls::Matrix<3, 3, double> invHnorm = {
-        sm[0], 0, cm[0],
-        0, sm[1], cm[1],
-        0, 0, 1
-    };
+    const gls::Matrix<3, 3, double> invHnorm = {sm[0], 0, cm[0], 0, sm[1], cm[1], 0, 0, 1};
     const gls::Matrix<3, 3, double> Hnorm2 = {
-        1 / sM[0], 0, -cM[0] / sM[0],
-        0, 1 / sM[1], -cM[1] / sM[1],
-        0, 0, 1
-    };
+        1 / sM[0], 0, -cM[0] / sM[0], 0, 1 / sM[1], -cM[1] / sM[1], 0, 0, 1};
 
     // Invert the point set coordinates scaling
     const auto H = invHnorm * H0 * Hnorm2;
 
     // Convert to a float 3x3 Matrix and normalize
-    return gls::Matrix<3, 3, float>(H) / (float) H[2][2];
+    return gls::Matrix<3, 3, float>(H) / (float)H[2][2];
 }
 
 }  // namespace gls

--- a/src/iPhone11Calibration.cpp
+++ b/src/iPhone11Calibration.cpp
@@ -13,21 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CameraCalibration.hpp"
-
-#include "demosaic.hpp"
-#include "demosaic_cl.hpp"
-#include "raw_converter.hpp"
-
 #include <array>
 #include <cmath>
 #include <filesystem>
+
+#include "CameraCalibration.hpp"
+#include "demosaic.hpp"
+#include "demosaic_cl.hpp"
+#include "raw_converter.hpp"
 
 template <size_t levels = 5>
 class iPhone11Calibration : public CameraCalibration<levels> {
     static const std::array<NoiseModel<levels>, 8> NLFData;
 
-public:
+   public:
     NoiseModel<levels> nlfFromIso(int iso) const override {
         iso = std::clamp(iso, 32, 2500);
         if (iso >= 32 && iso < 64) {
@@ -48,152 +47,141 @@ public:
         } else if (iso >= 800 && iso < 1600) {
             float a = (iso - 800) / 800;
             return lerp<levels>(NLFData[5], NLFData[6], a);
-        } /* else if (iso >= 1600 && iso < 2500) */ {
+        } /* else if (iso >= 1600 && iso < 2500) */
+        {
             float a = (iso - 1600) / 900;
             return lerp<levels>(NLFData[6], NLFData[7], a);
         }
     }
 
-//    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParametersPlain(int iso) const override {
-//        const float nlf_alpha = std::clamp((log2(iso) - log2(20)) / (log2(3200) - log2(20)), 0.0, 1.0);
-//
-//        std::cout << "iPhone11 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
-//
-//        float lerp = std::lerp(0.125f, 1.2f, nlf_alpha);
-//        float lerp_c = std::lerp(0.5f, 1.2f, nlf_alpha);
-//
-//        float lmult[5] = { 0.125, 0.5, 0.25, 0.125, 0.125 / 2 };
-//        float cmult[5] = { 0.5, 0.5, 0.5, 0.5, 0.5 };
-//
-//        float chromaBoost = std::lerp(4.0f, 16.0f, nlf_alpha);
-//
-//        float gradientBoost = 1 + 3 * smoothstep(0.3, 0.6, nlf_alpha);
-//
-//        std::array<DenoiseParameters, 5> denoiseParameters = {{
-//            {
-//                .luma = lmult[0] * lerp,
-//                .chroma = cmult[0] * lerp_c,
-//                .chromaBoost = 4 * chromaBoost,
-//                .gradientBoost = 8 * gradientBoost,
-//                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)
-//            },
-//            {
-//                .luma = lmult[1] * lerp,
-//                .chroma = cmult[1] * lerp_c,
-//                .chromaBoost = chromaBoost,
-//                .gradientBoost = gradientBoost,
-//                .sharpening = 1.2
-//            },
-//            {
-//                .luma = lmult[2] * lerp,
-//                .chroma = cmult[2] * lerp_c,
-//                .chromaBoost = chromaBoost,
-//                .gradientBoost = gradientBoost,
-//                .sharpening = 1
-//            },
-//            {
-//                .luma = lmult[3] * lerp,
-//                .chroma = cmult[3] * lerp_c,
-//                .chromaBoost = chromaBoost,
-//                .gradientBoost = gradientBoost,
-//                .sharpening = 1
-//            },
-//            {
-//                .luma = lmult[4] * lerp,
-//                .chroma = cmult[4] * lerp_c,
-//                .chromaBoost = chromaBoost,
-//                .gradientBoost = gradientBoost,
-//                .sharpening = 1
-//            }
-//        }};
-//
-//        return { nlf_alpha, denoiseParameters };
-//    }
+    //    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParametersPlain(int iso)
+    //    const override {
+    //        const float nlf_alpha = std::clamp((log2(iso) - log2(20)) / (log2(3200) - log2(20)),
+    //        0.0, 1.0);
+    //
+    //        std::cout << "iPhone11 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+    //        << std::endl;
+    //
+    //        float lerp = std::lerp(0.125f, 1.2f, nlf_alpha);
+    //        float lerp_c = std::lerp(0.5f, 1.2f, nlf_alpha);
+    //
+    //        float lmult[5] = { 0.125, 0.5, 0.25, 0.125, 0.125 / 2 };
+    //        float cmult[5] = { 0.5, 0.5, 0.5, 0.5, 0.5 };
+    //
+    //        float chromaBoost = std::lerp(4.0f, 16.0f, nlf_alpha);
+    //
+    //        float gradientBoost = 1 + 3 * smoothstep(0.3, 0.6, nlf_alpha);
+    //
+    //        std::array<DenoiseParameters, 5> denoiseParameters = {{
+    //            {
+    //                .luma = lmult[0] * lerp,
+    //                .chroma = cmult[0] * lerp_c,
+    //                .chromaBoost = 4 * chromaBoost,
+    //                .gradientBoost = 8 * gradientBoost,
+    //                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)
+    //            },
+    //            {
+    //                .luma = lmult[1] * lerp,
+    //                .chroma = cmult[1] * lerp_c,
+    //                .chromaBoost = chromaBoost,
+    //                .gradientBoost = gradientBoost,
+    //                .sharpening = 1.2
+    //            },
+    //            {
+    //                .luma = lmult[2] * lerp,
+    //                .chroma = cmult[2] * lerp_c,
+    //                .chromaBoost = chromaBoost,
+    //                .gradientBoost = gradientBoost,
+    //                .sharpening = 1
+    //            },
+    //            {
+    //                .luma = lmult[3] * lerp,
+    //                .chroma = cmult[3] * lerp_c,
+    //                .chromaBoost = chromaBoost,
+    //                .gradientBoost = gradientBoost,
+    //                .sharpening = 1
+    //            },
+    //            {
+    //                .luma = lmult[4] * lerp,
+    //                .chroma = cmult[4] * lerp_c,
+    //                .chromaBoost = chromaBoost,
+    //                .gradientBoost = gradientBoost,
+    //                .sharpening = 1
+    //            }
+    //        }};
+    //
+    //        return { nlf_alpha, denoiseParameters };
+    //    }
 
-    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(int iso) const override {
-        const float nlf_alpha = std::clamp((log2(iso) - log2(20)) / (log2(3200) - log2(20)), 0.0, 1.0);
+    std::pair<float, std::array<DenoiseParameters, levels>> getDenoiseParameters(
+        int iso) const override {
+        const float nlf_alpha =
+            std::clamp((log2(iso) - log2(20)) / (log2(3200) - log2(20)), 0.0, 1.0);
 
-        std::cout << "iPhone11 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso << std::endl;
+        std::cout << "iPhone11 DenoiseParameters nlf_alpha: " << nlf_alpha << ", ISO: " << iso
+                  << std::endl;
 
         float lerp = std::lerp(0.125f, 1.2f, nlf_alpha);
         float lerp_c = std::lerp(0.5f, 1.2f, nlf_alpha);
 
-        float lmult[5] = { 0.5, 1, 0.5, 0.25, 0.125 };
-        float cmult[5] = { 0.5, 0.5, 0.5, 0.5, 0.5 };
+        float lmult[5] = {0.5, 1, 0.5, 0.25, 0.125};
+        float cmult[5] = {0.5, 0.5, 0.5, 0.5, 0.5};
 
         float chromaBoost = std::lerp(4.0f, 16.0f, nlf_alpha);
 
         float gradientBoost = 1 + 3 * smoothstep(0.3, 0.6, nlf_alpha);
 
-        std::array<DenoiseParameters, 5> denoiseParameters = {{
-            {
-                .luma = lmult[0] * lerp,
-                .chroma = cmult[0] * lerp_c,
-                .chromaBoost = 4 * chromaBoost,
-                .gradientBoost = 8 * gradientBoost,
-                .gradientThreshold = 4,
-                .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)
-            },
-            {
-                .luma = lmult[1] * lerp,
-                .chroma = cmult[1] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1.2
-            },
-            {
-                .luma = lmult[2] * lerp,
-                .chroma = cmult[2] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[3] * lerp,
-                .chroma = cmult[3] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            },
-            {
-                .luma = lmult[4] * lerp,
-                .chroma = cmult[4] * lerp_c,
-                .chromaBoost = chromaBoost,
-                .gradientBoost = gradientBoost,
-                .sharpening = 1
-            }
-        }};
+        std::array<DenoiseParameters, 5> denoiseParameters = {
+            {{.luma = lmult[0] * lerp,
+              .chroma = cmult[0] * lerp_c,
+              .chromaBoost = 4 * chromaBoost,
+              .gradientBoost = 8 * gradientBoost,
+              .gradientThreshold = 4,
+              .sharpening = std::lerp(1.5f, 1.0f, nlf_alpha)},
+             {.luma = lmult[1] * lerp,
+              .chroma = cmult[1] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1.2},
+             {.luma = lmult[2] * lerp,
+              .chroma = cmult[2] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[3] * lerp,
+              .chroma = cmult[3] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1},
+             {.luma = lmult[4] * lerp,
+              .chroma = cmult[4] * lerp_c,
+              .chromaBoost = chromaBoost,
+              .gradientBoost = gradientBoost,
+              .sharpening = 1}}};
 
-        return { nlf_alpha, denoiseParameters };
+        return {nlf_alpha, denoiseParameters};
     }
 
     DemosaicParameters buildDemosaicParameters() const override {
-        return {
-            .rgbConversionParameters = {
-                // .exposureBias = 0.3,
-                // .blacks = 0.1,
-                .localToneMapping = true
-            },
+        return {.rgbConversionParameters =
+                    {// .exposureBias = 0.3,
+                     // .blacks = 0.1,
+                     .localToneMapping = true},
                 .ltmParameters = {
-                    .eps = 0.01,
-                    .shadows = 0.8,
-                    .highlights = 1.1,
-                    .detail = { 1, 1.1, 1.5 }
-                }
-        };
+                    .eps = 0.01, .shadows = 0.8, .highlights = 1.1, .detail = {1, 1.1, 1.5}}};
     }
 
-    void calibrate(RawConverter* rawConverter, const std::filesystem::path& input_dir) const override {
-        std::array<CalibrationEntry, 8> calibration_files = {{
-            { 32,   "IPHONE11hSLI0032NRD.dng", { 1798, 2199, 382, 269 }, false },
-            { 64,   "IPHONE11hSLI0064NRD.dng", { 1799, 2200, 382, 269 }, false },
-            { 100,  "IPHONE11hSLI0100NRD.dng", { 1800, 2200, 382, 269 }, false },
-            { 200,  "IPHONE11hSLI0200NRD.dng", { 1796, 2199, 382, 269 }, false },
-            { 400,  "IPHONE11hSLI0400NRD.dng", { 1796, 2204, 382, 269 }, false },
-            { 800,  "IPHONE11hSLI0800NRD.dng", { 1795, 2199, 382, 269 }, false },
-            { 1600, "IPHONE11hSLI1600NRD.dng", { 1793, 2195, 382, 269 }, false },
-            { 2500, "IPHONE11hSLI2500NRD.dng", { 1794, 2200, 382, 269 }, false }
-        }};
+    void calibrate(RawConverter* rawConverter,
+                   const std::filesystem::path& input_dir) const override {
+        std::array<CalibrationEntry, 8> calibration_files = {
+            {{32, "IPHONE11hSLI0032NRD.dng", {1798, 2199, 382, 269}, false},
+             {64, "IPHONE11hSLI0064NRD.dng", {1799, 2200, 382, 269}, false},
+             {100, "IPHONE11hSLI0100NRD.dng", {1800, 2200, 382, 269}, false},
+             {200, "IPHONE11hSLI0200NRD.dng", {1796, 2199, 382, 269}, false},
+             {400, "IPHONE11hSLI0400NRD.dng", {1796, 2204, 382, 269}, false},
+             {800, "IPHONE11hSLI0800NRD.dng", {1795, 2199, 382, 269}, false},
+             {1600, "IPHONE11hSLI1600NRD.dng", {1793, 2195, 382, 269}, false},
+             {2500, "IPHONE11hSLI2500NRD.dng", {1794, 2200, 382, 269}, false}}};
 
         std::array<NoiseModel<5>, 8> noiseModel;
 
@@ -201,16 +189,17 @@ public:
             auto& entry = calibration_files[i];
             const auto input_path = input_dir / entry.fileName;
 
-            DemosaicParameters demosaicParameters = {
-                .rgbConversionParameters = {
-                    .contrast = 1.05,
-                    .saturation = 1.0,
-                    .toneCurveSlope = 3.5,
-                }
-            };
+            DemosaicParameters demosaicParameters = {.rgbConversionParameters = {
+                                                         .contrast = 1.05,
+                                                         .saturation = 1.0,
+                                                         .toneCurveSlope = 3.5,
+                                                     }};
 
-            const auto rgb_image = CameraCalibration<5>::calibrate(rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
-            rgb_image->write_png_file((input_path.parent_path() / input_path.stem()).string() + "_cal.png", /*skip_alpha=*/ true);
+            const auto rgb_image = CameraCalibration<5>::calibrate(
+                rawConverter, input_path, &demosaicParameters, entry.iso, entry.gmb_position);
+            rgb_image->write_png_file(
+                (input_path.parent_path() / input_path.stem()).string() + "_cal.png",
+                /*skip_alpha=*/true);
 
             noiseModel[i] = demosaicParameters.noiseModel;
         }
@@ -229,106 +218,94 @@ void calibrateiPhone11(RawConverter* rawConverter, const std::filesystem::path& 
     calibration.calibrate(rawConverter, input_dir);
 }
 
-gls::image<gls::rgb_pixel>::unique_ptr demosaiciPhone11(RawConverter* rawConverter, const std::filesystem::path& input_path) {
+gls::image<gls::rgb_pixel>::unique_ptr demosaiciPhone11(RawConverter* rawConverter,
+                                                        const std::filesystem::path& input_path) {
     gls::tiff_metadata dng_metadata, exif_metadata;
-    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(input_path.string(), &dng_metadata, &exif_metadata);
+    const auto inputImage = gls::image<gls::luma_pixel_16>::read_dng_file(
+        input_path.string(), &dng_metadata, &exif_metadata);
 
     iPhone11Calibration calibration;
-    auto demosaicParameters = calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
+    auto demosaicParameters =
+        calibration.getDemosaicParameters(*inputImage, &dng_metadata, &exif_metadata);
 
-    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(*inputImage, demosaicParameters.get(), /*calibrateFromImage=*/ true));
+    return RawConverter::convertToRGBImage(*rawConverter->runPipeline(
+        *inputImage, demosaicParameters.get(), /*calibrateFromImage=*/true));
 }
 
 // --- NLFData ---
 
-template<>
+template <>
 const std::array<NoiseModel<5>, 8> iPhone11Calibration<5>::NLFData = {{
     // ISO 32
-    {
-        {{9.462e-06, 1.124e-05, 1.009e-05, 1.159e-05}, {3.359e-04, 1.143e-04, 3.730e-04, 1.352e-04}},
-        {{
-            {{1.684e-05, 6.679e-07, 1.234e-06}, {9.303e-05, 1.775e-05, 1.687e-05}},
-            {{2.406e-05, 9.927e-07, 1.968e-06}, {5.867e-06, 9.615e-06, 7.823e-06}},
-            {{2.993e-05, 1.696e-06, 2.354e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
-            {{4.175e-05, 1.725e-06, 2.400e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
-            {{1.288e-04, 5.087e-06, 6.974e-06}, {1.049e-04, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{9.462e-06, 1.124e-05, 1.009e-05, 1.159e-05}, {3.359e-04, 1.143e-04, 3.730e-04, 1.352e-04}},
+     {{
+         {{1.684e-05, 6.679e-07, 1.234e-06}, {9.303e-05, 1.775e-05, 1.687e-05}},
+         {{2.406e-05, 9.927e-07, 1.968e-06}, {5.867e-06, 9.615e-06, 7.823e-06}},
+         {{2.993e-05, 1.696e-06, 2.354e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
+         {{4.175e-05, 1.725e-06, 2.400e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
+         {{1.288e-04, 5.087e-06, 6.974e-06}, {1.049e-04, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 64
-    {
-        {{9.059e-06, 1.183e-05, 9.381e-06, 1.205e-05}, {6.179e-04, 1.930e-04, 7.074e-04, 2.320e-04}},
-        {{
-            {{1.676e-05, 6.408e-07, 1.562e-06}, {1.743e-04, 3.259e-05, 3.117e-05}},
-            {{2.403e-05, 1.044e-06, 2.101e-06}, {2.134e-05, 1.900e-05, 1.866e-05}},
-            {{3.051e-05, 1.787e-06, 3.055e-06}, {1.000e-08, 2.836e-06, 2.594e-07}},
-            {{4.171e-05, 1.881e-06, 2.602e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
-            {{1.282e-04, 5.147e-06, 7.079e-06}, {1.068e-04, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{9.059e-06, 1.183e-05, 9.381e-06, 1.205e-05}, {6.179e-04, 1.930e-04, 7.074e-04, 2.320e-04}},
+     {{
+         {{1.676e-05, 6.408e-07, 1.562e-06}, {1.743e-04, 3.259e-05, 3.117e-05}},
+         {{2.403e-05, 1.044e-06, 2.101e-06}, {2.134e-05, 1.900e-05, 1.866e-05}},
+         {{3.051e-05, 1.787e-06, 3.055e-06}, {1.000e-08, 2.836e-06, 2.594e-07}},
+         {{4.171e-05, 1.881e-06, 2.602e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
+         {{1.282e-04, 5.147e-06, 7.079e-06}, {1.068e-04, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 100
-    {
-        {{1.101e-05, 1.296e-05, 1.086e-05, 1.316e-05}, {9.290e-04, 2.776e-04, 1.075e-03, 3.368e-04}},
-        {{
-            {{1.592e-05, 4.663e-07, 1.820e-06}, {2.757e-04, 5.071e-05, 4.690e-05}},
-            {{2.387e-05, 1.136e-06, 2.265e-06}, {3.884e-05, 2.900e-05, 3.067e-05}},
-            {{3.107e-05, 1.769e-06, 3.100e-06}, {1.000e-08, 6.557e-06, 4.896e-06}},
-            {{4.187e-05, 2.049e-06, 2.846e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
-            {{1.276e-04, 5.143e-06, 7.123e-06}, {1.074e-04, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{1.101e-05, 1.296e-05, 1.086e-05, 1.316e-05}, {9.290e-04, 2.776e-04, 1.075e-03, 3.368e-04}},
+     {{
+         {{1.592e-05, 4.663e-07, 1.820e-06}, {2.757e-04, 5.071e-05, 4.690e-05}},
+         {{2.387e-05, 1.136e-06, 2.265e-06}, {3.884e-05, 2.900e-05, 3.067e-05}},
+         {{3.107e-05, 1.769e-06, 3.100e-06}, {1.000e-08, 6.557e-06, 4.896e-06}},
+         {{4.187e-05, 2.049e-06, 2.846e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
+         {{1.276e-04, 5.143e-06, 7.123e-06}, {1.074e-04, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 200
-    {
-        {{1.970e-05, 1.495e-05, 1.862e-05, 1.498e-05}, {1.732e-03, 5.315e-04, 1.991e-03, 6.495e-04}},
-        {{
-            {{1.357e-05, 3.728e-07, 1.905e-06}, {5.787e-04, 1.003e-04, 9.756e-05}},
-            {{2.454e-05, 1.358e-06, 2.918e-06}, {8.124e-05, 5.640e-05, 6.104e-05}},
-            {{3.239e-05, 1.896e-06, 3.292e-06}, {2.879e-06, 1.675e-05, 1.718e-05}},
-            {{4.236e-05, 2.607e-06, 3.499e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
-            {{1.278e-04, 5.390e-06, 7.127e-06}, {1.154e-04, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{1.970e-05, 1.495e-05, 1.862e-05, 1.498e-05}, {1.732e-03, 5.315e-04, 1.991e-03, 6.495e-04}},
+     {{
+         {{1.357e-05, 3.728e-07, 1.905e-06}, {5.787e-04, 1.003e-04, 9.756e-05}},
+         {{2.454e-05, 1.358e-06, 2.918e-06}, {8.124e-05, 5.640e-05, 6.104e-05}},
+         {{3.239e-05, 1.896e-06, 3.292e-06}, {2.879e-06, 1.675e-05, 1.718e-05}},
+         {{4.236e-05, 2.607e-06, 3.499e-06}, {1.000e-08, 1.000e-08, 1.000e-08}},
+         {{1.278e-04, 5.390e-06, 7.127e-06}, {1.154e-04, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 400
-    {
-        {{4.664e-05, 1.791e-05, 4.449e-05, 1.896e-05}, {3.170e-03, 1.078e-03, 3.545e-03, 1.286e-03}},
-        {{
-            {{1.429e-05, 1.128e-06, 3.052e-06}, {6.968e-04, 1.488e-04, 1.520e-04}},
-            {{2.517e-05, 1.534e-06, 3.940e-06}, {1.306e-04, 1.010e-04, 1.073e-04}},
-            {{3.276e-05, 2.313e-06, 3.799e-06}, {2.053e-05, 3.632e-05, 4.144e-05}},
-            {{4.362e-05, 3.070e-06, 4.703e-06}, {1.000e-08, 4.686e-06, 1.900e-06}},
-            {{1.286e-04, 5.896e-06, 7.708e-06}, {1.160e-04, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{4.664e-05, 1.791e-05, 4.449e-05, 1.896e-05}, {3.170e-03, 1.078e-03, 3.545e-03, 1.286e-03}},
+     {{
+         {{1.429e-05, 1.128e-06, 3.052e-06}, {6.968e-04, 1.488e-04, 1.520e-04}},
+         {{2.517e-05, 1.534e-06, 3.940e-06}, {1.306e-04, 1.010e-04, 1.073e-04}},
+         {{3.276e-05, 2.313e-06, 3.799e-06}, {2.053e-05, 3.632e-05, 4.144e-05}},
+         {{4.362e-05, 3.070e-06, 4.703e-06}, {1.000e-08, 4.686e-06, 1.900e-06}},
+         {{1.286e-04, 5.896e-06, 7.708e-06}, {1.160e-04, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 800
-    {
-        {{1.362e-04, 3.155e-05, 1.263e-04, 3.453e-05}, {5.551e-03, 2.220e-03, 6.054e-03, 2.611e-03}},
-        {{
-            {{2.439e-05, 4.008e-06, 7.094e-06}, {1.306e-03, 2.957e-04, 3.205e-04}},
-            {{2.634e-05, 2.803e-06, 6.180e-06}, {3.051e-04, 2.117e-04, 2.422e-04}},
-            {{3.376e-05, 3.533e-06, 5.791e-06}, {5.677e-05, 7.318e-05, 8.935e-05}},
-            {{4.552e-05, 3.468e-06, 5.437e-06}, {1.000e-08, 1.602e-05, 1.653e-05}},
-            {{1.286e-04, 6.393e-06, 8.568e-06}, {1.207e-04, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{1.362e-04, 3.155e-05, 1.263e-04, 3.453e-05}, {5.551e-03, 2.220e-03, 6.054e-03, 2.611e-03}},
+     {{
+         {{2.439e-05, 4.008e-06, 7.094e-06}, {1.306e-03, 2.957e-04, 3.205e-04}},
+         {{2.634e-05, 2.803e-06, 6.180e-06}, {3.051e-04, 2.117e-04, 2.422e-04}},
+         {{3.376e-05, 3.533e-06, 5.791e-06}, {5.677e-05, 7.318e-05, 8.935e-05}},
+         {{4.552e-05, 3.468e-06, 5.437e-06}, {1.000e-08, 1.602e-05, 1.653e-05}},
+         {{1.286e-04, 6.393e-06, 8.568e-06}, {1.207e-04, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 1600
-    {
-        {{8.129e-05, 7.693e-06, 3.514e-05, 5.903e-06}, {1.779e-02, 7.791e-03, 2.038e-02, 8.951e-03}},
-        {{
-            {{8.760e-05, 1.248e-05, 1.858e-05}, {1.980e-03, 6.189e-04, 7.015e-04}},
-            {{3.040e-05, 6.244e-06, 1.337e-05}, {7.118e-04, 4.614e-04, 5.471e-04}},
-            {{3.810e-05, 4.306e-06, 9.439e-06}, {1.317e-04, 1.759e-04, 2.055e-04}},
-            {{4.886e-05, 4.135e-06, 7.119e-06}, {6.791e-06, 4.486e-05, 5.131e-05}},
-            {{1.269e-04, 7.618e-06, 1.017e-05}, {9.000e-05, 1.000e-08, 1.000e-08}},
-        }}
-    },
+    {{{8.129e-05, 7.693e-06, 3.514e-05, 5.903e-06}, {1.779e-02, 7.791e-03, 2.038e-02, 8.951e-03}},
+     {{
+         {{8.760e-05, 1.248e-05, 1.858e-05}, {1.980e-03, 6.189e-04, 7.015e-04}},
+         {{3.040e-05, 6.244e-06, 1.337e-05}, {7.118e-04, 4.614e-04, 5.471e-04}},
+         {{3.810e-05, 4.306e-06, 9.439e-06}, {1.317e-04, 1.759e-04, 2.055e-04}},
+         {{4.886e-05, 4.135e-06, 7.119e-06}, {6.791e-06, 4.486e-05, 5.131e-05}},
+         {{1.269e-04, 7.618e-06, 1.017e-05}, {9.000e-05, 1.000e-08, 1.000e-08}},
+     }}},
     // ISO 2500
-    {
-        {{7.087e-05, 1.000e-08, 8.272e-05, 1.000e-08}, {2.722e-02, 1.401e-02, 2.702e-02, 1.598e-02}},
-        {{
-            {{1.902e-04, 2.307e-05, 3.353e-05}, {2.236e-03, 9.970e-04, 1.170e-03}},
-            {{3.882e-05, 1.150e-05, 2.147e-05}, {1.155e-03, 7.807e-04, 9.602e-04}},
-            {{3.834e-05, 5.670e-06, 1.174e-05}, {2.709e-04, 3.062e-04, 3.873e-04}},
-            {{4.783e-05, 5.935e-06, 9.429e-06}, {4.375e-05, 7.575e-05, 9.467e-05}},
-            {{1.319e-04, 8.472e-06, 1.255e-05}, {9.194e-05, 5.087e-06, 1.000e-08}},
-        }}
-    },
+    {{{7.087e-05, 1.000e-08, 8.272e-05, 1.000e-08}, {2.722e-02, 1.401e-02, 2.702e-02, 1.598e-02}},
+     {{
+         {{1.902e-04, 2.307e-05, 3.353e-05}, {2.236e-03, 9.970e-04, 1.170e-03}},
+         {{3.882e-05, 1.150e-05, 2.147e-05}, {1.155e-03, 7.807e-04, 9.602e-04}},
+         {{3.834e-05, 5.670e-06, 1.174e-05}, {2.709e-04, 3.062e-04, 3.873e-04}},
+         {{4.783e-05, 5.935e-06, 9.429e-06}, {4.375e-05, 7.575e-05, 9.467e-05}},
+         {{1.319e-04, 8.472e-06, 1.255e-05}, {9.194e-05, 5.087e-06, 1.000e-08}},
+     }}},
 }};

--- a/src/pyramid_processor.cpp
+++ b/src/pyramid_processor.cpp
@@ -18,22 +18,23 @@
 #include <iomanip>
 
 template <size_t levels>
-PyramidProcessor<levels>::PyramidProcessor(gls::OpenCLContext *glsContext, int _width, int _height) : width(_width), height(_height), fusedFrames(0)
-{
-    for (int i = 0, scale = 2; i < levels - 1; i++, scale *= 2)
-    {
-        imagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
-        gradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(glsContext->clContext(), width / scale, height / scale);
+PyramidProcessor<levels>::PyramidProcessor(gls::OpenCLContext* glsContext, int _width, int _height)
+    : width(_width), height(_height), fusedFrames(0) {
+    for (int i = 0, scale = 2; i < levels - 1; i++, scale *= 2) {
+        imagePyramid[i] =
+            std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+        gradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+            glsContext->clContext(), width / scale, height / scale);
     }
-    for (int i = 0, scale = 1; i < levels; i++, scale *= 2)
-    {
-        denoisedImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
-        subtractedImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+    for (int i = 0, scale = 1; i < levels; i++, scale *= 2) {
+        denoisedImagePyramid[i] =
+            std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+        subtractedImagePyramid[i] =
+            std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
     }
 }
 
-gls::Vector<3> nflMultiplier(const DenoiseParameters &denoiseParameters)
-{
+gls::Vector<3> nflMultiplier(const DenoiseParameters& denoiseParameters) {
     float luma_mul = denoiseParameters.luma;
     float chroma_mul = denoiseParameters.chroma;
     return {luma_mul, chroma_mul, chroma_mul};
@@ -42,206 +43,198 @@ gls::Vector<3> nflMultiplier(const DenoiseParameters &denoiseParameters)
 #if DEBUG_PYRAMID
 extern const gls::Matrix<3, 3> ycbcr_srgb;
 
-void dumpYCbCrImage(const gls::cl_image_2d<gls::rgba_pixel_float> &image)
-{
+void dumpYCbCrImage(const gls::cl_image_2d<gls::rgba_pixel_float>& image) {
     gls::image<gls::rgb_pixel> out(image.width, image.height);
     const auto downsampledCPU = image.mapImage();
-    out.apply([&downsampledCPU](gls::rgb_pixel *p, int x, int y)
-              {
+    out.apply([&downsampledCPU](gls::rgb_pixel* p, int x, int y) {
         const auto& ip = downsampledCPU[y][x];
         const auto& v = ycbcr_srgb * gls::Vector<3>{ip.x, ip.y, ip.z};
-        *p = gls::rgb_pixel {
-            (uint8_t) (255 * std::sqrt(std::clamp(v[0], 0.0f, 1.0f))),
-            (uint8_t) (255 * std::sqrt(std::clamp(v[1], 0.0f, 1.0f))),
-            (uint8_t) (255 * std::sqrt(std::clamp(v[2], 0.0f, 1.0f)))
-        }; });
+        *p = gls::rgb_pixel{(uint8_t)(255 * std::sqrt(std::clamp(v[0], 0.0f, 1.0f))),
+                            (uint8_t)(255 * std::sqrt(std::clamp(v[1], 0.0f, 1.0f))),
+                            (uint8_t)(255 * std::sqrt(std::clamp(v[2], 0.0f, 1.0f)))};
+    });
     image.unmapImage(downsampledCPU);
     static int count = 1;
     out.write_png_file("/Users/fabio/pyramid_7x7" + std::to_string(count++) + ".png");
 }
 
-void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float> &image);
+void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float>& image);
 
-#endif // DEBUG_PYRAMID
+#endif  // DEBUG_PYRAMID
 
 // TODO: Make this a tunable
-static const constexpr float lumaDenoiseWeight[4] = {
-    1, 1, 1, 1};
+static const constexpr float lumaDenoiseWeight[4] = {1, 1, 1, 1};
 
 template <size_t levels>
-typename PyramidProcessor<levels>::imageType *PyramidProcessor<levels>::denoise(gls::OpenCLContext *glsContext,
-                                                                                std::array<DenoiseParameters, levels> *denoiseParameters,
-                                                                                const imageType &image,
-                                                                                const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
-                                                                                std::array<YCbCrNLF, levels> *nlfParameters,
-                                                                                float exposure_multiplier, bool calibrateFromImage)
-{
+typename PyramidProcessor<levels>::imageType* PyramidProcessor<levels>::denoise(
+    gls::OpenCLContext* glsContext, std::array<DenoiseParameters, levels>* denoiseParameters,
+    const imageType& image, const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
+    std::array<YCbCrNLF, levels>* nlfParameters, float exposure_multiplier,
+    bool calibrateFromImage) {
     std::array<gls::Vector<3>, levels> thresholdMultipliers;
 
     // Create gaussian image pyramid an setup noise model
-    for (int i = 0; i < levels; i++)
-    {
+    for (int i = 0; i < levels; i++) {
         const auto currentLayer = i > 0 ? imagePyramid[i - 1].get() : &image;
         const auto currentGradientLayer = i > 0 ? gradientPyramid[i - 1].get() : &gradientImage;
 
-        if (i < levels - 1)
-        {
+        if (i < levels - 1) {
             // Generate next layer in the pyramid
             resampleImage(glsContext, "downsampleImageXYZ", *currentLayer, imagePyramid[i].get());
-            resampleImage(glsContext, "downsampleImageXY", *currentGradientLayer, gradientPyramid[i].get());
+            resampleImage(glsContext, "downsampleImageXY", *currentGradientLayer,
+                          gradientPyramid[i].get());
         }
 
-        if (calibrateFromImage)
-        {
+        if (calibrateFromImage) {
             (*nlfParameters)[i] = MeasureYCbCrNLF(glsContext, *currentLayer, exposure_multiplier);
         }
 
         thresholdMultipliers[i] = nflMultiplier((*denoiseParameters)[i]);
     }
 
-    // Denoise pyramid layers from the bottom to the top, subtracting the noise of the previous layer from the next
-    for (int i = levels - 1; i >= 0; i--)
-    {
+    // Denoise pyramid layers from the bottom to the top, subtracting the noise of the previous
+    // layer from the next
+    for (int i = levels - 1; i >= 0; i--) {
         const auto denoiseInput = i > 0 ? imagePyramid[i - 1].get() : &image;
         const auto gradientInput = i > 0 ? gradientPyramid[i - 1].get() : &gradientImage;
 
-        if (i < levels - 1)
-        {
+        if (i < levels - 1) {
             // Subtract the previous layer's noise from the current one
-            // std::cout << "Reassembling layer " << i + 1 << " with sharpening: " << (*denoiseParameters)[i].sharpening << std::endl;
+            // std::cout << "Reassembling layer " << i + 1 << " with sharpening: " <<
+            // (*denoiseParameters)[i].sharpening << std::endl;
 
-            const auto np = YCbCrNLF{(*nlfParameters)[i].first * thresholdMultipliers[i], (*nlfParameters)[i].second * thresholdMultipliers[i]};
-            subtractNoiseImage(glsContext, *denoiseInput,
-                               *(imagePyramid[i]),
-                               *(denoisedImagePyramid[i + 1]),
-                               *gradientInput,
-                               lumaDenoiseWeight[i],
-                               (*denoiseParameters)[i].sharpening,
-                               {np.first[0], np.second[0]},
+            const auto np = YCbCrNLF{(*nlfParameters)[i].first * thresholdMultipliers[i],
+                                     (*nlfParameters)[i].second * thresholdMultipliers[i]};
+            subtractNoiseImage(glsContext, *denoiseInput, *(imagePyramid[i]),
+                               *(denoisedImagePyramid[i + 1]), *gradientInput, lumaDenoiseWeight[i],
+                               (*denoiseParameters)[i].sharpening, {np.first[0], np.second[0]},
                                subtractedImagePyramid[i].get());
         }
 
-        // std::cout << "Denoising image level " << i << " with multipliers " << thresholdMultipliers[i] << std::endl;
+        // std::cout << "Denoising image level " << i << " with multipliers " <<
+        // thresholdMultipliers[i] << std::endl;
 
         // Denoise current layer
-        denoiseImage(glsContext, i < levels - 1 ? *(subtractedImagePyramid[i]) : *denoiseInput, *gradientInput,
-                     (*nlfParameters)[i].first, (*nlfParameters)[i].second, thresholdMultipliers[i],
-                     (*denoiseParameters)[i].chromaBoost, (*denoiseParameters)[i].gradientBoost, (*denoiseParameters)[i].gradientThreshold,
-                     denoisedImagePyramid[i].get());
+        denoiseImage(glsContext, i < levels - 1 ? *(subtractedImagePyramid[i]) : *denoiseInput,
+                     *gradientInput, (*nlfParameters)[i].first, (*nlfParameters)[i].second,
+                     thresholdMultipliers[i], (*denoiseParameters)[i].chromaBoost,
+                     (*denoiseParameters)[i].gradientBoost,
+                     (*denoiseParameters)[i].gradientThreshold, denoisedImagePyramid[i].get());
     }
 
     return denoisedImagePyramid[0].get();
 }
 
 // TODO: tunables
-const gls::Vector<2> fusionWeights[5] = {
-    {1, 4},
-    {1, 4},
-    {1, 4},
-    {1, 4},
-    {1, 4}};
+const gls::Vector<2> fusionWeights[5] = {{1, 4}, {1, 4}, {1, 4}, {1, 4}, {1, 4}};
 
 template <size_t levels>
-void PyramidProcessor<levels>::fuseFrame(gls::OpenCLContext *glsContext,
-                                         std::array<DenoiseParameters, levels> *denoiseParameters,
-                                         const imageType &image,
-                                         const gls::Matrix<3, 3> &homography,
-                                         const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
-                                         std::array<YCbCrNLF, levels> *nlfParameters,
-                                         float exposure_multiplier, bool calibrateFromImage)
-{
+void PyramidProcessor<levels>::fuseFrame(
+    gls::OpenCLContext* glsContext, std::array<DenoiseParameters, levels>* denoiseParameters,
+    const imageType& image, const gls::Matrix<3, 3>& homography,
+    const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
+    std::array<YCbCrNLF, levels>* nlfParameters, float exposure_multiplier,
+    bool calibrateFromImage) {
     std::cout << "Fusing frame " << fusedFrames << std::endl;
 
-    if (fusionImagePyramidA[0] == nullptr)
-    {
+    if (fusionImagePyramidA[0] == nullptr) {
         std::cout << "Allocating fusionImagePyramid" << std::endl;
-        for (int i = 0, scale = 1; i < levels; i++, scale *= 2)
-        {
-            fusionImagePyramidA[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
-            fusionImagePyramidB[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
-            fusionReferenceImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
-            fusionReferenceGradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(glsContext->clContext(), width / scale, height / scale);
+        for (int i = 0, scale = 1; i < levels; i++, scale *= 2) {
+            fusionImagePyramidA[i] =
+                std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+            fusionImagePyramidB[i] =
+                std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+            fusionReferenceImagePyramid[i] =
+                std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+            fusionReferenceGradientPyramid[i] =
+                std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+                    glsContext->clContext(), width / scale, height / scale);
         }
         fusionBuffer[0] = &fusionImagePyramidA;
         fusionBuffer[1] = &fusionImagePyramidB;
     }
 
-    auto &newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 0];
-    auto &previousFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
+    auto& newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 0];
+    auto& previousFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
 
     // Create gaussian image pyramid
-    for (int i = 0; i < levels; i++)
-    {
-        const auto currentLayer = i > 0 ? (fusedFrames == 0 ? newFusedImagePyramid[i].get() : imagePyramid[i - 1].get()) : &image;
+    for (int i = 0; i < levels; i++) {
+        const auto currentLayer =
+            i > 0 ? (fusedFrames == 0 ? newFusedImagePyramid[i].get() : imagePyramid[i - 1].get())
+                  : &image;
         const auto currentGradientLayer = i > 0 ? gradientPyramid[i - 1].get() : &gradientImage;
 
-        if (fusedFrames == 0 && i == 0)
-        {
+        if (fusedFrames == 0 && i == 0) {
             cl::enqueueCopyImage(currentLayer->getImage2D(), newFusedImagePyramid[i]->getImage2D(),
-                                 {0, 0, 0}, {0, 0, 0}, {(size_t)currentLayer->width, (size_t)currentLayer->height, 1});
+                                 {0, 0, 0}, {0, 0, 0},
+                                 {(size_t)currentLayer->width, (size_t)currentLayer->height, 1});
 
-            cl::enqueueCopyImage(currentLayer->getImage2D(), fusionReferenceImagePyramid[i]->getImage2D(),
-                                 {0, 0, 0}, {0, 0, 0}, {(size_t)currentLayer->width, (size_t)currentLayer->height, 1});
+            cl::enqueueCopyImage(currentLayer->getImage2D(),
+                                 fusionReferenceImagePyramid[i]->getImage2D(), {0, 0, 0}, {0, 0, 0},
+                                 {(size_t)currentLayer->width, (size_t)currentLayer->height, 1});
 
-            cl::enqueueCopyImage(currentGradientLayer->getImage2D(), fusionReferenceGradientPyramid[i]->getImage2D(),
-                                 {0, 0, 0}, {0, 0, 0}, {(size_t)currentGradientLayer->width, (size_t)currentGradientLayer->height, 1});
+            cl::enqueueCopyImage(
+                currentGradientLayer->getImage2D(), fusionReferenceGradientPyramid[i]->getImage2D(),
+                {0, 0, 0}, {0, 0, 0},
+                {(size_t)currentGradientLayer->width, (size_t)currentGradientLayer->height, 1});
         }
 
-        if (i < levels - 1)
-        {
+        if (i < levels - 1) {
             // Generate next layer in the pyramid
-            resampleImage(glsContext, "downsampleImageXYZ", *currentLayer, fusedFrames == 0 ? newFusedImagePyramid[i + 1].get() : imagePyramid[i].get());
+            resampleImage(
+                glsContext, "downsampleImageXYZ", *currentLayer,
+                fusedFrames == 0 ? newFusedImagePyramid[i + 1].get() : imagePyramid[i].get());
 
-            if (fusedFrames == 0)
-            {
-                resampleImage(glsContext, "downsampleImageXY", *fusionReferenceGradientPyramid[i], fusionReferenceGradientPyramid[i + 1].get());
+            if (fusedFrames == 0) {
+                resampleImage(glsContext, "downsampleImageXY", *fusionReferenceGradientPyramid[i],
+                              fusionReferenceGradientPyramid[i + 1].get());
 
-                cl::enqueueCopyImage(newFusedImagePyramid[i + 1]->getImage2D(), fusionReferenceImagePyramid[i + 1]->getImage2D(),
-                                     {0, 0, 0}, {0, 0, 0}, {(size_t)newFusedImagePyramid[i + 1]->width, (size_t)newFusedImagePyramid[i + 1]->height, 1});
+                cl::enqueueCopyImage(newFusedImagePyramid[i + 1]->getImage2D(),
+                                     fusionReferenceImagePyramid[i + 1]->getImage2D(), {0, 0, 0},
+                                     {0, 0, 0},
+                                     {(size_t)newFusedImagePyramid[i + 1]->width,
+                                      (size_t)newFusedImagePyramid[i + 1]->height, 1});
             }
         }
 
-        if (calibrateFromImage)
-        {
+        if (calibrateFromImage) {
             (*nlfParameters)[i] = MeasureYCbCrNLF(glsContext, *currentLayer, exposure_multiplier);
         }
     }
 
-    if (fusedFrames > 0)
-    {
-        for (int i = levels - 1; i >= 0; i--)
-        {
-            const auto m = gls::Vector<3>{fusionWeights[i][0], fusionWeights[i][1], fusionWeights[i][1]};
-            const auto &np = YCbCrNLF{(*nlfParameters)[i].first * m * m, (*nlfParameters)[i].second * m * m};
+    if (fusedFrames > 0) {
+        for (int i = levels - 1; i >= 0; i--) {
+            const auto m =
+                gls::Vector<3>{fusionWeights[i][0], fusionWeights[i][1], fusionWeights[i][1]};
+            const auto& np =
+                YCbCrNLF{(*nlfParameters)[i].first * m * m, (*nlfParameters)[i].second * m * m};
             const auto currentLayer = i > 0 ? imagePyramid[i - 1].get() : &image;
 
-            if (i < levels - 1)
-            {
+            if (i < levels - 1) {
                 // Subtract the previous layer's noise from the current one
-                std::cout << "Reassembling layer " << i + 1 << " with sharpening: " << (*denoiseParameters)[i].sharpening << std::endl;
+                std::cout << "Reassembling layer " << i + 1
+                          << " with sharpening: " << (*denoiseParameters)[i].sharpening
+                          << std::endl;
 
                 // TODO: The reference image should be the first frame and not be the fused pyramid
-                subtractNoiseFusedImage(glsContext, *currentLayer,
-                                        *(previousFusedImagePyramid[i + 1]),
-                                        *(newFusedImagePyramid[i + 1]),
-                                        subtractedImagePyramid[i].get());
+                subtractNoiseFusedImage(
+                    glsContext, *currentLayer, *(previousFusedImagePyramid[i + 1]),
+                    *(newFusedImagePyramid[i + 1]), subtractedImagePyramid[i].get());
             }
 
             clFuseFrames(glsContext, *fusionReferenceImagePyramid[i],
-                         *fusionReferenceGradientPyramid[i],
-                         *subtractedImagePyramid[i],
-                         *previousFusedImagePyramid[i],
-                         homography,
-                         np.first, np.second, fusedFrames, newFusedImagePyramid[i].get());
+                         *fusionReferenceGradientPyramid[i], *subtractedImagePyramid[i],
+                         *previousFusedImagePyramid[i], homography, np.first, np.second,
+                         fusedFrames, newFusedImagePyramid[i].get());
         }
     }
     fusedFrames++;
 }
 
 template <size_t levels>
-typename PyramidProcessor<levels>::imageType *PyramidProcessor<levels>::getFusedImage(gls::OpenCLContext *glsContext)
-{
-    auto &newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
+typename PyramidProcessor<levels>::imageType* PyramidProcessor<levels>::getFusedImage(
+    gls::OpenCLContext* glsContext) {
+    auto& newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
 
     fusedFrames = 0;
 

--- a/src/pyramid_processor.cpp
+++ b/src/pyramid_processor.cpp
@@ -18,73 +18,81 @@
 #include <iomanip>
 
 template <size_t levels>
-PyramidProcessor<levels>::PyramidProcessor(gls::OpenCLContext* glsContext, int _width, int _height) : width(_width), height(_height), fusedFrames(0) {
-    for (int i = 0, scale = 2; i < levels-1; i++, scale *= 2) {
-        imagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width/scale, height/scale);
-        gradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(glsContext->clContext(), width/scale, height/scale);
+PyramidProcessor<levels>::PyramidProcessor(gls::OpenCLContext *glsContext, int _width, int _height) : width(_width), height(_height), fusedFrames(0)
+{
+    for (int i = 0, scale = 2; i < levels - 1; i++, scale *= 2)
+    {
+        imagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+        gradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(glsContext->clContext(), width / scale, height / scale);
     }
-    for (int i = 0, scale = 1; i < levels; i++, scale *= 2) {
-        denoisedImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width/scale, height/scale);
-        subtractedImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width/scale, height/scale);
+    for (int i = 0, scale = 1; i < levels; i++, scale *= 2)
+    {
+        denoisedImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+        subtractedImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
     }
 }
 
-gls::Vector<3> nflMultiplier(const DenoiseParameters &denoiseParameters) {
+gls::Vector<3> nflMultiplier(const DenoiseParameters &denoiseParameters)
+{
     float luma_mul = denoiseParameters.luma;
     float chroma_mul = denoiseParameters.chroma;
-    return { luma_mul, chroma_mul, chroma_mul };
+    return {luma_mul, chroma_mul, chroma_mul};
 }
 
 #if DEBUG_PYRAMID
 extern const gls::Matrix<3, 3> ycbcr_srgb;
 
-void dumpYCbCrImage(const gls::cl_image_2d<gls::rgba_pixel_float>& image) {
+void dumpYCbCrImage(const gls::cl_image_2d<gls::rgba_pixel_float> &image)
+{
     gls::image<gls::rgb_pixel> out(image.width, image.height);
     const auto downsampledCPU = image.mapImage();
-    out.apply([&downsampledCPU](gls::rgb_pixel* p, int x, int y){
+    out.apply([&downsampledCPU](gls::rgb_pixel *p, int x, int y)
+              {
         const auto& ip = downsampledCPU[y][x];
         const auto& v = ycbcr_srgb * gls::Vector<3>{ip.x, ip.y, ip.z};
         *p = gls::rgb_pixel {
             (uint8_t) (255 * std::sqrt(std::clamp(v[0], 0.0f, 1.0f))),
             (uint8_t) (255 * std::sqrt(std::clamp(v[1], 0.0f, 1.0f))),
             (uint8_t) (255 * std::sqrt(std::clamp(v[2], 0.0f, 1.0f)))
-        };
-    });
+        }; });
     image.unmapImage(downsampledCPU);
     static int count = 1;
     out.write_png_file("/Users/fabio/pyramid_7x7" + std::to_string(count++) + ".png");
 }
 
-void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float>& image);
+void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float> &image);
 
-#endif  // DEBUG_PYRAMID
+#endif // DEBUG_PYRAMID
 
 // TODO: Make this a tunable
 static const constexpr float lumaDenoiseWeight[4] = {
-    1, 1, 1, 1
-};
+    1, 1, 1, 1};
 
 template <size_t levels>
-typename PyramidProcessor<levels>::imageType* PyramidProcessor<levels>::denoise(gls::OpenCLContext* glsContext,
-                                                                                std::array<DenoiseParameters, levels>* denoiseParameters,
-                                                                                const imageType& image,
-                                                                                const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                                                                                std::array<YCbCrNLF, levels>* nlfParameters,
-                                                                                float exposure_multiplier, bool calibrateFromImage) {
+typename PyramidProcessor<levels>::imageType *PyramidProcessor<levels>::denoise(gls::OpenCLContext *glsContext,
+                                                                                std::array<DenoiseParameters, levels> *denoiseParameters,
+                                                                                const imageType &image,
+                                                                                const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                                                                                std::array<YCbCrNLF, levels> *nlfParameters,
+                                                                                float exposure_multiplier, bool calibrateFromImage)
+{
     std::array<gls::Vector<3>, levels> thresholdMultipliers;
 
     // Create gaussian image pyramid an setup noise model
-    for (int i = 0; i < levels; i++) {
+    for (int i = 0; i < levels; i++)
+    {
         const auto currentLayer = i > 0 ? imagePyramid[i - 1].get() : &image;
         const auto currentGradientLayer = i > 0 ? gradientPyramid[i - 1].get() : &gradientImage;
 
-        if (i < levels - 1) {
+        if (i < levels - 1)
+        {
             // Generate next layer in the pyramid
             resampleImage(glsContext, "downsampleImageXYZ", *currentLayer, imagePyramid[i].get());
             resampleImage(glsContext, "downsampleImageXY", *currentGradientLayer, gradientPyramid[i].get());
         }
 
-        if (calibrateFromImage) {
+        if (calibrateFromImage)
+        {
             (*nlfParameters)[i] = MeasureYCbCrNLF(glsContext, *currentLayer, exposure_multiplier);
         }
 
@@ -92,29 +100,31 @@ typename PyramidProcessor<levels>::imageType* PyramidProcessor<levels>::denoise(
     }
 
     // Denoise pyramid layers from the bottom to the top, subtracting the noise of the previous layer from the next
-    for (int i = levels - 1; i >= 0; i--) {
+    for (int i = levels - 1; i >= 0; i--)
+    {
         const auto denoiseInput = i > 0 ? imagePyramid[i - 1].get() : &image;
         const auto gradientInput = i > 0 ? gradientPyramid[i - 1].get() : &gradientImage;
 
-        if (i < levels - 1) {
+        if (i < levels - 1)
+        {
             // Subtract the previous layer's noise from the current one
-            std::cout << "Reassembling layer " << i + 1 << " with sharpening: " << (*denoiseParameters)[i].sharpening << std::endl;
+            // std::cout << "Reassembling layer " << i + 1 << " with sharpening: " << (*denoiseParameters)[i].sharpening << std::endl;
 
-            const auto np = YCbCrNLF {(*nlfParameters)[i].first * thresholdMultipliers[i], (*nlfParameters)[i].second * thresholdMultipliers[i]};
+            const auto np = YCbCrNLF{(*nlfParameters)[i].first * thresholdMultipliers[i], (*nlfParameters)[i].second * thresholdMultipliers[i]};
             subtractNoiseImage(glsContext, *denoiseInput,
                                *(imagePyramid[i]),
-                               *(denoisedImagePyramid[i+1]),
+                               *(denoisedImagePyramid[i + 1]),
                                *gradientInput,
                                lumaDenoiseWeight[i],
                                (*denoiseParameters)[i].sharpening,
-                               { np.first[0], np.second[0] },
+                               {np.first[0], np.second[0]},
                                subtractedImagePyramid[i].get());
         }
 
-        std::cout << "Denoising image level " << i << " with multipliers " << thresholdMultipliers[i] << std::endl;
+        // std::cout << "Denoising image level " << i << " with multipliers " << thresholdMultipliers[i] << std::endl;
 
         // Denoise current layer
-        denoiseImage(glsContext, i < levels - 1 ? *(subtractedImagePyramid[i]) :  *denoiseInput, *gradientInput,
+        denoiseImage(glsContext, i < levels - 1 ? *(subtractedImagePyramid[i]) : *denoiseInput, *gradientInput,
                      (*nlfParameters)[i].first, (*nlfParameters)[i].second, thresholdMultipliers[i],
                      (*denoiseParameters)[i].chromaBoost, (*denoiseParameters)[i].gradientBoost, (*denoiseParameters)[i].gradientThreshold,
                      denoisedImagePyramid[i].get());
@@ -129,81 +139,91 @@ const gls::Vector<2> fusionWeights[5] = {
     {1, 4},
     {1, 4},
     {1, 4},
-    {1, 4}
-};
+    {1, 4}};
 
 template <size_t levels>
-void PyramidProcessor<levels>::fuseFrame(gls::OpenCLContext* glsContext,
-                                         std::array<DenoiseParameters, levels>* denoiseParameters,
-                                         const imageType& image,
-                                         const gls::Matrix<3, 3>& homography,
-                                         const gls::cl_image_2d<gls::luma_alpha_pixel_float>& gradientImage,
-                                         std::array<YCbCrNLF, levels>* nlfParameters,
-                                         float exposure_multiplier, bool calibrateFromImage) {
+void PyramidProcessor<levels>::fuseFrame(gls::OpenCLContext *glsContext,
+                                         std::array<DenoiseParameters, levels> *denoiseParameters,
+                                         const imageType &image,
+                                         const gls::Matrix<3, 3> &homography,
+                                         const gls::cl_image_2d<gls::luma_alpha_pixel_float> &gradientImage,
+                                         std::array<YCbCrNLF, levels> *nlfParameters,
+                                         float exposure_multiplier, bool calibrateFromImage)
+{
     std::cout << "Fusing frame " << fusedFrames << std::endl;
 
-    if (fusionImagePyramidA[0] == nullptr) {
+    if (fusionImagePyramidA[0] == nullptr)
+    {
         std::cout << "Allocating fusionImagePyramid" << std::endl;
-        for (int i = 0, scale = 1; i < levels; i++, scale *= 2) {
-            fusionImagePyramidA[i] = std::make_unique<imageType>(glsContext->clContext(), width/scale, height/scale);
-            fusionImagePyramidB[i] = std::make_unique<imageType>(glsContext->clContext(), width/scale, height/scale);
-            fusionReferenceImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width/scale, height/scale);
-            fusionReferenceGradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(glsContext->clContext(), width/scale, height/scale);
+        for (int i = 0, scale = 1; i < levels; i++, scale *= 2)
+        {
+            fusionImagePyramidA[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+            fusionImagePyramidB[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+            fusionReferenceImagePyramid[i] = std::make_unique<imageType>(glsContext->clContext(), width / scale, height / scale);
+            fusionReferenceGradientPyramid[i] = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(glsContext->clContext(), width / scale, height / scale);
         }
         fusionBuffer[0] = &fusionImagePyramidA;
         fusionBuffer[1] = &fusionImagePyramidB;
     }
 
-    auto& newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 0];
-    auto& previousFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
+    auto &newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 0];
+    auto &previousFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
 
     // Create gaussian image pyramid
-    for (int i = 0; i < levels; i++) {
+    for (int i = 0; i < levels; i++)
+    {
         const auto currentLayer = i > 0 ? (fusedFrames == 0 ? newFusedImagePyramid[i].get() : imagePyramid[i - 1].get()) : &image;
         const auto currentGradientLayer = i > 0 ? gradientPyramid[i - 1].get() : &gradientImage;
 
-        if (fusedFrames == 0 && i == 0) {
+        if (fusedFrames == 0 && i == 0)
+        {
             cl::enqueueCopyImage(currentLayer->getImage2D(), newFusedImagePyramid[i]->getImage2D(),
-                                 {0, 0, 0}, {0, 0, 0}, {(size_t) currentLayer->width, (size_t) currentLayer->height, 1});
+                                 {0, 0, 0}, {0, 0, 0}, {(size_t)currentLayer->width, (size_t)currentLayer->height, 1});
 
             cl::enqueueCopyImage(currentLayer->getImage2D(), fusionReferenceImagePyramid[i]->getImage2D(),
-                                 {0, 0, 0}, {0, 0, 0}, {(size_t) currentLayer->width, (size_t) currentLayer->height, 1});
+                                 {0, 0, 0}, {0, 0, 0}, {(size_t)currentLayer->width, (size_t)currentLayer->height, 1});
 
             cl::enqueueCopyImage(currentGradientLayer->getImage2D(), fusionReferenceGradientPyramid[i]->getImage2D(),
-                                 {0, 0, 0}, {0, 0, 0}, {(size_t) currentGradientLayer->width, (size_t) currentGradientLayer->height, 1});
+                                 {0, 0, 0}, {0, 0, 0}, {(size_t)currentGradientLayer->width, (size_t)currentGradientLayer->height, 1});
         }
 
-        if (i < levels - 1) {
+        if (i < levels - 1)
+        {
             // Generate next layer in the pyramid
-            resampleImage(glsContext, "downsampleImageXYZ", *currentLayer, fusedFrames == 0 ? newFusedImagePyramid[i+1].get() : imagePyramid[i].get());
+            resampleImage(glsContext, "downsampleImageXYZ", *currentLayer, fusedFrames == 0 ? newFusedImagePyramid[i + 1].get() : imagePyramid[i].get());
 
-            if (fusedFrames == 0) {
-                resampleImage(glsContext, "downsampleImageXY", *fusionReferenceGradientPyramid[i], fusionReferenceGradientPyramid[i+1].get());
+            if (fusedFrames == 0)
+            {
+                resampleImage(glsContext, "downsampleImageXY", *fusionReferenceGradientPyramid[i], fusionReferenceGradientPyramid[i + 1].get());
 
-                cl::enqueueCopyImage(newFusedImagePyramid[i+1]->getImage2D(), fusionReferenceImagePyramid[i+1]->getImage2D(),
-                                     {0, 0, 0}, {0, 0, 0}, {(size_t) newFusedImagePyramid[i+1]->width, (size_t) newFusedImagePyramid[i+1]->height, 1});
+                cl::enqueueCopyImage(newFusedImagePyramid[i + 1]->getImage2D(), fusionReferenceImagePyramid[i + 1]->getImage2D(),
+                                     {0, 0, 0}, {0, 0, 0}, {(size_t)newFusedImagePyramid[i + 1]->width, (size_t)newFusedImagePyramid[i + 1]->height, 1});
             }
         }
 
-        if (calibrateFromImage) {
+        if (calibrateFromImage)
+        {
             (*nlfParameters)[i] = MeasureYCbCrNLF(glsContext, *currentLayer, exposure_multiplier);
         }
     }
 
-    if (fusedFrames > 0) {
-        for (int i = levels - 1; i >= 0; i--) {
-            const auto m = gls::Vector<3> { fusionWeights[i][0], fusionWeights[i][1], fusionWeights[i][1] };
-            const auto& np = YCbCrNLF { (*nlfParameters)[i].first * m * m, (*nlfParameters)[i].second * m * m };
+    if (fusedFrames > 0)
+    {
+        for (int i = levels - 1; i >= 0; i--)
+        {
+            const auto m = gls::Vector<3>{fusionWeights[i][0], fusionWeights[i][1], fusionWeights[i][1]};
+            const auto &np = YCbCrNLF{(*nlfParameters)[i].first * m * m, (*nlfParameters)[i].second * m * m};
             const auto currentLayer = i > 0 ? imagePyramid[i - 1].get() : &image;
 
-            if (i < levels - 1) {
+            if (i < levels - 1)
+            {
                 // Subtract the previous layer's noise from the current one
                 std::cout << "Reassembling layer " << i + 1 << " with sharpening: " << (*denoiseParameters)[i].sharpening << std::endl;
 
                 // TODO: The reference image should be the first frame and not be the fused pyramid
                 subtractNoiseFusedImage(glsContext, *currentLayer,
-                                        *(previousFusedImagePyramid[i+1]),
-                                        *(newFusedImagePyramid[i+1]),
+                                        *(previousFusedImagePyramid[i + 1]),
+                                        *(newFusedImagePyramid[i + 1]),
                                         subtractedImagePyramid[i].get());
             }
 
@@ -219,8 +239,9 @@ void PyramidProcessor<levels>::fuseFrame(gls::OpenCLContext* glsContext,
 }
 
 template <size_t levels>
-typename PyramidProcessor<levels>::imageType* PyramidProcessor<levels>::getFusedImage(gls::OpenCLContext* glsContext) {
-    auto& newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
+typename PyramidProcessor<levels>::imageType *PyramidProcessor<levels>::getFusedImage(gls::OpenCLContext *glsContext)
+{
+    auto &newFusedImagePyramid = *fusionBuffer[(fusedFrames & 1) == 1];
 
     fusedFrames = 0;
 

--- a/src/raw_converter.cpp
+++ b/src/raw_converter.cpp
@@ -18,163 +18,173 @@
 #include <iomanip>
 #include <limits>
 
-#include "gls_logging.h"
 #include "demosaic.hpp"
+#include "gls_logging.h"
 
-static const char *TAG = "RAW Converter";
+static const char* TAG = "RAW Converter";
 
 #define PRINT_EXECUTION_TIME true
 
-void RawConverter::allocateTextures(gls::OpenCLContext *glsContext, int width, int height)
-{
+void RawConverter::allocateTextures(gls::OpenCLContext* glsContext, int width, int height) {
     auto clContext = glsContext->clContext();
 
-    if (!clRawImage || clRawImage->width != width || clRawImage->height != height)
-    {
-        clRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(clContext, width, height);
-        clScaledRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
-        clRawSobelImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
-        clRawGradientImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(clContext, width, height);
-        clGreenImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
-        clLinearRGBImageA = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
-        clLinearRGBImageB = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
-        clsRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
+    if (!clRawImage || clRawImage->width != width || clRawImage->height != height) {
+        clRawImage =
+            std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(clContext, width, height);
+        clScaledRawImage =
+            std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
+        clRawSobelImage =
+            std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
+        clRawGradientImage = std::make_unique<gls::cl_image_2d<gls::luma_alpha_pixel_float>>(
+            clContext, width, height);
+        clGreenImage =
+            std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
+        clLinearRGBImageA =
+            std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
+        clLinearRGBImageB =
+            std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
+        clsRGBImage =
+            std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
 
         pyramidProcessor = std::make_unique<PyramidProcessor<5>>(glsContext, width, height);
 
-        // const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("Assets/HDR_L_0b.png");
-        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file(_assets_root / "HDR_L_0b.png");
-        clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(), *blueNoise);
+        // const auto blueNoise =
+        // gls::image<gls::luma_pixel_16>::read_png_file("Assets/HDR_L_0b.png");
+        const auto blueNoise =
+            gls::image<gls::luma_pixel_16>::read_png_file(_assets_root / "HDR_L_0b.png");
+        clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(
+            _glsContext->clContext(), *blueNoise);
     }
 }
 
-void RawConverter::allocateHighNoiseTextures(gls::OpenCLContext *glsContext, int width, int height)
-{
+void RawConverter::allocateHighNoiseTextures(gls::OpenCLContext* glsContext, int width,
+                                             int height) {
     auto clContext = glsContext->clContext();
 
-    if (!rgbaRawImage || rgbaRawImage->width != width / 2 || rgbaRawImage->height != height / 2)
-    {
-        rgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
-        denoisedRgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
+    if (!rgbaRawImage || rgbaRawImage->width != width / 2 || rgbaRawImage->height != height / 2) {
+        rgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(
+            clContext, width / 2, height / 2);
+        denoisedRgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(
+            clContext, width / 2, height / 2);
 
-        //        // TODO: where do we keep the blue noise texture asset? Maybe generate this dynamically?
-        //        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("/Users/fabio/work/CLImage/CLImage/app/src/main/assets/HDR_L_0.png");
-        //        clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(), *blueNoise);
+        //        // TODO: where do we keep the blue noise texture asset? Maybe generate this
+        //        dynamically? const auto blueNoise =
+        //        gls::image<gls::luma_pixel_16>::read_png_file("/Users/fabio/work/CLImage/CLImage/app/src/main/assets/HDR_L_0.png");
+        //        clBlueNoise =
+        //        std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(),
+        //        *blueNoise);
     }
 }
 
-void RawConverter::allocateFastDemosaicTextures(gls::OpenCLContext *glsContext, int width, int height)
-{
+void RawConverter::allocateFastDemosaicTextures(gls::OpenCLContext* glsContext, int width,
+                                                int height) {
     auto clContext = glsContext->clContext();
 
-    if (!clFastLinearRGBImage || clFastLinearRGBImage->width != width / 2 || clFastLinearRGBImage->height != height / 2)
-    {
-        clRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(clContext, width, height);
-        clScaledRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
-        clFastLinearRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
-        clsFastRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
+    if (!clFastLinearRGBImage || clFastLinearRGBImage->width != width / 2 ||
+        clFastLinearRGBImage->height != height / 2) {
+        clRawImage =
+            std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(clContext, width, height);
+        clScaledRawImage =
+            std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
+        clFastLinearRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(
+            clContext, width / 2, height / 2);
+        clsFastRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(
+            clContext, width / 2, height / 2);
     }
 }
 
 template <typename T>
-void SaveRawChannels(const gls::image<T> &rawImage, float maxVal, const std::string &basePath)
-{
+void SaveRawChannels(const gls::image<T>& rawImage, float maxVal, const std::string& basePath) {
     gls::image<gls::luma_pixel> chan0(rawImage.width / 2, rawImage.height / 2);
     gls::image<gls::luma_pixel> chan1(rawImage.width / 2, rawImage.height / 2);
     gls::image<gls::luma_pixel> chan2(rawImage.width / 2, rawImage.height / 2);
     gls::image<gls::luma_pixel> chan3(rawImage.width / 2, rawImage.height / 2);
 
-    rawImage.apply([&chan0, &chan1, &chan2, &chan3, maxVal](const T &p, int x, int y)
-                   {
-        uint8_t val = 255 * std::sqrt(std::clamp((float) p, 0.0f, maxVal) / maxVal);
+    rawImage.apply([&chan0, &chan1, &chan2, &chan3, maxVal](const T& p, int x, int y) {
+        uint8_t val = 255 * std::sqrt(std::clamp((float)p, 0.0f, maxVal) / maxVal);
 
         if ((x & 0) == 0 && (y & 0) == 0) {
-            chan0[y/2][x/2] = val;
+            chan0[y / 2][x / 2] = val;
         }
         if ((x & 1) == 0 && (y & 0) == 0) {
-            chan1[y/2][x/2] = val;
+            chan1[y / 2][x / 2] = val;
         }
         if ((x & 0) == 0 && (y & 1) == 0) {
-            chan2[y/2][x/2] = val;
+            chan2[y / 2][x / 2] = val;
         }
         if ((x & 1) == 0 && (y & 1) == 0) {
-            chan3[y/2][x/2] = val;
-        } });
+            chan3[y / 2][x / 2] = val;
+        }
+    });
     chan0.write_png_file(basePath + "0.png");
     chan1.write_png_file(basePath + "1.png");
     chan2.write_png_file(basePath + "2.png");
     chan3.write_png_file(basePath + "3.png");
 }
 
-void saveGreenChannel(const gls::cl_image_2d<gls::luma_pixel_float> &clGreenImage)
-{
+void saveGreenChannel(const gls::cl_image_2d<gls::luma_pixel_float>& clGreenImage) {
     gls::image<gls::luma_pixel> out(clGreenImage.width, clGreenImage.height);
     const auto greenImageCPU = clGreenImage.mapImage();
-    out.apply([&greenImageCPU](gls::luma_pixel *p, int x, int y)
-              {
+    out.apply([&greenImageCPU](gls::luma_pixel* p, int x, int y) {
         const auto& ip = greenImageCPU[y][x];
-        *p = gls::luma_pixel {
-            (uint8_t) (255 * std::sqrt(std::clamp((float) ip.luma, 0.0f, 1.0f)))
-        }; });
+        *p = gls::luma_pixel{(uint8_t)(255 * std::sqrt(std::clamp((float)ip.luma, 0.0f, 1.0f)))};
+    });
     clGreenImage.unmapImage(greenImageCPU);
     static int count = 1;
     out.write_png_file("/Users/fabio/green" + std::to_string(count++) + ".png");
 }
 
-std::array<gls::Vector<2>, 3> getRawVariance(const RawNLF &rawNLF)
-{
-    const gls::Vector<2> greenVariance = {(rawNLF.first[1] + rawNLF.first[3]) / 2, (rawNLF.second[1] + rawNLF.second[3]) / 2};
+std::array<gls::Vector<2>, 3> getRawVariance(const RawNLF& rawNLF) {
+    const gls::Vector<2> greenVariance = {(rawNLF.first[1] + rawNLF.first[3]) / 2,
+                                          (rawNLF.second[1] + rawNLF.second[3]) / 2};
     const gls::Vector<2> redVariance = {rawNLF.first[0], rawNLF.second[0]};
     const gls::Vector<2> blueVariance = {rawNLF.first[2], rawNLF.second[2]};
 
     return {redVariance, greenVariance, blueVariance};
 }
 
-template<typename T>
+template <typename T>
 void dumpGradientImage(const gls::cl_image_2d<T>& image) {
     gls::image<gls::rgb_pixel> out(image.width, image.height);
     const auto image_cpu = image.mapImage();
-    out.apply([&](gls::rgb_pixel *p, int x, int y)
-              {
+    out.apply([&](gls::rgb_pixel* p, int x, int y) {
         const auto& ip = image_cpu[y][x];
 
         // float direction = (1 + atan2(ip.y, ip.x) / M_PI) / 2;
         // float direction = atan2(abs(ip.y), ip.x) / M_PI;
         float direction = std::atan2(std::abs(ip.y), std::abs(ip.x)) / M_PI_2;
-        float magnitude = std::sqrt((float) (ip.x * ip.x + ip.y * ip.y));
+        float magnitude = std::sqrt((float)(ip.x * ip.x + ip.y * ip.y));
 
         uint8_t val = std::clamp(255 * std::sqrt(magnitude), 0.0f, 255.0f);
 
-        *p = gls::rgb_pixel {
-            (uint8_t) (val * std::lerp(1.0f, 0.0f, direction)),
+        *p = gls::rgb_pixel{
+            (uint8_t)(val * std::lerp(1.0f, 0.0f, direction)),
             0,
-            (uint8_t) (val * std::lerp(1.0f, 0.0f, 1 - direction)),
-        }; });
+            (uint8_t)(val * std::lerp(1.0f, 0.0f, 1 - direction)),
+        };
+    });
     image.unmapImage(image_cpu);
     static int count = 0;
     out.write_png_file("/Users/fabio/raw_gradient_sgn_5_fine_" + std::to_string(count++) + ".png");
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::demosaic(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                                DemosaicParameters *demosaicParameters, bool calibrateFromImage)
-{
+gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::demosaic(
+    const gls::image<gls::luma_pixel_16>& rawImage, DemosaicParameters* demosaicParameters,
+    bool calibrateFromImage) {
     // LOG_INFO(TAG) << "Begin Demosaicing..." << std::endl;
 
     allocateTextures(_glsContext, rawImage.width, rawImage.height);
 
-    if (demosaicParameters->rgbConversionParameters.localToneMapping)
-    {
+    if (demosaicParameters->rgbConversionParameters.localToneMapping) {
         localToneMapping->allocateTextures(_glsContext, rawImage.width, rawImage.height);
     }
 
     // Copy input data to the OpenCL input buffer
-    clRawImage->copyPixelsFrom(rawImage); // clRawImage still has values
+    clRawImage->copyPixelsFrom(rawImage);  // clRawImage still has values
 
     // TODO: clRawImage comes out black here! scale_mul is zero if whitelevel is 65k
-    scaleRawData(_glsContext, *clRawImage, clScaledRawImage.get(),
-                 demosaicParameters->bayerPattern,
-                 demosaicParameters->scale_mul,
-                 demosaicParameters->black_level / 0xffff);
+    scaleRawData(_glsContext, *clRawImage, clScaledRawImage.get(), demosaicParameters->bayerPattern,
+                 demosaicParameters->scale_mul, demosaicParameters->black_level / 0xffff);
 
     rawImageSobel(_glsContext, *clScaledRawImage, clRawSobelImage.get());
     // dumpGradientImage(*clRawSobelImage);
@@ -193,38 +203,45 @@ gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::demosaic(const gls::image
 
     const bool high_noise_image = rawVariance[1][1] > kHighNoiseVariance;
 
-    // std::cout << "Green Channel RAW Variance: " << std::scientific << rawVariance[1][1] << ", high_noise_image: " << high_noise_image << std::endl;
+    // std::cout << "Green Channel RAW Variance: " << std::scientific << rawVariance[1][1] << ",
+    // high_noise_image: " << high_noise_image << std::endl;
 
-    if (high_noise_image)
-    {
+    if (high_noise_image) {
         // std::cout << "Despeckeling RAW Image" << std::endl;
 
         allocateHighNoiseTextures(_glsContext, rawImage.width, rawImage.height);
 
-        bayerToRawRGBA(_glsContext, *clScaledRawImage, rgbaRawImage.get(), demosaicParameters->bayerPattern);
+        bayerToRawRGBA(_glsContext, *clScaledRawImage, rgbaRawImage.get(),
+                       demosaicParameters->bayerPattern);
 
-        despeckleRawRGBAImage(_glsContext, *rgbaRawImage, noiseModel->rawNlf.second, denoisedRgbaRawImage.get());
+        despeckleRawRGBAImage(_glsContext, *rgbaRawImage, noiseModel->rawNlf.second,
+                              denoisedRgbaRawImage.get());
 
-        // denoiseRawRGBAImage(_glsContext, *denoisedRgbaRawImage, noiseModel->rawNlf.second, rgbaRawImage.get());
+        // denoiseRawRGBAImage(_glsContext, *denoisedRgbaRawImage, noiseModel->rawNlf.second,
+        // rgbaRawImage.get());
 
-        rawRGBAToBayer(_glsContext, *denoisedRgbaRawImage, clScaledRawImage.get(), demosaicParameters->bayerPattern);
+        rawRGBAToBayer(_glsContext, *denoisedRgbaRawImage, clScaledRawImage.get(),
+                       demosaicParameters->bayerPattern);
     }
 
-    gaussianBlurSobelImage(_glsContext, *clScaledRawImage, *clRawSobelImage, rawVariance[1], 1.5, 4.5, clRawGradientImage.get());
+    gaussianBlurSobelImage(_glsContext, *clScaledRawImage, *clRawSobelImage, rawVariance[1], 1.5,
+                           4.5, clRawGradientImage.get());
     // dumpGradientImage(*clRawGradientImage);
 
-    //    malvar(_glsContext, *clScaledRawImage, *clRawGradientImage, clLinearRGBImageA.get(), demosaicParameters->bayerPattern,
+    //    malvar(_glsContext, *clScaledRawImage, *clRawGradientImage, clLinearRGBImageA.get(),
+    //    demosaicParameters->bayerPattern,
     //           rawVariance[0], rawVariance[1], rawVariance[2]);
 
-    interpolateGreen(_glsContext, *clScaledRawImage, *clRawGradientImage, clGreenImage.get(), demosaicParameters->bayerPattern, rawVariance[1]);
+    interpolateGreen(_glsContext, *clScaledRawImage, *clRawGradientImage, clGreenImage.get(),
+                     demosaicParameters->bayerPattern, rawVariance[1]);
 
-    interpolateRedBlue(_glsContext, *clScaledRawImage, *clGreenImage,
-                       *clRawGradientImage, clLinearRGBImageA.get(),
-                       demosaicParameters->bayerPattern, rawVariance[0], rawVariance[2]);
+    interpolateRedBlue(_glsContext, *clScaledRawImage, *clGreenImage, *clRawGradientImage,
+                       clLinearRGBImageA.get(), demosaicParameters->bayerPattern, rawVariance[0],
+                       rawVariance[2]);
 
-    interpolateRedBlueAtGreen(_glsContext, *clLinearRGBImageA,
-                              *clRawGradientImage, clLinearRGBImageA.get(),
-                              demosaicParameters->bayerPattern, rawVariance[0], rawVariance[2]);
+    interpolateRedBlueAtGreen(_glsContext, *clLinearRGBImageA, *clRawGradientImage,
+                              clLinearRGBImageA.get(), demosaicParameters->bayerPattern,
+                              rawVariance[0], rawVariance[2]);
 
     // Recover clipped highlights
     blendHighlightsImage(_glsContext, *clLinearRGBImageA, /*clip=*/1.0, clLinearRGBImageA.get());
@@ -232,74 +249,73 @@ gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::demosaic(const gls::image
     return clLinearRGBImageA.get();
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::denoise(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
-                                                               DemosaicParameters *demosaicParameters, bool calibrateFromImage)
-{
-    NoiseModel<5> *noiseModel = &demosaicParameters->noiseModel;
+gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::denoise(
+    const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+    DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
+    NoiseModel<5>* noiseModel = &demosaicParameters->noiseModel;
 
     // Luma and Chroma Despeckling
-    const auto &np = noiseModel->pyramidNlf[0];
+    const auto& np = noiseModel->pyramidNlf[0];
     despeckleImage(_glsContext, inputImage,
                    /*var_a=*/np.first,
-                   /*var_b=*/np.second,
-                   clLinearRGBImageB.get());
+                   /*var_b=*/np.second, clLinearRGBImageB.get());
 
-    gls::cl_image_2d<gls::rgba_pixel_float> *clDenoisedImage =
-        pyramidProcessor->denoise(_glsContext, &(demosaicParameters->denoiseParameters),
-                                  *clLinearRGBImageB,
-                                  *clRawGradientImage,
-                                  &(noiseModel->pyramidNlf), demosaicParameters->exposure_multiplier, calibrateFromImage);
+    gls::cl_image_2d<gls::rgba_pixel_float>* clDenoisedImage = pyramidProcessor->denoise(
+        _glsContext, &(demosaicParameters->denoiseParameters), *clLinearRGBImageB,
+        *clRawGradientImage, &(noiseModel->pyramidNlf), demosaicParameters->exposure_multiplier,
+        calibrateFromImage);
 
-    if (demosaicParameters->rgbConversionParameters.localToneMapping)
-    {
-        const std::array<const gls::cl_image_2d<gls::rgba_pixel_float> *, 3> &guideImage = {
+    if (demosaicParameters->rgbConversionParameters.localToneMapping) {
+        const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage = {
             pyramidProcessor->denoisedImagePyramid[4].get(),
             pyramidProcessor->denoisedImagePyramid[2].get(),
             pyramidProcessor->denoisedImagePyramid[0].get()};
-        localToneMapping->createMask(_glsContext, *clDenoisedImage, guideImage, *noiseModel, *demosaicParameters);
+        localToneMapping->createMask(_glsContext, *clDenoisedImage, guideImage, *noiseModel,
+                                     *demosaicParameters);
     }
 
     // High ISO noise texture replacement
-    if (clBlueNoise != nullptr)
-    {
+    if (clBlueNoise != nullptr) {
         const gls::Vector<2> lumaVariance = {np.first[0], np.second[0]};
 
-        // std::cout << "Adding Blue Noise for variance: " << std::scientific << lumaVariance << std::endl;
+        // std::cout << "Adding Blue Noise for variance: " << std::scientific << lumaVariance <<
+        // std::endl;
 
         const auto grainAmount = 1 + 3 * smoothstep(4e-4, 6e-4, lumaVariance[1]);
 
-        blueNoiseImage(_glsContext, *clDenoisedImage, *clBlueNoise, 2 * grainAmount * lumaVariance, clLinearRGBImageB.get());
+        blueNoiseImage(_glsContext, *clDenoisedImage, *clBlueNoise, 2 * grainAmount * lumaVariance,
+                       clLinearRGBImageB.get());
         clDenoisedImage = clLinearRGBImageB.get();
     }
 
     return clDenoisedImage;
 }
 
-void RawConverter::fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage, const gls::Matrix<3, 3> &homography,
-                             DemosaicParameters *demosaicParameters, bool calibrateFromImage)
-{
-    NoiseModel<5> *noiseModel = &demosaicParameters->noiseModel;
-    pyramidProcessor->fuseFrame(_glsContext, &(demosaicParameters->denoiseParameters), inputImage, homography,
-                                *clRawGradientImage, &(noiseModel->pyramidNlf),
+void RawConverter::fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+                             const gls::Matrix<3, 3>& homography,
+                             DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
+    NoiseModel<5>* noiseModel = &demosaicParameters->noiseModel;
+    pyramidProcessor->fuseFrame(_glsContext, &(demosaicParameters->denoiseParameters), inputImage,
+                                homography, *clRawGradientImage, &(noiseModel->pyramidNlf),
                                 demosaicParameters->exposure_multiplier, calibrateFromImage);
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::getFusedImage()
-{
+gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::getFusedImage() {
     return pyramidProcessor->getFusedImage(_glsContext);
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::postProcess(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
-                                                                   const DemosaicParameters &demosaicParameters)
-{
-    convertTosRGB(_glsContext, inputImage, localToneMapping->getMask(), clsRGBImage.get(), demosaicParameters);
+gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::postProcess(
+    const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
+    const DemosaicParameters& demosaicParameters) {
+    convertTosRGB(_glsContext, inputImage, localToneMapping->getMask(), clsRGBImage.get(),
+                  demosaicParameters);
 
     return clsRGBImage.get();
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                                   DemosaicParameters *demosaicParameters, bool calibrateFromImage)
-{
+gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runPipeline(
+    const gls::image<gls::luma_pixel_16>& rawImage, DemosaicParameters* demosaicParameters,
+    bool calibrateFromImage) {
     auto t_start = std::chrono::high_resolution_clock::now();
 
     // --- Image Demosaicing ---
@@ -312,14 +328,17 @@ gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runPipeline(const gls::im
     // Convert linear image to YCbCr for denoising
     const auto cam_to_ycbcr = cam_ycbcr(demosaicParameters->rgb_cam);
 
-    // std::cout << "cam_to_ycbcr: " << std::setprecision(4) << std::scientific << cam_to_ycbcr.span() << std::endl;
+    // std::cout << "cam_to_ycbcr: " << std::setprecision(4) << std::scientific <<
+    // cam_to_ycbcr.span() << std::endl;
 
     transformImage(_glsContext, *demosaicedImage, clLinearRGBImageA.get(), cam_to_ycbcr);
 
-    const auto clDenoisedImage = denoise(*clLinearRGBImageA, demosaicParameters, calibrateFromImage);
+    const auto clDenoisedImage =
+        denoise(*clLinearRGBImageA, demosaicParameters, calibrateFromImage);
 
     // Convert result back to camera RGB
-    const auto normalized_ycbcr_to_cam = inverse(cam_to_ycbcr) * demosaicParameters->exposure_multiplier;
+    const auto normalized_ycbcr_to_cam =
+        inverse(cam_to_ycbcr) * demosaicParameters->exposure_multiplier;
     transformImage(_glsContext, *clDenoisedImage, clLinearRGBImageA.get(), normalized_ycbcr_to_cam);
 
     // --- Image Post Processing ---
@@ -331,14 +350,14 @@ gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runPipeline(const gls::im
     auto t_end = std::chrono::high_resolution_clock::now();
     double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    // LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    // LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image
+    // of size: " << rawImage.width << " x " << rawImage.height << std::endl;
 
     return sRGBImage;
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runFastPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
-                                                                       const DemosaicParameters &demosaicParameters)
-{
+gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runFastPipeline(
+    const gls::image<gls::luma_pixel_16>& rawImage, const DemosaicParameters& demosaicParameters) {
     allocateFastDemosaicTextures(_glsContext, rawImage.width, rawImage.height);
 
     LOG_INFO(TAG) << "Begin Fast Demosaicing (GPU)..." << std::endl;
@@ -350,50 +369,54 @@ gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runFastPipeline(const gls
 
     // --- Image Demosaicing ---
 
-    scaleRawData(_glsContext, *clRawImage, clScaledRawImage.get(), demosaicParameters.bayerPattern, demosaicParameters.scale_mul,
-                 demosaicParameters.black_level / 0xffff);
+    scaleRawData(_glsContext, *clRawImage, clScaledRawImage.get(), demosaicParameters.bayerPattern,
+                 demosaicParameters.scale_mul, demosaicParameters.black_level / 0xffff);
 
-    fasteDebayer(_glsContext, *clScaledRawImage, clFastLinearRGBImage.get(), demosaicParameters.bayerPattern);
+    fasteDebayer(_glsContext, *clScaledRawImage, clFastLinearRGBImage.get(),
+                 demosaicParameters.bayerPattern);
 
     // Recover clipped highlights
-    blendHighlightsImage(_glsContext, *clFastLinearRGBImage, /*clip=*/1.0, clFastLinearRGBImage.get());
+    blendHighlightsImage(_glsContext, *clFastLinearRGBImage, /*clip=*/1.0,
+                         clFastLinearRGBImage.get());
 
     // --- Image Post Processing ---
 
-    convertTosRGB(_glsContext, *clFastLinearRGBImage, localToneMapping->getMask(), clsFastRGBImage.get(), demosaicParameters);
+    convertTosRGB(_glsContext, *clFastLinearRGBImage, localToneMapping->getMask(),
+                  clsFastRGBImage.get(), demosaicParameters);
 
     cl::CommandQueue queue = cl::CommandQueue::getDefault();
     queue.finish();
     auto t_end = std::chrono::high_resolution_clock::now();
     double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms
+                  << "ms for image of size: " << rawImage.width << " x " << rawImage.height
+                  << std::endl;
 
     return clsFastRGBImage.get();
 }
 
 template <typename T>
-/*static*/ typename gls::image<T>::unique_ptr RawConverter::convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage)
-{
+/*static*/ typename gls::image<T>::unique_ptr RawConverter::convertToRGBImage(
+    const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage) {
     const constexpr auto scale = std::numeric_limits<typename T::value_type>::max();
 
     auto rgbImage = std::make_unique<gls::image<T>>(clRGBAImage.width, clRGBAImage.height);
     auto rgbaImage = clRGBAImage.mapImage();
-    for (int y = 0; y < clRGBAImage.height; y++)
-    {
-        for (int x = 0; x < clRGBAImage.width; x++)
-        {
-            const auto &p = rgbaImage[y][x];
-            (*rgbImage)[y][x] = {
-                (typename T::value_type)(scale * p.red),
-                (typename T::value_type)(scale * p.green),
-                (typename T::value_type)(scale * p.blue)};
+    for (int y = 0; y < clRGBAImage.height; y++) {
+        for (int x = 0; x < clRGBAImage.width; x++) {
+            const auto& p = rgbaImage[y][x];
+            (*rgbImage)[y][x] = {(typename T::value_type)(scale * p.red),
+                                 (typename T::value_type)(scale * p.green),
+                                 (typename T::value_type)(scale * p.blue)};
         }
     }
     clRGBAImage.unmapImage(rgbaImage);
     return rgbImage;
 }
 
-template gls::image<gls::rgb_pixel>::unique_ptr RawConverter::convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage);
+template gls::image<gls::rgb_pixel>::unique_ptr RawConverter::convertToRGBImage(
+    const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage);
 
-template gls::image<gls::rgb_pixel_16>::unique_ptr RawConverter::convertToRGBImage<gls::rgb_pixel_16>(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage);
+template gls::image<gls::rgb_pixel_16>::unique_ptr RawConverter::convertToRGBImage<
+    gls::rgb_pixel_16>(const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage);

--- a/src/raw_converter.cpp
+++ b/src/raw_converter.cpp
@@ -21,14 +21,16 @@
 #include "gls_logging.h"
 #include "demosaic.hpp"
 
-static const char* TAG = "RAW Converter";
+static const char *TAG = "RAW Converter";
 
 #define PRINT_EXECUTION_TIME true
 
-void RawConverter::allocateTextures(gls::OpenCLContext* glsContext, int width, int height) {
+void RawConverter::allocateTextures(gls::OpenCLContext *glsContext, int width, int height)
+{
     auto clContext = glsContext->clContext();
 
-    if (!clRawImage || clRawImage->width != width || clRawImage->height != height) {
+    if (!clRawImage || clRawImage->width != width || clRawImage->height != height)
+    {
         clRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(clContext, width, height);
         clScaledRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
         clRawSobelImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width, height);
@@ -40,43 +42,50 @@ void RawConverter::allocateTextures(gls::OpenCLContext* glsContext, int width, i
 
         pyramidProcessor = std::make_unique<PyramidProcessor<5>>(glsContext, width, height);
 
-        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("Assets/HDR_L_0b.png");
+        // const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("Assets/HDR_L_0b.png");
+        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file(_assets_root / "HDR_L_0b.png");
         clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(), *blueNoise);
     }
 }
 
-void RawConverter::allocateHighNoiseTextures(gls::OpenCLContext* glsContext, int width, int height) {
+void RawConverter::allocateHighNoiseTextures(gls::OpenCLContext *glsContext, int width, int height)
+{
     auto clContext = glsContext->clContext();
 
-    if (!rgbaRawImage || rgbaRawImage->width != width/2 || rgbaRawImage->height != height/2) {
-        rgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width/2, height/2);
-        denoisedRgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width/2, height/2);
+    if (!rgbaRawImage || rgbaRawImage->width != width / 2 || rgbaRawImage->height != height / 2)
+    {
+        rgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
+        denoisedRgbaRawImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
 
-//        // TODO: where do we keep the blue noise texture asset? Maybe generate this dynamically?
-//        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("/Users/fabio/work/CLImage/CLImage/app/src/main/assets/HDR_L_0.png");
-//        clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(), *blueNoise);
+        //        // TODO: where do we keep the blue noise texture asset? Maybe generate this dynamically?
+        //        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("/Users/fabio/work/CLImage/CLImage/app/src/main/assets/HDR_L_0.png");
+        //        clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(), *blueNoise);
     }
 }
 
-void RawConverter::allocateFastDemosaicTextures(gls::OpenCLContext* glsContext, int width, int height) {
+void RawConverter::allocateFastDemosaicTextures(gls::OpenCLContext *glsContext, int width, int height)
+{
     auto clContext = glsContext->clContext();
 
-    if (!clFastLinearRGBImage || clFastLinearRGBImage->width != width/2 || clFastLinearRGBImage->height != height/2) {
+    if (!clFastLinearRGBImage || clFastLinearRGBImage->width != width / 2 || clFastLinearRGBImage->height != height / 2)
+    {
         clRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(clContext, width, height);
         clScaledRawImage = std::make_unique<gls::cl_image_2d<gls::luma_pixel_float>>(clContext, width, height);
-        clFastLinearRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width/2, height/2);
-        clsFastRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width/2, height/2);
+        clFastLinearRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
+        clsFastRGBImage = std::make_unique<gls::cl_image_2d<gls::rgba_pixel_float>>(clContext, width / 2, height / 2);
     }
 }
 
 template <typename T>
-void SaveRawChannels(const gls::image<T>& rawImage, float maxVal, const std::string& basePath) {
-    gls::image<gls::luma_pixel> chan0(rawImage.width/2, rawImage.height/2);
-    gls::image<gls::luma_pixel> chan1(rawImage.width/2, rawImage.height/2);
-    gls::image<gls::luma_pixel> chan2(rawImage.width/2, rawImage.height/2);
-    gls::image<gls::luma_pixel> chan3(rawImage.width/2, rawImage.height/2);
+void SaveRawChannels(const gls::image<T> &rawImage, float maxVal, const std::string &basePath)
+{
+    gls::image<gls::luma_pixel> chan0(rawImage.width / 2, rawImage.height / 2);
+    gls::image<gls::luma_pixel> chan1(rawImage.width / 2, rawImage.height / 2);
+    gls::image<gls::luma_pixel> chan2(rawImage.width / 2, rawImage.height / 2);
+    gls::image<gls::luma_pixel> chan3(rawImage.width / 2, rawImage.height / 2);
 
-    rawImage.apply([&chan0, &chan1, &chan2, &chan3, maxVal](const T& p, int x, int y){
+    rawImage.apply([&chan0, &chan1, &chan2, &chan3, maxVal](const T &p, int x, int y)
+                   {
         uint8_t val = 255 * std::sqrt(std::clamp((float) p, 0.0f, maxVal) / maxVal);
 
         if ((x & 0) == 0 && (y & 0) == 0) {
@@ -90,40 +99,43 @@ void SaveRawChannels(const gls::image<T>& rawImage, float maxVal, const std::str
         }
         if ((x & 1) == 0 && (y & 1) == 0) {
             chan3[y/2][x/2] = val;
-        }
-    });
+        } });
     chan0.write_png_file(basePath + "0.png");
     chan1.write_png_file(basePath + "1.png");
     chan2.write_png_file(basePath + "2.png");
     chan3.write_png_file(basePath + "3.png");
 }
 
-void saveGreenChannel(const gls::cl_image_2d<gls::luma_pixel_float>& clGreenImage) {
+void saveGreenChannel(const gls::cl_image_2d<gls::luma_pixel_float> &clGreenImage)
+{
     gls::image<gls::luma_pixel> out(clGreenImage.width, clGreenImage.height);
     const auto greenImageCPU = clGreenImage.mapImage();
-    out.apply([&greenImageCPU](gls::luma_pixel* p, int x, int y){
+    out.apply([&greenImageCPU](gls::luma_pixel *p, int x, int y)
+              {
         const auto& ip = greenImageCPU[y][x];
         *p = gls::luma_pixel {
             (uint8_t) (255 * std::sqrt(std::clamp((float) ip.luma, 0.0f, 1.0f)))
-        };
-    });
+        }; });
     clGreenImage.unmapImage(greenImageCPU);
     static int count = 1;
     out.write_png_file("/Users/fabio/green" + std::to_string(count++) + ".png");
 }
 
-std::array<gls::Vector<2>, 3> getRawVariance(const RawNLF& rawNLF) {
-    const gls::Vector<2> greenVariance = { (rawNLF.first[1] + rawNLF.first[3]) / 2, (rawNLF.second[1] + rawNLF.second[3]) / 2 };
-    const gls::Vector<2> redVariance = { rawNLF.first[0], rawNLF.second[0] };
-    const gls::Vector<2> blueVariance = { rawNLF.first[2], rawNLF.second[2] };
+std::array<gls::Vector<2>, 3> getRawVariance(const RawNLF &rawNLF)
+{
+    const gls::Vector<2> greenVariance = {(rawNLF.first[1] + rawNLF.first[3]) / 2, (rawNLF.second[1] + rawNLF.second[3]) / 2};
+    const gls::Vector<2> redVariance = {rawNLF.first[0], rawNLF.second[0]};
+    const gls::Vector<2> blueVariance = {rawNLF.first[2], rawNLF.second[2]};
 
-    return { redVariance, greenVariance, blueVariance };
+    return {redVariance, greenVariance, blueVariance};
 }
 
-void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float>& image) {
+void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float> &image)
+{
     gls::image<gls::rgb_pixel> out(image.width, image.height);
     const auto image_cpu = image.mapImage();
-    out.apply([&](gls::rgb_pixel* p, int x, int y) {
+    out.apply([&](gls::rgb_pixel *p, int x, int y)
+              {
         const auto& ip = image_cpu[y][x];
 
         // float direction = (1 + atan2(ip.y, ip.x) / M_PI) / 2;
@@ -137,36 +149,52 @@ void dumpGradientImage(const gls::cl_image_2d<gls::luma_alpha_pixel_float>& imag
             (uint8_t) (val * std::lerp(1.0f, 0.0f, direction)),
             0,
             (uint8_t) (val * std::lerp(1.0f, 0.0f, 1 - direction)),
-        };
-    });
+        }; });
     image.unmapImage(image_cpu);
     static int count = 1;
     out.write_png_file("/Users/fabio/raw_gradient_sgn_5_fine_" + std::to_string(count++) + ".png");
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::demosaic(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                                DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
-    LOG_INFO(TAG) << "Begin Demosaicing..." << std::endl;
+gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::demosaic(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                                DemosaicParameters *demosaicParameters, bool calibrateFromImage)
+{
+    // LOG_INFO(TAG) << "Begin Demosaicing..." << std::endl;
 
     allocateTextures(_glsContext, rawImage.width, rawImage.height);
 
-    if (demosaicParameters->rgbConversionParameters.localToneMapping) {
+    if (demosaicParameters->rgbConversionParameters.localToneMapping)
+    {
         localToneMapping->allocateTextures(_glsContext, rawImage.width, rawImage.height);
     }
 
     // Copy input data to the OpenCL input buffer
-    clRawImage->copyPixelsFrom(rawImage);
+    clRawImage->copyPixelsFrom(rawImage); // clRawImage still has values
 
+    // TODO: clRawImage comes out black here! scale_mul is zero if whitelevel is 65k
     scaleRawData(_glsContext, *clRawImage, clScaledRawImage.get(),
                  demosaicParameters->bayerPattern,
                  demosaicParameters->scale_mul,
                  demosaicParameters->black_level / 0xffff);
 
-    NoiseModel<5>* noiseModel = &demosaicParameters->noiseModel;
+    // int max = 0;
+    // auto clScaledRawImage_map = clScaledRawImage->mapImage();
+    // for (int j = 0; j < clScaledRawImage_map.height; j++)
+    // {
+    //     for (int i = 0; i < clScaledRawImage_map.width; i++)
+    //     {
+    //         auto pixel = clScaledRawImage_map[j][i];
+    //         if (pixel > max)
+    //             max = pixel;
+    //     }
+    // }
+    // printf("MAX  clRawImage_map %i\n", max);
 
-    LOG_INFO(TAG) << "NoiseLevel: " << demosaicParameters->noiseLevel << std::endl;
+    NoiseModel<5> *noiseModel = &demosaicParameters->noiseModel;
 
-    if (calibrateFromImage) {
+    // LOG_INFO(TAG) << "NoiseLevel: " << demosaicParameters->noiseLevel << std::endl;
+
+    if (calibrateFromImage)
+    {
         noiseModel->rawNlf = MeasureRawNLF(_glsContext, *clScaledRawImage,
                                            demosaicParameters->exposure_multiplier,
                                            demosaicParameters->bayerPattern);
@@ -176,10 +204,11 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::demosaic(const gls::image
 
     const bool high_noise_image = rawVariance[1][1] > kHighNoiseVariance;
 
-    std::cout << "Green Channel RAW Variance: " << std::scientific << rawVariance[1][1] << ", high_noise_image: " << high_noise_image << std::endl;
+    // std::cout << "Green Channel RAW Variance: " << std::scientific << rawVariance[1][1] << ", high_noise_image: " << high_noise_image << std::endl;
 
-    if (high_noise_image) {
-        std::cout << "Despeckeling RAW Image" << std::endl;
+    if (high_noise_image)
+    {
+        // std::cout << "Despeckeling RAW Image" << std::endl;
 
         allocateHighNoiseTextures(_glsContext, rawImage.width, rawImage.height);
 
@@ -196,8 +225,8 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::demosaic(const gls::image
     gaussianBlurSobelImage(_glsContext, *clScaledRawImage, *clRawSobelImage, rawVariance[1], 1.5, 4.5, clRawGradientImage.get());
     // dumpGradientImage(*clRawGradientImage);
 
-//    malvar(_glsContext, *clScaledRawImage, *clRawGradientImage, clLinearRGBImageA.get(), demosaicParameters->bayerPattern,
-//           rawVariance[0], rawVariance[1], rawVariance[2]);
+    //    malvar(_glsContext, *clScaledRawImage, *clRawGradientImage, clLinearRGBImageA.get(), demosaicParameters->bayerPattern,
+    //           rawVariance[0], rawVariance[1], rawVariance[2]);
 
     interpolateGreen(_glsContext, *clScaledRawImage, *clRawGradientImage, clGreenImage.get(), demosaicParameters->bayerPattern, rawVariance[1]);
 
@@ -210,42 +239,44 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::demosaic(const gls::image
                               demosaicParameters->bayerPattern, rawVariance[0], rawVariance[2]);
 
     // Recover clipped highlights
-    blendHighlightsImage(_glsContext, *clLinearRGBImageA, /*clip=*/ 1.0, clLinearRGBImageA.get());
+    blendHighlightsImage(_glsContext, *clLinearRGBImageA, /*clip=*/1.0, clLinearRGBImageA.get());
 
     return clLinearRGBImageA.get();
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::denoise(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                                                               DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
-    NoiseModel<5>* noiseModel = &demosaicParameters->noiseModel;
+gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::denoise(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                                               DemosaicParameters *demosaicParameters, bool calibrateFromImage)
+{
+    NoiseModel<5> *noiseModel = &demosaicParameters->noiseModel;
 
     // Luma and Chroma Despeckling
-    const auto& np = noiseModel->pyramidNlf[0];
+    const auto &np = noiseModel->pyramidNlf[0];
     despeckleImage(_glsContext, inputImage,
-                   /*var_a=*/ np.first,
-                   /*var_b=*/ np.second,
+                   /*var_a=*/np.first,
+                   /*var_b=*/np.second,
                    clLinearRGBImageB.get());
 
-    gls::cl_image_2d<gls::rgba_pixel_float>* clDenoisedImage =
+    gls::cl_image_2d<gls::rgba_pixel_float> *clDenoisedImage =
         pyramidProcessor->denoise(_glsContext, &(demosaicParameters->denoiseParameters),
                                   *clLinearRGBImageB,
                                   *clRawGradientImage,
                                   &(noiseModel->pyramidNlf), demosaicParameters->exposure_multiplier, calibrateFromImage);
 
-    if (demosaicParameters->rgbConversionParameters.localToneMapping) {
-        const std::array<const gls::cl_image_2d<gls::rgba_pixel_float>*, 3>& guideImage = {
+    if (demosaicParameters->rgbConversionParameters.localToneMapping)
+    {
+        const std::array<const gls::cl_image_2d<gls::rgba_pixel_float> *, 3> &guideImage = {
             pyramidProcessor->denoisedImagePyramid[4].get(),
             pyramidProcessor->denoisedImagePyramid[2].get(),
-            pyramidProcessor->denoisedImagePyramid[0].get()
-        };
+            pyramidProcessor->denoisedImagePyramid[0].get()};
         localToneMapping->createMask(_glsContext, *clDenoisedImage, guideImage, *noiseModel, *demosaicParameters);
     }
 
     // High ISO noise texture replacement
-    if (clBlueNoise != nullptr) {
-        const gls::Vector<2> lumaVariance = { np.first[0], np.second[0] };
+    if (clBlueNoise != nullptr)
+    {
+        const gls::Vector<2> lumaVariance = {np.first[0], np.second[0]};
 
-        std::cout << "Adding Blue Noise for variance: " << std::scientific << lumaVariance << std::endl;
+        // std::cout << "Adding Blue Noise for variance: " << std::scientific << lumaVariance << std::endl;
 
         const auto grainAmount = 1 + 3 * smoothstep(4e-4, 6e-4, lumaVariance[1]);
 
@@ -256,31 +287,36 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::denoise(const gls::cl_ima
     return clDenoisedImage;
 }
 
-void RawConverter::fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage, const gls::Matrix<3, 3>& homography,
-                             DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
-    NoiseModel<5>* noiseModel = &demosaicParameters->noiseModel;
+void RawConverter::fuseFrame(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage, const gls::Matrix<3, 3> &homography,
+                             DemosaicParameters *demosaicParameters, bool calibrateFromImage)
+{
+    NoiseModel<5> *noiseModel = &demosaicParameters->noiseModel;
     pyramidProcessor->fuseFrame(_glsContext, &(demosaicParameters->denoiseParameters), inputImage, homography,
                                 *clRawGradientImage, &(noiseModel->pyramidNlf),
                                 demosaicParameters->exposure_multiplier, calibrateFromImage);
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::getFusedImage() {
+gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::getFusedImage()
+{
     return pyramidProcessor->getFusedImage(_glsContext);
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::postProcess(const gls::cl_image_2d<gls::rgba_pixel_float>& inputImage,
-                                                                   const DemosaicParameters& demosaicParameters) {
+gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::postProcess(const gls::cl_image_2d<gls::rgba_pixel_float> &inputImage,
+                                                                   const DemosaicParameters &demosaicParameters)
+{
     convertTosRGB(_glsContext, inputImage, localToneMapping->getMask(), clsRGBImage.get(), demosaicParameters);
 
     return clsRGBImage.get();
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                                   DemosaicParameters* demosaicParameters, bool calibrateFromImage) {
+gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                                   DemosaicParameters *demosaicParameters, bool calibrateFromImage)
+{
     auto t_start = std::chrono::high_resolution_clock::now();
 
     // --- Image Demosaicing ---
 
+    // TODO: rawImage has non-zero values but demosaicedImage comes out all zero!
     const auto demosaicedImage = demosaic(rawImage, demosaicParameters, calibrateFromImage);
 
     // --- Image Denoising ---
@@ -288,7 +324,7 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runPipeline(const gls::im
     // Convert linear image to YCbCr for denoising
     const auto cam_to_ycbcr = cam_ycbcr(demosaicParameters->rgb_cam);
 
-    std::cout << "cam_to_ycbcr: " << std::setprecision(4) << std::scientific << cam_to_ycbcr.span() << std::endl;
+    // std::cout << "cam_to_ycbcr: " << std::setprecision(4) << std::scientific << cam_to_ycbcr.span() << std::endl;
 
     transformImage(_glsContext, *demosaicedImage, clLinearRGBImageA.get(), cam_to_ycbcr);
 
@@ -305,15 +341,16 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runPipeline(const gls::im
     cl::CommandQueue queue = cl::CommandQueue::getDefault();
     queue.finish();
     auto t_end = std::chrono::high_resolution_clock::now();
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    // LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
 
     return sRGBImage;
 }
 
-gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runFastPipeline(const gls::image<gls::luma_pixel_16>& rawImage,
-                                                                       const DemosaicParameters& demosaicParameters) {
+gls::cl_image_2d<gls::rgba_pixel_float> *RawConverter::runFastPipeline(const gls::image<gls::luma_pixel_16> &rawImage,
+                                                                       const DemosaicParameters &demosaicParameters)
+{
     allocateFastDemosaicTextures(_glsContext, rawImage.width, rawImage.height);
 
     LOG_INFO(TAG) << "Begin Fast Demosaicing (GPU)..." << std::endl;
@@ -331,7 +368,7 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runFastPipeline(const gls
     fasteDebayer(_glsContext, *clScaledRawImage, clFastLinearRGBImage.get(), demosaicParameters.bayerPattern);
 
     // Recover clipped highlights
-    blendHighlightsImage(_glsContext, *clFastLinearRGBImage, /*clip=*/ 1.0, clFastLinearRGBImage.get());
+    blendHighlightsImage(_glsContext, *clFastLinearRGBImage, /*clip=*/1.0, clFastLinearRGBImage.get());
 
     // --- Image Post Processing ---
 
@@ -340,35 +377,35 @@ gls::cl_image_2d<gls::rgba_pixel_float>* RawConverter::runFastPipeline(const gls
     cl::CommandQueue queue = cl::CommandQueue::getDefault();
     queue.finish();
     auto t_end = std::chrono::high_resolution_clock::now();
-    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int) elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
+    LOG_INFO(TAG) << "OpenCL Pipeline Execution Time: " << (int)elapsed_time_ms << "ms for image of size: " << rawImage.width << " x " << rawImage.height << std::endl;
 
     return clsFastRGBImage.get();
 }
 
 template <typename T>
-/*static*/ typename gls::image<T>::unique_ptr RawConverter::convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage) {
+/*static*/ typename gls::image<T>::unique_ptr RawConverter::convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage)
+{
     const constexpr auto scale = std::numeric_limits<typename T::value_type>::max();
 
     auto rgbImage = std::make_unique<gls::image<T>>(clRGBAImage.width, clRGBAImage.height);
     auto rgbaImage = clRGBAImage.mapImage();
-    for (int y = 0; y < clRGBAImage.height; y++) {
-        for (int x = 0; x < clRGBAImage.width; x++) {
-            const auto& p = rgbaImage[y][x];
+    for (int y = 0; y < clRGBAImage.height; y++)
+    {
+        for (int x = 0; x < clRGBAImage.width; x++)
+        {
+            const auto &p = rgbaImage[y][x];
             (*rgbImage)[y][x] = {
-                (typename T::value_type) (scale * p.red),
-                (typename T::value_type) (scale * p.green),
-                (typename T::value_type) (scale * p.blue)
-            };
+                (typename T::value_type)(scale * p.red),
+                (typename T::value_type)(scale * p.green),
+                (typename T::value_type)(scale * p.blue)};
         }
     }
     clRGBAImage.unmapImage(rgbaImage);
     return rgbImage;
 }
 
-template
-gls::image<gls::rgb_pixel>::unique_ptr RawConverter::convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage);
+template gls::image<gls::rgb_pixel>::unique_ptr RawConverter::convertToRGBImage(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage);
 
-template
-gls::image<gls::rgb_pixel_16>::unique_ptr RawConverter::convertToRGBImage<gls::rgb_pixel_16>(const gls::cl_image_2d<gls::rgba_pixel_float>& clRGBAImage);
+template gls::image<gls::rgb_pixel_16>::unique_ptr RawConverter::convertToRGBImage<gls::rgb_pixel_16>(const gls::cl_image_2d<gls::rgba_pixel_float> &clRGBAImage);


### PR DESCRIPTION
Changes to use as module in GlassImagePy, especially adding parameter-based (instead of DNG-based) `demosaic_raw_data() `and removing the debug outputs. 

We should think about a logging concept, ideally one that turns on/off at runtime, alternatively based on compiler flags.

**Update:**
The GlassImage submodule in here was linked through an SSH key / git@... URL, most likely because it was cloned that way into GlassPipeline.
However, GlassPipeline is again a submodule in GlassImagePy, which clones all of its submodules using HTTPS keys. 
This lead to a chain of GlassImagePy --HTTPS--> GlassPipeline --SSH--> GlassImage, which apparently prevents cloning with recursive submodules as Git only accepts one type of credential at a time.
Therefore, we have to use either HTTPS or SSH and SSH did conflict with Pip-installs in the past, therefore the convention probably has to be HTTPS. I have updated the submodule URL accordingly here, such that GlassPipeline --HTTPS--> GlassImage