### PR TITLE
Changes to work inside GlassImagePy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "GlassImage"]
 	path = GlassImage
-	url = git@github.com:Glass-Imaging/GlassImage.git
+	url = https://github.com/Glass-Imaging/GlassImage.git

--- a/ImagingPipeline/imagingPipeline.cpp
+++ b/ImagingPipeline/imagingPipeline.cpp
@@ -13,24 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <filesystem>
-#include <string>
-#include <cmath>
-#include <chrono>
-
-#include "gls_logging.h"
-#include "gls_image.hpp"
-
-#include "raw_converter.hpp"
-
-#include "demosaic.hpp"
-#include "gls_tiff_metadata.hpp"
-
-#include "gls_linalg.hpp"
-
-#include "CameraCalibration.hpp"
-
-static const char* TAG = "RawPipeline Test";
+#include "imagingPipeline.hpp"
 
 void copyMetadata(const gls::tiff_metadata& source, gls::tiff_metadata* destination, ttag_t tag) {
     const auto entry = source.find(tag);

--- a/ImagingPipeline/imagingPipeline.cpp
+++ b/ImagingPipeline/imagingPipeline.cpp
@@ -15,6 +15,8 @@
 
 #include "imagingPipeline.hpp"
 
+static const char* TAG = "RawPipeline Test";
+
 void copyMetadata(const gls::tiff_metadata& source, gls::tiff_metadata* destination, ttag_t tag) {
     const auto entry = source.find(tag);
     if (entry != source.end()) {

--- a/ImagingPipeline/imagingPipeline.cpp
+++ b/ImagingPipeline/imagingPipeline.cpp
@@ -257,8 +257,6 @@ gls::image<gls::rgb_pixel_16>::unique_ptr demosaic_raw_data(
     RawConverter* rawConverter, const gls::image<gls::luma_pixel_16>& raw_data, int ISO,
     std::vector<float> color_matrix, std::vector<float> as_shot_neutral,
     std::vector<uint8_t> cfapattern, int blacklevel, int whitelevel) {
-    // std::vector<float> color_matrix = {1.2594, -0.5333, -0.1138, -0.1404, 0.9717, 0.1688, 0.0342,
-    // 0.0969, 0.4330}; std::vector<float> as_shot_neutral = {1 / 1.8930, 1.0000, 1 / 1.7007};
 
     gls::tiff_metadata dng_metadata, exif_metadata;
 

--- a/ImagingPipeline/imagingPipeline.hpp
+++ b/ImagingPipeline/imagingPipeline.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2021-2022 Glass Imaging Inc.
+// Author: Fabio Riccardi <fabio@glass-imaging.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef imagingPipeline_hpp
+#define imagingPipeline_hpp
+
+#include <filesystem>
+#include <string>
+#include <cmath>
+#include <chrono>
+
+#include "gls_logging.h"
+#include "gls_image.hpp"
+
+#include "raw_converter.hpp"
+
+#include "demosaic.hpp"
+#include "gls_tiff_metadata.hpp"
+
+#include "gls_linalg.hpp"
+
+#include "CameraCalibration.hpp"
+
+static const char* TAG = "RawPipeline Test";
+
+void copyMetadata(const gls::tiff_metadata& source, gls::tiff_metadata* destination, ttag_t tag);
+
+void saveStrippedDNG(const std::string& file_name, const gls::image<gls::luma_pixel_16>& inputImage, const gls::tiff_metadata& dng_metadata, const gls::tiff_metadata& exif_metadata);
+
+void transcodeAdobeDNG(const std::filesystem::path& input_path);
+
+gls::image<gls::rgb_pixel>::unique_ptr demosaicPlainFile(RawConverter* rawConverter, const std::filesystem::path& input_path);
+
+void processKodakSet(gls::OpenCLContext* glsContext, const std::filesystem::path& input_path);
+
+void demosaicFile(RawConverter* rawConverter, std::filesystem::path input_path);
+
+void demosaicDirectory(RawConverter* rawConverter, std::filesystem::path input_path);
+
+gls::image<gls::rgb_pixel_16>::unique_ptr demosaic_raw_data(
+    RawConverter* rawConverter, const gls::image<gls::luma_pixel_16>& raw_data, int ISO,
+    std::vector<float> color_matrix, std::vector<float> as_shot_neutral,
+    std::vector<uint8_t> cfapattern, int blacklevel, int whitelevel);
+
+#endif /* imagingPipeline_hpp */

--- a/ImagingPipeline/imagingPipeline.hpp
+++ b/ImagingPipeline/imagingPipeline.hpp
@@ -33,8 +33,6 @@
 
 #include "CameraCalibration.hpp"
 
-static const char* TAG = "RawPipeline Test";
-
 void copyMetadata(const gls::tiff_metadata& source, gls::tiff_metadata* destination, ttag_t tag);
 
 void saveStrippedDNG(const std::string& file_name, const gls::image<gls::luma_pixel_16>& inputImage, const gls::tiff_metadata& dng_metadata, const gls::tiff_metadata& exif_metadata);

--- a/include/raw_converter.hpp
+++ b/include/raw_converter.hpp
@@ -105,7 +105,7 @@ class RawConverter {
     void allocateHighNoiseTextures(gls::OpenCLContext* glsContext, int width, int height);
     void allocateFastDemosaicTextures(gls::OpenCLContext* glsContext, int width, int height);
 
-    const std::filesystem::path& _assets_root = "Assets/";
+    const std::filesystem::path _assets_root;
 
    public:
     RawConverter(gls::OpenCLContext* glsContext, const std::filesystem::path& assets_root = "Assets/")

--- a/include/raw_converter.hpp
+++ b/include/raw_converter.hpp
@@ -16,6 +16,8 @@
 #ifndef raw_converter_hpp
 #define raw_converter_hpp
 
+#include <filesystem>
+
 #include "gls_cl_image.hpp"
 #include "pyramid_processor.hpp"
 
@@ -103,8 +105,11 @@ class RawConverter {
     void allocateHighNoiseTextures(gls::OpenCLContext* glsContext, int width, int height);
     void allocateFastDemosaicTextures(gls::OpenCLContext* glsContext, int width, int height);
 
+    const std::filesystem::path& _assets_root = "Assets/";
+
    public:
-    RawConverter(gls::OpenCLContext* glsContext) : _glsContext(glsContext) {
+    RawConverter(gls::OpenCLContext* glsContext, const std::filesystem::path& assets_root = "Assets/")
+        : _glsContext(glsContext), _assets_root(assets_root) {
         localToneMapping = std::make_unique<LocalToneMapping>(_glsContext);
     }
 

--- a/src/SURF.cpp
+++ b/src/SURF.cpp
@@ -1224,6 +1224,8 @@ static inline float L2Norm(const float* p1, const float* p2, int n) {
 
 #ifdef __APPLE__
 typedef std::chrono::steady_clock::time_point time_point;
+#elif __linux__
+typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point;
 #else
 typedef std::chrono::system_clock::time_point time_point;
 #endif

--- a/src/raw_converter.cpp
+++ b/src/raw_converter.cpp
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "raw_converter.hpp"
+
 #include <iomanip>
 #include <limits>
 
 #include "demosaic.hpp"
 #include "gls_logging.h"
-#include "raw_converter.hpp"
 
 static const char* TAG = "DEMOSAIC";
 
@@ -39,7 +40,7 @@ void RawConverter::allocateTextures(gls::OpenCLContext* glsContext, int width, i
 
         pyramidProcessor = std::make_unique<PyramidProcessor<5>>(glsContext, width, height);
 
-        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file("Assets/HDR_L_0b.png");
+        const auto blueNoise = gls::image<gls::luma_pixel_16>::read_png_file(_assets_root / "HDR_L_0b.png");
         clBlueNoise = std::make_unique<gls::cl_image_2d<gls::luma_pixel_16>>(_glsContext->clContext(), *blueNoise);
     }
 }


### PR DESCRIPTION
- I now reference the GlassImage submodule via HTTPS instead of SSH as other ways cause errors during Pip installs
- I added a parameter-based demosaic_raw_data function as we discussed
- Minor changes to work smoothly in Linux